### PR TITLE
SOL-25375: Add configuration to turn on/off auto-provisioning

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
@@ -124,7 +124,7 @@ See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spri
         <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker. Typically, this queue's name should have a format of `{prefix}{destination}.{group}`.</p>
         <p>Default: true</p>
     </dd>
-    <dt>addDurableQueueSubscription</dt>
+    <dt>provisionSubscriptionsToDurableQueue</dt>
     <dd>
         <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions (the destination topic should be added at minimum) on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
         <p>Default: true</p>
@@ -255,7 +255,7 @@ See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spri
         <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker. Typically, this queue's name should have a format of `{prefix}{destination}.{group}`.</p>
         <p>Default: true</p>
     </dd>
-    <dt>addDurableQueueSubscription</dt>
+    <dt>provisionSubscriptionsToDurableQueue</dt>
     <dd>
         <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions (the destination topic should be added at minimum) on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
         <p>Default: true</p>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
@@ -121,12 +121,12 @@ See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spri
     </dd>
     <dt>provisionDurableQueue</dt>
     <dd>
-        <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker.</p>
+        <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker. Typically, this queue's name should have a format of `{prefix}{destination}.{group}`.</p>
         <p>Default: true</p>
     </dd>
     <dt>addDurableQueueSubscription</dt>
     <dd>
-        <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
+        <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions (the destination topic should be added at minimum) on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
         <p>Default: true</p>
     </dd>
     <dt>queueAccessType</dt>
@@ -193,7 +193,7 @@ See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spri
     </dd>
     <dt>provisionDmq</dt>
     <dd>
-        <p>Whether to provision durable queues for DMQs when autoBindDmq is true. This should only be set to false if you have externally pre-provisioned the required queue on the message broker.</p>
+        <p>Whether to provision durable queues for DMQs when autoBindDmq is true. This should only be set to false if you have externally pre-provisioned the required queue on the message broker. Typically, this queue's name should have a format of `{prefix}{destination}.{group}.dmq`.</p>
         <p>Default: true</p>
     </dd>
     <dt>dmqAccessType</dt>
@@ -252,12 +252,12 @@ See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spri
     </dd>
     <dt>provisionDurableQueue</dt>
     <dd>
-        <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker.</p>
+        <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker. Typically, this queue's name should have a format of `{prefix}{destination}.{group}`.</p>
         <p>Default: true</p>
     </dd>
     <dt>addDurableQueueSubscription</dt>
     <dd>
-        <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
+        <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions (the destination topic should be added at minimum) on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
         <p>Default: true</p>
     </dd>
     <dt>queueAccessType</dt>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
@@ -111,13 +111,23 @@ For general binder configuration options and properties, refer to the [Spring Cl
 
 The following properties are available for Solace consumers only and must be prefixed with `spring.cloud.stream.solace.bindings.<channelName>.consumer.`.
 
-See [SolaceConsumerProperties](../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java) for the most updated list.
+See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java) and [SolaceConsumerProperties](../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java) for the most updated list.
 
 <dl>
     <dt>prefix</dt>
     <dd>
         <p>Naming prefix for all topics and queues.</p>
         <p>Default: ""</p>
+    </dd>
+    <dt>provisionDurableQueue</dt>
+    <dd>
+        <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker.</p>
+        <p>Default: true</p>
+    </dd>
+    <dt>addDurableQueueSubscription</dt>
+    <dd>
+        <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
+        <p>Default: true</p>
     </dd>
     <dt>queueAccessType</dt>
     <dd>
