### PR TITLE
Fix solace-integration-test-support Submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "solace-integration-test-support"]
 	path = solace-integration-test-support
-	url = git@github.com:SolaceDev/solace-integration-test-support.git
+	url = ../../SolaceDev/solace-integration-test-support.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "solace-integration-test-support"]
 	path = solace-integration-test-support
-	url = https://github.com/SolaceDev/solace-integration-test-support.git
+	url = git@github.com:SolaceDev/solace-integration-test-support.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 dist: trusty
 sudo: false
-script: mvn clean package
+script:
+  - mvn clean package
+  - ./solace-integration-test-support/scripts/validate_submodule_not_changed.sh
 jdk:
   - oraclejdk8
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <solace.spring.cloud.connector.version>4.3.0-SNAPSHOT</solace.spring.cloud.connector.version>
         <solace.spring.cloud.stream-starter.version>2.1.0-SNAPSHOT</solace.spring.cloud.stream-starter.version>
 
-        <solace.integration.test.support.version>0.1.0</solace.integration.test.support.version>
+        <solace.integration.test.support.version>0.2.0</solace.integration.test.support.version>
         <solace.integration.test.support.fetch_checkout.skip>false</solace.integration.test.support.fetch_checkout.skip>
         <solace.integration.test.support.install.skip>true</solace.integration.test.support.install.skip>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <solace.spring.cloud.stream-starter.version>2.1.0-SNAPSHOT</solace.spring.cloud.stream-starter.version>
 
         <solace.integration.test.support.version>0.1.0</solace.integration.test.support.version>
+        <solace.integration.test.support.fetch_checkout.skip>false</solace.integration.test.support.fetch_checkout.skip>
         <solace.integration.test.support.install.skip>true</solace.integration.test.support.install.skip>
     </properties>
 
@@ -303,6 +304,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${solace.integration.test.support.fetch_checkout.skip}</skip>
                             <executable>git</executable>
                             <arguments>
                                 <argument>-C</argument>
@@ -322,6 +324,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${solace.integration.test.support.fetch_checkout.skip}</skip>
                             <executable>git</executable>
                             <arguments>
                                 <argument>-C</argument>


### PR DESCRIPTION
* Use relative URL for solace-integration-test-support. This so that Git will dynamically use HTTPS or SSH depending on the state of the parent project.
* add fetch & checkout skip property for solace-integration-test-support.
* Add Travis validation for submodule to ensure that it matches the version specified in the POM.