@@ -181,6 +191,11 @@ See [SolaceConsumerProperties](../../solace-spring-cloud-stream-binder/solace-sp
         <p>Whether to automatically create a durable dead message queue to which messages will be republished when message processing failures are encountered. Only applies once all internal retries have been exhausted.</p>
         <p>Default: false</p>
     </dd>
+    <dt>provisionDmq</dt>
+    <dd>
+        <p>Whether to provision durable queues for DMQs when autoBindDmq is true. This should only be set to false if you have externally pre-provisioned the required queue on the message broker.</p>
+        <p>Default: true</p>
+    </dd>
     <dt>dmqAccessType</dt>
     <dd>
         <p>Access type for the DMQ.</p>
@@ -227,13 +242,23 @@ See [SolaceConsumerProperties](../../solace-spring-cloud-stream-binder/solace-sp
 
 The following properties are available for Solace producers only and must be prefixed with `spring.cloud.stream.solace.bindings.<channelName>.producer.`.
 
-See [SolaceProducerProperties](../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java) for the most updated list.
+See [SolaceCommonProperties](../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java) and [SolaceProducerProperties](../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java) for the most updated list.
 
 <dl>
     <dt>prefix</dt>
     <dd>
         <p>Naming prefix for all topics and queues.</p>
         <p>Default: ""</p>
+    </dd>
+    <dt>provisionDurableQueue</dt>
+    <dd>
+        <p>Whether to provision durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-provisioned the required queue on the message broker.</p>
+        <p>Default: true</p>
+    </dd>
+    <dt>addDurableQueueSubscription</dt>
+    <dd>
+        <p>Whether to add topic subscriptions to durable queues for non-anonymous consumer groups. This should only be set to false if you have externally pre-added the required topic subscriptions on the consumer group's queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.</p>
+        <p>Default: true</p>
     </dd>
     <dt>queueAccessType</dt>
     <dd>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
@@ -5,7 +5,7 @@ import com.solacesystems.jcsmp.EndpointProperties;
 public class SolaceCommonProperties {
 	private String prefix = ""; // Naming prefix for all topics and queues
 	private boolean provisionDurableQueue = true;
-	private boolean addDurableQueueSubscription = true;
+	private boolean provisionSubscriptionsToDurableQueue = true;
 
 	// Queue Properties -------
 	private int queueAccessType = EndpointProperties.ACCESSTYPE_NONEXCLUSIVE;
@@ -33,12 +33,12 @@ public class SolaceCommonProperties {
 		this.provisionDurableQueue = provisionDurableQueue;
 	}
 
-	public boolean isAddDurableQueueSubscription() {
-		return addDurableQueueSubscription;
+	public boolean isProvisionSubscriptionsToDurableQueue() {
+		return provisionSubscriptionsToDurableQueue;
 	}
 
-	public void setAddDurableQueueSubscription(boolean addDurableQueueSubscription) {
-		this.addDurableQueueSubscription = addDurableQueueSubscription;
+	public void setProvisionSubscriptionsToDurableQueue(boolean provisionSubscriptionsToDurableQueue) {
+		this.provisionSubscriptionsToDurableQueue = provisionSubscriptionsToDurableQueue;
 	}
 
 	public int getQueueAccessType() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
@@ -4,6 +4,8 @@ import com.solacesystems.jcsmp.EndpointProperties;
 
 public class SolaceCommonProperties {
 	private String prefix = ""; // Naming prefix for all topics and queues
+	private boolean provisionDurableQueue = true;
+	private boolean addDurableQueueSubscription = true;
 
 	// Queue Properties -------
 	private int queueAccessType = EndpointProperties.ACCESSTYPE_NONEXCLUSIVE;
@@ -21,6 +23,22 @@ public class SolaceCommonProperties {
 
 	public void setPrefix(String prefix) {
 		this.prefix = prefix;
+	}
+
+	public boolean isProvisionDurableQueue() {
+		return provisionDurableQueue;
+	}
+
+	public void setProvisionDurableQueue(boolean provisionDurableQueue) {
+		this.provisionDurableQueue = provisionDurableQueue;
+	}
+
+	public boolean isAddDurableQueueSubscription() {
+		return addDurableQueueSubscription;
+	}
+
+	public void setAddDurableQueueSubscription(boolean addDurableQueueSubscription) {
+		this.addDurableQueueSubscription = addDurableQueueSubscription;
 	}
 
 	public int getQueueAccessType() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -11,6 +11,8 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	// DMQ Properties ---------
 	private boolean autoBindDmq = false;
+	private boolean provisionDmq = true;
+
 	private int dmqAccessType = EndpointProperties.ACCESSTYPE_NONEXCLUSIVE;
 	private int dmqPermission = EndpointProperties.PERMISSION_CONSUME;
 	private Integer dmqDiscardBehaviour = null;
@@ -59,6 +61,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setAutoBindDmq(boolean autoBindDmq) {
 		this.autoBindDmq = autoBindDmq;
+	}
+
+	public boolean isProvisionDmq() {
+		return provisionDmq;
+	}
+
+	public void setProvisionDmq(boolean provisionDmq) {
+		this.provisionDmq = provisionDmq;
 	}
 
 	public int getDmqAccessType() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -121,7 +121,13 @@ public class SolaceQueueProvisioner
 		return new SolaceConsumerDestination(queue.getName());
 	}
 
-	private Queue provisionQueue(String name, boolean isDurable, EndpointProperties endpointProperties, boolean doDurableProvisioning)
+	private Queue provisionQueue(String name, boolean isDurable, EndpointProperties endpointProperties,
+								 boolean doDurableProvisioning) {
+		return provisionQueue(name, isDurable, endpointProperties, doDurableProvisioning, "Durable queue");
+	}
+
+	private Queue provisionQueue(String name, boolean isDurable, EndpointProperties endpointProperties,
+								 boolean doDurableProvisioning, String durableQueueType)
 			throws ProvisioningException {
 		Queue queue;
 		try {
@@ -130,7 +136,9 @@ public class SolaceQueueProvisioner
 				if (doDurableProvisioning) {
 					jcsmpSession.provision(queue, endpointProperties, JCSMPSession.FLAG_IGNORE_ALREADY_EXISTS);
 				} else {
-					logger.warn(String.format("Durable queue provisioning is disabled, %s will not be provisioned nor will its configuration be validated", name));
+					logger.warn(String.format(
+							"%s provisioning is disabled, %s will not be provisioned nor will its configuration be validated",
+							durableQueueType, name));
 				}
 			} else {
 				// EndpointProperties will be applied during consumer creation
@@ -163,7 +171,8 @@ public class SolaceQueueProvisioner
 	private void provisionDMQ(String queueName, SolaceConsumerProperties properties) {
 		String dmqName = SolaceProvisioningUtil.getDMQName(queueName);
 		logger.info(String.format("Provisioning DMQ %s", dmqName));
-		provisionQueue(dmqName, true, SolaceProvisioningUtil.getDMQEndpointProperties(properties), properties.isProvisionDmq());
+		EndpointProperties endpointProperties = SolaceProvisioningUtil.getDMQEndpointProperties(properties);
+		provisionQueue(dmqName, true, endpointProperties, properties.isProvisionDmq(), "DMQ");
 	}
 
 	public void addSubscriptionToQueue(Queue queue, String topicName, SolaceCommonProperties properties) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -178,7 +178,7 @@ public class SolaceQueueProvisioner
 	public void addSubscriptionToQueue(Queue queue, String topicName, SolaceCommonProperties properties) {
 		logger.info(String.format("Subscribing queue %s to topic %s", queue.getName(), topicName));
 
-		if (queue.isDurable() && !properties.isAddDurableQueueSubscription()) {
+		if (queue.isDurable() && !properties.isProvisionSubscriptionsToDurableQueue()) {
 			logger.warn(String.format("Adding subscriptions to durable queues was disabled, queue %s will not be subscribed to topic %s",
 					queue.getName(), topicName));
 			return;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -145,7 +145,7 @@ public class SolaceQueueProvisioner
 
 		try {
 			logger.info(String.format("Testing consumer flow connection to queue %s (will not start it)", name));
-			final ConsumerFlowProperties testFlowProperties = new ConsumerFlowProperties().setEndpoint(queue);
+			final ConsumerFlowProperties testFlowProperties = new ConsumerFlowProperties().setEndpoint(queue).setStartState(false);
 			jcsmpSession.createFlow(null, testFlowProperties, endpointProperties).close();
 			logger.info(String.format("Connected test consumer flow to queue %s, closing it", name));
 		} catch (JCSMPException e) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -77,7 +77,7 @@ public class SolaceMessageChannelBinder
 	protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
 													 ExtendedConsumerProperties<SolaceConsumerProperties> properties) {
 		JCSMPInboundChannelAdapter adapter = new JCSMPInboundChannelAdapter(destination, jcsmpSession,
-				getConsumerEndpointProperties(properties), getConsumerPostStart());
+				getConsumerEndpointProperties(properties), getConsumerPostStart(properties));
 
 		ErrorInfrastructure errorInfra = registerErrorInfrastructure(destination, group, properties);
 		if (properties.getMaxAttempts() > 1) {
@@ -96,7 +96,7 @@ public class SolaceMessageChannelBinder
 																	ConsumerDestination destination,
 																	ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties) {
 		EndpointProperties endpointProperties = getConsumerEndpointProperties(consumerProperties);
-		Consumer<Queue> postStart = getConsumerPostStart();
+		Consumer<Queue> postStart = getConsumerPostStart(consumerProperties);
 		JCSMPMessageSource messageSource = new JCSMPMessageSource(destination, jcsmpSession, consumerProperties, endpointProperties, postStart);
 		ErrorInfrastructure errorInfra = registerErrorInfrastructure(destination, group, consumerProperties, true);
 		return new PolledConsumerResources(messageSource, errorInfra);
@@ -178,10 +178,10 @@ public class SolaceMessageChannelBinder
 		Temporary endpoints are only provisioned when the consumer is created.
 		Ideally, these should be done within the provisioningProvider itself.
 	*/
-	private Consumer<Queue> getConsumerPostStart() {
+	private Consumer<Queue> getConsumerPostStart(ExtendedConsumerProperties<SolaceConsumerProperties> properties) {
 		return (queue) -> {
 			for (String topic : provisioningProvider.getTrackedTopicsForQueue(queue.getName())) {
-				provisioningProvider.addSubscriptionToQueue(queue, topic);
+				provisioningProvider.addSubscriptionToQueue(queue, topic, properties.getExtension());
 			}
 		};
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicTest.java
@@ -1,0 +1,420 @@
+package com.solace.spring.cloud.stream.binder;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
+import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
+import com.solacesystems.jcsmp.ClosedFacilityException;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.PropertyMismatchException;
+import com.solacesystems.jcsmp.Queue;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.cloud.stream.binder.Binding;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.PartitionCapableBinderTests;
+import org.springframework.cloud.stream.binder.PollableSource;
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.provisioning.ProvisioningException;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.MimeTypeUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Runs all basic Spring Cloud Stream Binder functionality tests
+ * inherited by {@link PartitionCapableBinderTests PartitionCapableBinderTests}
+ * along with basic tests specific to the Solace Spring Cloud Stream Binder.
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = SolaceJavaAutoConfiguration.class, initializers = ConfigFileApplicationContextInitializer.class)
+public class SolaceBinderBasicTest extends SolaceBinderTestBase {
+	// NOT YET SUPPORTED ---------------------------------
+	@Override
+	public void testPartitionedModuleJava() {
+		Assume.assumeTrue("Partitioning not currently supported", false);
+	}
+
+	@Override
+	public void testPartitionedModuleSpEL() {
+		Assume.assumeTrue("Partitioning not currently supported", false);
+	}
+	// ---------------------------------------------------
+
+	@Test
+	public void testSendAndReceiveBad() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, "testSendAndReceiveBad", moduleInputChannel, createConsumerProperties());
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		final CountDownLatch latch = new CountDownLatch(3);
+		moduleInputChannel.subscribe(message1 -> {
+			latch.countDown();
+			throw new RuntimeException("bad");
+		});
+
+		moduleOutputChannel.send(message);
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testProducerErrorChannel() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String destination0EC = String.format("%s%serrors", destination0, getDestinationNameDelimiter());
+
+		ExtendedProducerProperties<SolaceProducerProperties> producerProps = createProducerProperties();
+		producerProps.setErrorChannelEnabled(true);
+		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel, producerProps);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		final CountDownLatch latch = new CountDownLatch(2);
+
+		final AtomicReference<Message<?>> errorMessage = new AtomicReference<>();
+		binder.getApplicationContext()
+				.getBean(destination0EC, SubscribableChannel.class)
+				.subscribe(message1 -> {
+					errorMessage.set(message1);
+					latch.countDown();
+				});
+
+		binder.getApplicationContext()
+				.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME, SubscribableChannel.class)
+				.subscribe(message12 -> latch.countDown());
+
+		jcsmpSession.closeSession();
+
+		try {
+			moduleOutputChannel.send(message);
+			fail("Expected the producer to fail to send the message...");
+		} catch (Exception e) {
+			logger.info("Successfully threw an exception during message publishing!");
+		}
+
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorMessage.get()).isInstanceOf(ErrorMessage.class);
+		assertThat(errorMessage.get().getPayload()).isInstanceOf(MessagingException.class);
+		assertThat((MessagingException) errorMessage.get().getPayload()).hasCauseInstanceOf(ClosedFacilityException.class);
+		producerBinding.unbind();
+	}
+
+	@Test
+	public void testPolledConsumer() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
+				destination0, "testPolledConsumer", moduleInputChannel, createConsumerProperties());
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		boolean gotMessage = false;
+		for (int i = 0; !gotMessage && i < 100; i++) {
+			gotMessage = moduleInputChannel.poll(message1 -> logger.info(String.format("Received message %s", message1)));
+		}
+		assertThat(gotMessage).isTrue();
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testPolledConsumerRequeue() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setRequeueRejected(true);
+		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
+				destination0, "testPolledConsumerRequeue", moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		boolean gotMessage = false;
+		for (int i = 0; !gotMessage && i < 100; i++) {
+			gotMessage = moduleInputChannel.poll(message1 -> {
+				throw new RuntimeException("Throwing expected exception!");
+			});
+		}
+		assertThat(gotMessage).isTrue();
+
+		gotMessage = moduleInputChannel.poll(message1 -> logger.info(String.format("Received message %s", message1)));
+		assertThat(gotMessage).isTrue();
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testFailProducerProvisioningOnRequiredQueuePropertyChange() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = "testFailProducerProvisioningOnRequiredQueuePropertyChange";
+
+		int defaultAccessType = createConsumerProperties().getExtension().getQueueAccessType();
+		EndpointProperties endpointProperties = new EndpointProperties();
+		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
+		Queue queue = JCSMPFactory.onlyInstance().createQueue(destination0 + getDestinationNameDelimiter() + group0);
+
+		logger.info(String.format("Pre-provisioning queue %s with AccessType %s to conflict with defaultAccessType %s",
+				queue.getName(), endpointProperties.getAccessType(), defaultAccessType));
+		jcsmpSession.provision(queue, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		Binding<MessageChannel> producerBinding;
+		try {
+			ExtendedProducerProperties<SolaceProducerProperties> bindingProducerProperties = createProducerProperties();
+			bindingProducerProperties.setRequiredGroups(group0);
+			producerBinding = binder.bindProducer(destination0, moduleOutputChannel, bindingProducerProperties);
+			producerBinding.unbind();
+			fail("Expected producer provisioning to fail due to queue property change");
+		} catch (ProvisioningException e) {
+			assertThat(e).hasCauseInstanceOf(PropertyMismatchException.class);
+			logger.info(String.format("Successfully threw a %s exception with cause %s",
+					ProvisioningException.class.getSimpleName(), PropertyMismatchException.class.getSimpleName()));
+		} finally {
+			jcsmpSession.deprovision(queue, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
+		}
+	}
+
+	@Test
+	public void testFailConsumerProvisioningOnQueuePropertyChange() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = "testFailConsumerProvisioningOnQueuePropertyChange";
+
+		int defaultAccessType = createConsumerProperties().getExtension().getQueueAccessType();
+		EndpointProperties endpointProperties = new EndpointProperties();
+		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
+		Queue queue = JCSMPFactory.onlyInstance().createQueue(destination0 + getDestinationNameDelimiter() + group0);
+
+		logger.info(String.format("Pre-provisioning queue %s with AccessType %s to conflict with defaultAccessType %s",
+				queue.getName(), endpointProperties.getAccessType(), defaultAccessType));
+		jcsmpSession.provision(queue, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+		Binding<MessageChannel> consumerBinding;
+		try {
+			consumerBinding = binder.bindConsumer(
+					destination0, group0, moduleInputChannel, createConsumerProperties());
+			consumerBinding.unbind();
+			fail("Expected consumer provisioning to fail due to queue property change");
+		} catch (ProvisioningException e) {
+			assertThat(e).hasCauseInstanceOf(PropertyMismatchException.class);
+			logger.info(String.format("Successfully threw a %s exception with cause %s",
+					ProvisioningException.class.getSimpleName(), PropertyMismatchException.class.getSimpleName()));
+		} finally {
+			jcsmpSession.deprovision(queue, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
+		}
+	}
+
+	@Test
+	public void testFailConsumerProvisioningOnDmqPropertyChange() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = "testFailConsumerProvisioningOnDmqPropertyChange";
+
+		int defaultAccessType = createConsumerProperties().getExtension().getQueueAccessType();
+		EndpointProperties endpointProperties = new EndpointProperties();
+		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
+		String dmqName = destination0 + getDestinationNameDelimiter() + group0 + getDestinationNameDelimiter() + "dmq";
+		Queue dmq = JCSMPFactory.onlyInstance().createQueue(dmqName);
+
+		logger.info(String.format("Pre-provisioning DMQ %s with AccessType %s to conflict with defaultAccessType %s",
+				dmq.getName(), endpointProperties.getAccessType(), defaultAccessType));
+		jcsmpSession.provision(dmq, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+		Binding<MessageChannel> consumerBinding;
+		try {
+			ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+			consumerProperties.getExtension().setAutoBindDmq(true);
+			consumerBinding = binder.bindConsumer(
+					destination0, group0, moduleInputChannel, consumerProperties);
+			consumerBinding.unbind();
+			fail("Expected consumer provisioning to fail due to DMQ property change");
+		} catch (ProvisioningException e) {
+			assertThat(e).hasCauseInstanceOf(PropertyMismatchException.class);
+			logger.info(String.format("Successfully threw a %s exception with cause %s",
+					ProvisioningException.class.getSimpleName(), PropertyMismatchException.class.getSimpleName()));
+		} finally {
+			jcsmpSession.deprovision(dmq, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
+		}
+	}
+
+	@Test
+	public void testConsumerAdditionalSubscriptions() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel0 = createBindableChannel("output0", new BindingProperties());
+		DirectChannel moduleOutputChannel1 = createBindableChannel("output1", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String destination1 = "some-destl";
+		String wildcardDestination1 = destination1.substring(0, destination1.length() - 1) + "*";
+
+		Binding<MessageChannel> producerBinding0 = binder.bindProducer(
+				destination0, moduleOutputChannel0, createProducerProperties());
+		Binding<MessageChannel> producerBinding1 = binder.bindProducer(
+				destination1, moduleOutputChannel1, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension()
+				.setQueueAdditionalSubscriptions(new String[]{wildcardDestination1, "some-random-sub"});
+
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, "testConsumerAdditionalSubscriptions", moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		final CountDownLatch latch = new CountDownLatch(2);
+		moduleInputChannel.subscribe(message1 -> {
+			logger.info(String.format("Received message %s", message1));
+			latch.countDown();
+		});
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel0.send(message);
+
+		logger.info(String.format("Sending message to destination %s: %s", destination1, message));
+		moduleOutputChannel1.send(message);
+
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		TimeUnit.SECONDS.sleep(1); // Give bindings a sec to finish processing successful message consume
+		producerBinding0.unbind();
+		producerBinding1.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testProducerAdditionalSubscriptions() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel0 = createBindableChannel("output0", new BindingProperties());
+		DirectChannel moduleOutputChannel1 = createBindableChannel("output1", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String destination1 = "some-destl";
+		String wildcardDestination1 = destination1.substring(0, destination1.length() - 1) + "*";
+		String group0 = "testProducerAdditionalSubscriptions";
+
+		ExtendedProducerProperties<SolaceProducerProperties> producerProperties = createProducerProperties();
+		Map<String,String[]> groupsAdditionalSubs = new HashMap<>();
+		groupsAdditionalSubs.put(group0, new String[]{wildcardDestination1});
+		producerProperties.setRequiredGroups(group0);
+		producerProperties.getExtension().setQueueAdditionalSubscriptions(groupsAdditionalSubs);
+
+		Binding<MessageChannel> producerBinding0 = binder.bindProducer(
+				destination0, moduleOutputChannel0, producerProperties);
+		Binding<MessageChannel> producerBinding1 = binder.bindProducer(
+				destination1, moduleOutputChannel1, createProducerProperties());
+
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, createConsumerProperties());
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		final CountDownLatch latch = new CountDownLatch(2);
+		moduleInputChannel.subscribe(message1 -> {
+			logger.info(String.format("Received message %s", message1));
+			latch.countDown();
+		});
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel0.send(message);
+
+		logger.info(String.format("Sending message to destination %s: %s", destination1, message));
+		moduleOutputChannel1.send(message);
+
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		TimeUnit.SECONDS.sleep(1); // Give bindings a sec to finish processing successful message consume
+		producerBinding0.unbind();
+		producerBinding1.unbind();
+		consumerBinding.unbind();
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleTest.java
@@ -111,7 +111,7 @@ public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase 
 
 		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
 		consumerProperties.getExtension().setProvisionDurableQueue(false);
-		consumerProperties.getExtension().setAddDurableQueueSubscription(false);
+		consumerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false);
 
 		Queue queue = JCSMPFactory.onlyInstance().createQueue(destination0 + getDestinationNameDelimiter() + group0);
 		EndpointProperties endpointProperties = new EndpointProperties();
@@ -379,18 +379,18 @@ public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase 
 	}
 
 	@Test
-	public void testConsumerAddDurableQueueSubscription() throws Exception {
+	public void testConsumerProvisionSubscriptionsToDurableQueue() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
 		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
 
 		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testConsumerAddDurableQueueSubscription";
+		String group0 = "testConsumerProvisionSubscriptionsToDurableQueue";
 
 		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
-		assertThat(consumerProperties.getExtension().isAddDurableQueueSubscription()).isTrue();
-		consumerProperties.getExtension().setAddDurableQueueSubscription(false);
+		assertThat(consumerProperties.getExtension().isProvisionSubscriptionsToDurableQueue()).isTrue();
+		consumerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel, createProducerProperties());
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(destination0, group0, moduleInputChannel, consumerProperties);
@@ -426,23 +426,23 @@ public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase 
 	}
 
 	@Test
-	public void testProducerAddDurableQueueSubscription() throws Exception {
+	public void testProducerProvisionSubscriptionsToDurableQueue() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
 		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
 
 		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testProducerAddDurableQueueSubscription";
+		String group0 = "testProducerProvisionSubscriptionsToDurableQueue";
 
 		ExtendedProducerProperties<SolaceProducerProperties> producerProperties = createProducerProperties();
-		assertThat(producerProperties.getExtension().isAddDurableQueueSubscription()).isTrue();
-		producerProperties.getExtension().setAddDurableQueueSubscription(false);
+		assertThat(producerProperties.getExtension().isProvisionSubscriptionsToDurableQueue()).isTrue();
+		producerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false);
 		producerProperties.setRequiredGroups(group0);
 
 		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
 		consumerProperties.getExtension().setProvisionDurableQueue(false);
-		consumerProperties.getExtension().setAddDurableQueueSubscription(false);
+		consumerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel, producerProperties);
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(destination0, group0, moduleInputChannel, consumerProperties);
@@ -478,18 +478,18 @@ public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase 
 	}
 
 	@Test
-	public void testPolledConsumerAddDurableQueueSubscription() throws Exception {
+	public void testPolledConsumerProvisionSubscriptionsToDurableQueue() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
 		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
 
 		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testConsumerAddDurableQueueSubscription";
+		String group0 = "testConsumerProvisionSubscriptionsToDurableQueue";
 
 		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
-		assertThat(consumerProperties.getExtension().isAddDurableQueueSubscription()).isTrue();
-		consumerProperties.getExtension().setAddDurableQueueSubscription(false);
+		assertThat(consumerProperties.getExtension().isProvisionSubscriptionsToDurableQueue()).isTrue();
+		consumerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel, createProducerProperties());
 		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(destination0, group0,
@@ -528,7 +528,7 @@ public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase 
 	}
 
 	@Test
-	public void testAnonConsumerAddDurableQueueSubscription() throws Exception {
+	public void testAnonConsumerProvisionSubscriptionsToDurableQueue() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
@@ -538,7 +538,7 @@ public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase 
 
 		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
 		assertThat(consumerProperties.getExtension().isProvisionDurableQueue()).isTrue();
-		consumerProperties.getExtension().setAddDurableQueueSubscription(false); // Expect this parameter to do nothing
+		consumerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false); // Expect this parameter to do nothing
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel, createProducerProperties());
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(destination0, null, moduleInputChannel, consumerProperties);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleTest.java
@@ -3,470 +3,47 @@ package com.solace.spring.cloud.stream.binder;
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
-import com.solacesystems.jcsmp.ClosedFacilityException;
+import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
+import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredSpringRunner;
+import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
 import com.solacesystems.jcsmp.EndpointProperties;
 import com.solacesystems.jcsmp.JCSMPErrorResponseException;
 import com.solacesystems.jcsmp.JCSMPErrorResponseSubcodeEx;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.PropertyMismatchException;
 import com.solacesystems.jcsmp.Queue;
-import com.solacesystems.jcsmp.SpringJCSMPFactory;
 import com.solacesystems.jcsmp.Topic;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
-import org.springframework.cloud.stream.binder.PartitionCapableBinderTests;
 import org.springframework.cloud.stream.binder.PollableSource;
-import org.springframework.cloud.stream.binder.Spy;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.SubscribableChannel;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.MimeTypeUtils;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@RunWith(SpringRunner.class)
+/**
+ * All tests which modify the default provisioning lifecycle.
+ */
+@RunWith(InheritedTestsFilteredSpringRunner.class)
 @ContextConfiguration(classes = SolaceJavaAutoConfiguration.class, initializers = ConfigFileApplicationContextInitializer.class)
-public class SolaceBinderTest
-		extends PartitionCapableBinderTests<SolaceTestBinder, ExtendedConsumerProperties<SolaceConsumerProperties>, ExtendedProducerProperties<SolaceProducerProperties>> {
-
-	@Autowired
-	private SpringJCSMPFactory springJCSMPFactory;
-
-	@Value("${test.fail.on.connection.exception:false}")
-	private Boolean failOnConnectError;
-
-	private JCSMPSession jcsmpSession;
-
-	private static SolaceExternalResourceHandler externalResource = new SolaceExternalResourceHandler();
-
-
-	@Override
-	protected boolean usesExplicitRouting() {
-		return true;
-	}
-
-	@Override
-	protected String getClassUnderTestName() {
-		return this.getClass().getSimpleName();
-	}
-
-	@Override
-	protected SolaceTestBinder getBinder() throws Exception {
-		if (testBinder == null) {
-			logger.info(String.format("Getting new %s instance", SolaceTestBinder.class.getSimpleName()));
-			jcsmpSession = externalResource.assumeAndGetActiveSession(springJCSMPFactory, failOnConnectError);
-			testBinder = new SolaceTestBinder(jcsmpSession);
-		}
-		return testBinder;
-	}
-
-	@Override
-	protected ExtendedConsumerProperties<SolaceConsumerProperties> createConsumerProperties() {
-		return new ExtendedConsumerProperties<>(new SolaceConsumerProperties());
-	}
-
-	@Override
-	protected ExtendedProducerProperties<SolaceProducerProperties> createProducerProperties() {
-		return new ExtendedProducerProperties<>(new SolaceProducerProperties());
-	}
-
-	@Override
-	public Spy spyOn(String name) {
-		return null;
-	}
-
-	// NOT YET SUPPORTED ---------------------------------
-	@Override
-	public void testPartitionedModuleJava() {
-		Assume.assumeTrue("Partitioning not currently supported", false);
-	}
-
-	@Override
-	public void testPartitionedModuleSpEL() {
-		Assume.assumeTrue("Partitioning not currently supported", false);
-	}
-	// ---------------------------------------------------
-
-	@Test
-	public void testSendAndReceiveBad() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-
-		Binding<MessageChannel> producerBinding = binder.bindProducer(
-				destination0, moduleOutputChannel, createProducerProperties());
-		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
-				destination0, "testSendAndReceiveBad", moduleInputChannel, createConsumerProperties());
-
-		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
-				.build();
-
-		binderBindUnbindLatency();
-
-		final CountDownLatch latch = new CountDownLatch(3);
-		moduleInputChannel.subscribe(message1 -> {
-			latch.countDown();
-			throw new RuntimeException("bad");
-		});
-
-		moduleOutputChannel.send(message);
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		producerBinding.unbind();
-		consumerBinding.unbind();
-	}
-
-	@Test
-	public void testProducerErrorChannel() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String destination0EC = String.format("%s%serrors", destination0, getDestinationNameDelimiter());
-
-		ExtendedProducerProperties<SolaceProducerProperties> producerProps = createProducerProperties();
-		producerProps.setErrorChannelEnabled(true);
-		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel, producerProps);
-
-		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
-				.build();
-
-		final CountDownLatch latch = new CountDownLatch(2);
-
-		final AtomicReference<Message<?>> errorMessage = new AtomicReference<>();
-		binder.getApplicationContext()
-				.getBean(destination0EC, SubscribableChannel.class)
-				.subscribe(message1 -> {
-					errorMessage.set(message1);
-					latch.countDown();
-				});
-
-		binder.getApplicationContext()
-				.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME, SubscribableChannel.class)
-				.subscribe(message12 -> latch.countDown());
-
-		jcsmpSession.closeSession();
-
-		try {
-			moduleOutputChannel.send(message);
-			fail("Expected the producer to fail to send the message...");
-		} catch (Exception e) {
-			logger.info("Successfully threw an exception during message publishing!");
-		}
-
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(errorMessage.get()).isInstanceOf(ErrorMessage.class);
-		assertThat(errorMessage.get().getPayload()).isInstanceOf(MessagingException.class);
-		assertThat((MessagingException) errorMessage.get().getPayload()).hasCauseInstanceOf(ClosedFacilityException.class);
-		producerBinding.unbind();
-	}
-
-	@Test
-	public void testPolledConsumer() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
-		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-
-		Binding<MessageChannel> producerBinding = binder.bindProducer(
-				destination0, moduleOutputChannel, createProducerProperties());
-		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
-				destination0, "testPolledConsumer", moduleInputChannel, createConsumerProperties());
-
-		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
-				.build();
-
-		binderBindUnbindLatency();
-
-		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
-		moduleOutputChannel.send(message);
-
-		boolean gotMessage = false;
-		for (int i = 0; !gotMessage && i < 100; i++) {
-			gotMessage = moduleInputChannel.poll(message1 -> logger.info(String.format("Received message %s", message1)));
-		}
-		assertThat(gotMessage).isTrue();
-
-		producerBinding.unbind();
-		consumerBinding.unbind();
-	}
-
-	@Test
-	public void testPolledConsumerRequeue() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
-		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-
-		Binding<MessageChannel> producerBinding = binder.bindProducer(
-				destination0, moduleOutputChannel, createProducerProperties());
-
-		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
-		consumerProperties.getExtension().setRequeueRejected(true);
-		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
-				destination0, "testPolledConsumerRequeue", moduleInputChannel, consumerProperties);
-
-		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
-				.build();
-
-		binderBindUnbindLatency();
-
-		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
-		moduleOutputChannel.send(message);
-
-		boolean gotMessage = false;
-		for (int i = 0; !gotMessage && i < 100; i++) {
-			gotMessage = moduleInputChannel.poll(message1 -> {
-				throw new RuntimeException("Throwing expected exception!");
-			});
-		}
-		assertThat(gotMessage).isTrue();
-
-		gotMessage = moduleInputChannel.poll(message1 -> logger.info(String.format("Received message %s", message1)));
-		assertThat(gotMessage).isTrue();
-
-		producerBinding.unbind();
-		consumerBinding.unbind();
-	}
-
-	@Test
-	public void testFailProducerProvisioningOnRequiredQueuePropertyChange() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testFailProducerProvisioningOnRequiredQueuePropertyChange";
-
-		int defaultAccessType = createConsumerProperties().getExtension().getQueueAccessType();
-		EndpointProperties endpointProperties = new EndpointProperties();
-		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
-		Queue queue = JCSMPFactory.onlyInstance().createQueue(destination0 + getDestinationNameDelimiter() + group0);
-
-		logger.info(String.format("Pre-provisioning queue %s with AccessType %s to conflict with defaultAccessType %s",
-				queue.getName(), endpointProperties.getAccessType(), defaultAccessType));
-		jcsmpSession.provision(queue, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
-
-		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
-		Binding<MessageChannel> producerBinding;
-		try {
-			ExtendedProducerProperties<SolaceProducerProperties> bindingProducerProperties = createProducerProperties();
-			bindingProducerProperties.setRequiredGroups(group0);
-			producerBinding = binder.bindProducer(destination0, moduleOutputChannel, bindingProducerProperties);
-			producerBinding.unbind();
-			fail("Expected producer provisioning to fail due to queue property change");
-		} catch (ProvisioningException e) {
-			assertThat(e).hasCauseInstanceOf(PropertyMismatchException.class);
-			logger.info(String.format("Successfully threw a %s exception with cause %s",
-					ProvisioningException.class.getSimpleName(), PropertyMismatchException.class.getSimpleName()));
-		} finally {
-			jcsmpSession.deprovision(queue, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
-		}
-	}
-
-	@Test
-	public void testFailConsumerProvisioningOnQueuePropertyChange() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testFailConsumerProvisioningOnQueuePropertyChange";
-
-		int defaultAccessType = createConsumerProperties().getExtension().getQueueAccessType();
-		EndpointProperties endpointProperties = new EndpointProperties();
-		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
-		Queue queue = JCSMPFactory.onlyInstance().createQueue(destination0 + getDestinationNameDelimiter() + group0);
-
-		logger.info(String.format("Pre-provisioning queue %s with AccessType %s to conflict with defaultAccessType %s",
-				queue.getName(), endpointProperties.getAccessType(), defaultAccessType));
-		jcsmpSession.provision(queue, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
-
-		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
-		Binding<MessageChannel> consumerBinding;
-		try {
-			consumerBinding = binder.bindConsumer(
-					destination0, group0, moduleInputChannel, createConsumerProperties());
-			consumerBinding.unbind();
-			fail("Expected consumer provisioning to fail due to queue property change");
-		} catch (ProvisioningException e) {
-			assertThat(e).hasCauseInstanceOf(PropertyMismatchException.class);
-			logger.info(String.format("Successfully threw a %s exception with cause %s",
-					ProvisioningException.class.getSimpleName(), PropertyMismatchException.class.getSimpleName()));
-		} finally {
-			jcsmpSession.deprovision(queue, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
-		}
-	}
-
-	@Test
-	public void testFailConsumerProvisioningOnDmqPropertyChange() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testFailConsumerProvisioningOnDmqPropertyChange";
-
-		int defaultAccessType = createConsumerProperties().getExtension().getQueueAccessType();
-		EndpointProperties endpointProperties = new EndpointProperties();
-		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
-		String dmqName = destination0 + getDestinationNameDelimiter() + group0 + getDestinationNameDelimiter() + "dmq";
-		Queue dmq = JCSMPFactory.onlyInstance().createQueue(dmqName);
-
-		logger.info(String.format("Pre-provisioning DMQ %s with AccessType %s to conflict with defaultAccessType %s",
-				dmq.getName(), endpointProperties.getAccessType(), defaultAccessType));
-		jcsmpSession.provision(dmq, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
-
-		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
-		Binding<MessageChannel> consumerBinding;
-		try {
-			ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
-			consumerProperties.getExtension().setAutoBindDmq(true);
-			consumerBinding = binder.bindConsumer(
-					destination0, group0, moduleInputChannel, consumerProperties);
-			consumerBinding.unbind();
-			fail("Expected consumer provisioning to fail due to DMQ property change");
-		} catch (ProvisioningException e) {
-			assertThat(e).hasCauseInstanceOf(PropertyMismatchException.class);
-			logger.info(String.format("Successfully threw a %s exception with cause %s",
-					ProvisioningException.class.getSimpleName(), PropertyMismatchException.class.getSimpleName()));
-		} finally {
-			jcsmpSession.deprovision(dmq, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
-		}
-	}
-
-	@Test
-	public void testConsumerAdditionalSubscriptions() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		DirectChannel moduleOutputChannel0 = createBindableChannel("output0", new BindingProperties());
-		DirectChannel moduleOutputChannel1 = createBindableChannel("output1", new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String destination1 = "some-destl";
-		String wildcardDestination1 = destination1.substring(0, destination1.length() - 1) + "*";
-
-		Binding<MessageChannel> producerBinding0 = binder.bindProducer(
-				destination0, moduleOutputChannel0, createProducerProperties());
-		Binding<MessageChannel> producerBinding1 = binder.bindProducer(
-				destination1, moduleOutputChannel1, createProducerProperties());
-
-		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
-		consumerProperties.getExtension()
-				.setQueueAdditionalSubscriptions(new String[]{wildcardDestination1, "some-random-sub"});
-
-		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
-				destination0, "testConsumerAdditionalSubscriptions", moduleInputChannel, consumerProperties);
-
-		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
-				.build();
-
-		binderBindUnbindLatency();
-
-		final CountDownLatch latch = new CountDownLatch(2);
-		moduleInputChannel.subscribe(message1 -> {
-			logger.info(String.format("Received message %s", message1));
-			latch.countDown();
-		});
-
-		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
-		moduleOutputChannel0.send(message);
-
-		logger.info(String.format("Sending message to destination %s: %s", destination1, message));
-		moduleOutputChannel1.send(message);
-
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		TimeUnit.SECONDS.sleep(1); // Give bindings a sec to finish processing successful message consume
-		producerBinding0.unbind();
-		producerBinding1.unbind();
-		consumerBinding.unbind();
-	}
-
-	@Test
-	public void testProducerAdditionalSubscriptions() throws Exception {
-		SolaceTestBinder binder = getBinder();
-
-		DirectChannel moduleOutputChannel0 = createBindableChannel("output0", new BindingProperties());
-		DirectChannel moduleOutputChannel1 = createBindableChannel("output1", new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
-
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String destination1 = "some-destl";
-		String wildcardDestination1 = destination1.substring(0, destination1.length() - 1) + "*";
-		String group0 = "testProducerAdditionalSubscriptions";
-
-		ExtendedProducerProperties<SolaceProducerProperties> producerProperties = createProducerProperties();
-		Map<String,String[]> groupsAdditionalSubs = new HashMap<>();
-		groupsAdditionalSubs.put(group0, new String[]{wildcardDestination1});
-		producerProperties.setRequiredGroups(group0);
-		producerProperties.getExtension().setQueueAdditionalSubscriptions(groupsAdditionalSubs);
-
-		Binding<MessageChannel> producerBinding0 = binder.bindProducer(
-				destination0, moduleOutputChannel0, producerProperties);
-		Binding<MessageChannel> producerBinding1 = binder.bindProducer(
-				destination1, moduleOutputChannel1, createProducerProperties());
-
-		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
-				destination0, group0, moduleInputChannel, createConsumerProperties());
-
-		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
-				.build();
-
-		binderBindUnbindLatency();
-
-		final CountDownLatch latch = new CountDownLatch(2);
-		moduleInputChannel.subscribe(message1 -> {
-			logger.info(String.format("Received message %s", message1));
-			latch.countDown();
-		});
-
-		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
-		moduleOutputChannel0.send(message);
-
-		logger.info(String.format("Sending message to destination %s: %s", destination1, message));
-		moduleOutputChannel1.send(message);
-
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		TimeUnit.SECONDS.sleep(1); // Give bindings a sec to finish processing successful message consume
-		producerBinding0.unbind();
-		producerBinding1.unbind();
-		consumerBinding.unbind();
-	}
-
+@IgnoreInheritedTests
+public class SolaceBinderProvisioningLifecycleTest extends SolaceBinderTestBase {
 	@Test
 	public void testConsumerProvisionDurableQueue() throws Exception {
 		SolaceTestBinder binder = getBinder();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderTestBase.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderTestBase.java
@@ -1,0 +1,74 @@
+package com.solace.spring.cloud.stream.binder;
+
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
+import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
+import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredSpringRunner;
+import com.solace.spring.cloud.stream.binder.test.util.SolaceExternalResourceHandler;
+import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.SpringJCSMPFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.PartitionCapableBinderTests;
+import org.springframework.cloud.stream.binder.Spy;
+
+/**
+ * <p>Base class for all Solace Spring Cloud Stream Binder test classes.
+ *
+ * <p>Typically, you'll want to filter out all inherited test cases from
+ * the parent class {@link PartitionCapableBinderTests PartitionCapableBinderTests}.
+ * To do this, run your test class with the
+ * {@link InheritedTestsFilteredSpringRunner InheritedTestsFilteredSpringRunner} runner
+ * along with the {@link IgnoreInheritedTests @IgnoreInheritedTests} annotation.
+ */
+public abstract class SolaceBinderTestBase
+		extends PartitionCapableBinderTests<SolaceTestBinder, ExtendedConsumerProperties<SolaceConsumerProperties>, ExtendedProducerProperties<SolaceProducerProperties>> {
+	@Autowired
+	private SpringJCSMPFactory springJCSMPFactory;
+
+	@Value("${test.fail.on.connection.exception:false}")
+	private Boolean failOnConnectError;
+
+	JCSMPSession jcsmpSession;
+
+	static SolaceExternalResourceHandler externalResource = new SolaceExternalResourceHandler();
+
+
+	@Override
+	protected boolean usesExplicitRouting() {
+		return true;
+	}
+
+	@Override
+	protected String getClassUnderTestName() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	protected SolaceTestBinder getBinder() throws Exception {
+		if (testBinder == null) {
+			logger.info(String.format("Getting new %s instance", SolaceTestBinder.class.getSimpleName()));
+			jcsmpSession = externalResource.assumeAndGetActiveSession(springJCSMPFactory, failOnConnectError);
+			testBinder = new SolaceTestBinder(jcsmpSession);
+		}
+		return testBinder;
+	}
+
+	@Override
+	protected ExtendedConsumerProperties<SolaceConsumerProperties> createConsumerProperties() {
+		return new ExtendedConsumerProperties<>(new SolaceConsumerProperties());
+	}
+
+	@Override
+	protected ExtendedProducerProperties<SolaceProducerProperties> createProducerProperties() {
+		return new ExtendedProducerProperties<>(new SolaceProducerProperties());
+	}
+
+	@Override
+	public Spy spyOn(String name) {
+		return null;
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/IgnoreInheritedTests.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/IgnoreInheritedTests.java
@@ -1,0 +1,17 @@
+package com.solace.spring.cloud.stream.binder.test.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When the test class is marked with {@link IgnoreInheritedTests @IgnoreInheritedTests}
+ * and runs with the {@link InheritedTestsFilteredSpringRunner InheritedTestsFilteredSpringRunner},
+ * all inherited test cases will be filtered from the test run.
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface IgnoreInheritedTests {
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/InheritedTestsFilteredSpringRunner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/InheritedTestsFilteredSpringRunner.java
@@ -1,0 +1,61 @@
+package com.solace.spring.cloud.stream.binder.test.util;
+
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runners.model.InitializationError;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * <p>Extends off of the {@link SpringJUnit4ClassRunner SpringJUnit4ClassRunner},
+ * but with the additional feature of filtering out all inherited tests
+ * if the test class is annotated with {@link IgnoreInheritedTests IgnoreInheritedTests}.
+ *
+ * <p>Based off this Stack Overflow answer:
+ * https://stackoverflow.com/questions/2207070/junit-ignore-test-methods-from-base-class/5248700#answer-12459947
+ */
+public final class InheritedTestsFilteredSpringRunner extends SpringJUnit4ClassRunner {
+	/**
+	 * Construct a new {@code SpringRunner} and initialize a
+	 * {@link TestContextManager TestContextManager}
+	 * to provide Spring testing functionality to standard JUnit 4 tests.
+	 *
+	 * Also filters out any inherited JUnit test methods if the test class is also annotated with
+	 * {@link IgnoreInheritedTests IgnoreInheritedTests}.
+	 *
+	 * @param clazz the test class to be run
+	 * @see #createTestContextManager(Class)
+	 */
+	public InheritedTestsFilteredSpringRunner(Class<?> clazz) throws InitializationError {
+		super(clazz);
+		try {
+			this.filter(new InheritedTestsFilter());
+		} catch (NoTestsRemainException e) {
+			throw new IllegalStateException("class should contain at least one runnable test", e);
+		}
+	}
+
+	public static class InheritedTestsFilter extends Filter {
+
+		@Override
+		public boolean shouldRun(Description description) {
+			Class<?> clazz = description.getTestClass();
+			String methodName = description.getMethodName();
+			if (clazz.isAnnotationPresent(IgnoreInheritedTests.class)) {
+				try {
+					return clazz.getDeclaredMethod(methodName) != null;
+				} catch (Exception e) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public String describe() {
+			return null;
+		}
+
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceExternalResourceHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceExternalResourceHandler.java
@@ -1,4 +1,4 @@
-package com.solace.spring.cloud.stream.binder;
+package com.solace.spring.cloud.stream.binder.test.util;
 
 import com.solacesystems.jcsmp.InvalidPropertiesException;
 import com.solacesystems.jcsmp.JCSMPException;
@@ -9,13 +9,13 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Assume;
 
-class SolaceExternalResourceHandler {
+public class SolaceExternalResourceHandler {
 
 	private JCSMPException sessionConnectError;
 
 	private static final Log logger = LogFactory.getLog(SolaceExternalResourceHandler.class);
 
-	JCSMPSession assumeAndGetActiveSession(SpringJCSMPFactory springJCSMPFactory, boolean failOnConnectionException)
+	public JCSMPSession assumeAndGetActiveSession(SpringJCSMPFactory springJCSMPFactory, boolean failOnConnectionException)
 			throws InvalidPropertiesException {
 
 		handleConnectionError(failOnConnectionException);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
@@ -1,5 +1,6 @@
-package com.solace.spring.cloud.stream.binder;
+package com.solace.spring.cloud.stream.binder.test.util;
 
+import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solace.spring.cloud.stream.binder.provisioning.SolaceQueueProvisioner;


### PR DESCRIPTION
* Add `provisionDurableQueue` consumer/producer config parameter to skip consumer group queue provisioning
* Add `addDurableQueueSubscription` consumer/producer config parameter to skip topic subscriptions on consumer group queues
* Add `provisionDmq` consumer config parameter to skip DMQ provisioning
* Add consumer connection check to test connections to consumer group queues and DMQs during endpoint provisioning phase