### PR TITLE
SOL-37880: Fix SCSt Consumer High CPU Usage

### DIFF
--- a/solace-spring-cloud-bom/README.md
+++ b/solace-spring-cloud-bom/README.md
@@ -32,7 +32,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.cloud</groupId>
             <artifactId>solace-spring-cloud-bom</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -60,7 +60,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:1.1.0"
+        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:1.1.1"
     }
 }
 
@@ -72,7 +72,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:1.1.0"))
+    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:1.1.1"))
     implementation("com.solace.spring.cloud:spring-cloud-starter-stream-solace")
 }
 ```

--- a/solace-spring-cloud-connector/README.md
+++ b/solace-spring-cloud-connector/README.md
@@ -76,7 +76,7 @@ Include version 4.0.0 or later to use Spring Boot release 2.x
 
 ```
 // Solace Cloud
-compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.0")
+compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.1")
 ```
 
 ### Using it with Maven
@@ -86,7 +86,7 @@ compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.0")
 <dependency>
   <groupId>com.solace.cloud.cloudfoundry</groupId>
   <artifactId>solace-spring-cloud-connector</artifactId>
-  <version>4.3.0</version>
+  <version>4.3.1</version>
 </dependency>
 ```
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.md
@@ -56,7 +56,7 @@ Here is how to include the spring cloud stream starter in your project using Gra
 
 ```groovy
 // Solace Spring Cloud Stream Binder
-compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:2.1.0")
+compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:2.1.1")
 ```
 
 #### Using it with Maven
@@ -66,7 +66,7 @@ compile("com.solace.spring.cloud:spring-cloud-starter-stream-solace:2.1.0")
 <dependency>
   <groupId>com.solace.spring.cloud</groupId>
   <artifactId>spring-cloud-starter-stream-solace</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -81,7 +81,7 @@ class InboundXMLMessageListener implements Runnable {
 				}
 			}
 		} finally {
-			logger.warn(String.format("Closing flow receiver to destination %s", consumerDestination.getName()));
+			logger.info(String.format("Closing flow receiver to destination %s", consumerDestination.getName()));
 			flowReceiver.close();
 		}
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -16,6 +16,7 @@ import org.springframework.integration.acks.AckUtils;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.messaging.Message;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -29,6 +30,7 @@ class InboundXMLMessageListener implements Runnable {
 	private final Function<RuntimeException,Boolean> errorHandlerFunction;
 	private final boolean needHolder;
 	private final boolean needAttributes;
+	private final AtomicBoolean stopFlag = new AtomicBoolean(false);
 
 	private static final Log logger = LogFactory.getLog(InboundXMLMessageListener.class);
 
@@ -60,7 +62,7 @@ class InboundXMLMessageListener implements Runnable {
 	@Override
 	public void run() {
 		try {
-			while (!Thread.currentThread().isInterrupted()) {
+			while (!stopFlag.get() && !Thread.currentThread().isInterrupted()) {
 				try {
 					receive();
 				} catch (RuntimeException e) {
@@ -139,5 +141,9 @@ class InboundXMLMessageListener implements Runnable {
 		boolean wasProcessedByErrorHandler = errorHandlerFunction != null && errorHandlerFunction.apply(e);
 		acknowledgement.run();
 		if (!wasProcessedByErrorHandler) throw e;
+	}
+
+	public AtomicBoolean getStopFlag() {
+		return stopFlag;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -81,6 +81,7 @@ class InboundXMLMessageListener implements Runnable {
 				}
 			}
 		} finally {
+			logger.warn(String.format("Closing flow receiver to destination %s", consumerDestination.getName()));
 			flowReceiver.close();
 		}
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -79,7 +79,7 @@ class InboundXMLMessageListener implements Runnable {
 		BytesXMLMessage bytesXMLMessage;
 
 		try {
-			bytesXMLMessage = flowReceiver.receiveNoWait();
+			bytesXMLMessage = flowReceiver.receive();
 		} catch (JCSMPException e) {
 			logger.warn(String.format("Received error while trying to read message from endpoint %s",
 					flowReceiver.getEndpoint().getName()), e);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
@@ -38,7 +38,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 	private final EndpointProperties endpointProperties;
 	private final Consumer<Queue> postStart;
 	private final int concurrency;
-	private final long shutdownDelayInMillis = 500; //TODO Make this configurable
+	private final long shutdownInterruptThresholdInMillis = 500; //TODO Make this configurable
 	private final AtomicBoolean remoteStopFlag;
 	private final Set<AtomicBoolean> consumerStopFlags;
 	private ExecutorService executorService;
@@ -134,7 +134,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 				concurrency, queueName, id));
 		consumerStopFlags.forEach(flag -> flag.set(true)); // Mark threads for shutdown
 		try {
-			if (!executorService.awaitTermination(shutdownDelayInMillis, TimeUnit.MILLISECONDS)) {
+			if (!executorService.awaitTermination(shutdownInterruptThresholdInMillis, TimeUnit.MILLISECONDS)) {
 				logger.info(String.format("Interrupting all workers for inbound adapter %s", id));
 				executorService.shutdownNow();
 				if (!executorService.awaitTermination(1, TimeUnit.MINUTES)) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
@@ -38,6 +38,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 	private final EndpointProperties endpointProperties;
 	private final Consumer<Queue> postStart;
 	private final int concurrency;
+	private final AtomicBoolean remoteStopFlag;
 	private final Set<AtomicBoolean> consumerStopFlags;
 	private ExecutorService executorService;
 	private RetryTemplate retryTemplate;
@@ -50,12 +51,14 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 									  JCSMPSession jcsmpSession,
 									  int concurrency,
 									  @Nullable EndpointProperties endpointProperties,
-									  @Nullable Consumer<Queue> postStart) {
+									  @Nullable Consumer<Queue> postStart,
+									  @Nullable AtomicBoolean remoteStopFlag) {
 		this.consumerDestination = consumerDestination;
 		this.jcsmpSession = jcsmpSession;
 		this.concurrency = concurrency;
 		this.endpointProperties = endpointProperties;
 		this.postStart = postStart;
+		this.remoteStopFlag = remoteStopFlag;
 		this.consumerStopFlags = new HashSet<>(this.concurrency);
 	}
 
@@ -185,6 +188,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 					(exception) -> sendErrorMessageIfNecessary(null, exception),
 					retryTemplate,
 					recoveryCallback,
+					remoteStopFlag,
 					attributesHolder
 			);
 			retryTemplate.registerListener(retryableMessageListener);
@@ -195,6 +199,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 					consumerDestination,
 					this::sendMessage,
 					(exception) -> sendErrorMessageIfNecessary(null, exception),
+					remoteStopFlag,
 					attributesHolder,
 					this.getErrorChannel() != null
 			);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/RetryableInboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/RetryableInboundXMLMessageListener.java
@@ -8,6 +8,7 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.acks.AckUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
@@ -15,6 +16,7 @@ import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
 import org.springframework.retry.support.RetryTemplate;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -30,8 +32,9 @@ class RetryableInboundXMLMessageListener extends InboundXMLMessageListener imple
 									   Function<RuntimeException,Boolean> errorHandlerFunction,
 									   RetryTemplate retryTemplate,
 									   RecoveryCallback<?> recoveryCallback,
+									   @Nullable AtomicBoolean remoteStopFlag,
 									   ThreadLocal<AttributeAccessor> attributesHolder) {
-		super(flowReceiver, consumerDestination, messageConsumer, errorHandlerFunction, attributesHolder, false, true);
+		super(flowReceiver, consumerDestination, messageConsumer, errorHandlerFunction, remoteStopFlag, attributesHolder, false, true);
 		this.retryTemplate = retryTemplate;
 		this.recoveryCallback = recoveryCallback;
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SharedResourceManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SharedResourceManager.java
@@ -21,6 +21,13 @@ abstract class SharedResourceManager<T> {
 	abstract T create() throws Exception;
 	abstract void close();
 
+	/**
+	 * Register {@code key} to the shared resource.
+	 * <p>If this is the first key to claim this shared resource, {@link #create()} the resource.
+	 * @param key the registration key of the caller that wants to use this resource
+	 * @return the shared resource
+	 * @throws Exception whatever exception that may be thrown by {@link #create()}
+	 */
 	public T get(String key) throws Exception {
 		synchronized (lock) {
 			if (registeredIds.isEmpty()) {
@@ -36,6 +43,11 @@ abstract class SharedResourceManager<T> {
 		return sharedResource;
 	}
 
+	/**
+	 * De-register {@code key} from the shared resource.
+	 * <p>If this is the last {@code key} associated to the shared resource, {@link #close()} the resource.
+	 * @param key the registration key of the caller that is using the resource
+	 */
 	public void release(String key) {
 		synchronized (lock) {
 			if (!registeredIds.contains(key)) return;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -57,7 +57,7 @@ public class SolaceMessageChannelBinder
 
 	@Override
 	public void destroy() {
-		logger.info("Closing JCSMP session");
+		logger.info(String.format("Closing JCSMP session %s", jcsmpSession.getSessionName()));
 		sessionProducerManager.release(errorHandlerProducerKey);
 		consumersRemoteStopFlag.set(true);
 		jcsmpSession.closeSession();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -30,6 +30,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 public class SolaceMessageChannelBinder
@@ -42,6 +43,7 @@ public class SolaceMessageChannelBinder
 
 	private final JCSMPSession jcsmpSession;
 	private final JCSMPSessionProducerManager sessionProducerManager;
+	private final AtomicBoolean consumersRemoteStopFlag = new AtomicBoolean(false);
 	private final String errorHandlerProducerKey = UUID.randomUUID().toString();
 	private SolaceExtendedBindingProperties extendedBindingProperties = new SolaceExtendedBindingProperties();
 
@@ -55,7 +57,9 @@ public class SolaceMessageChannelBinder
 
 	@Override
 	public void destroy() {
+		logger.info("Closing JCSMP session");
 		sessionProducerManager.release(errorHandlerProducerKey);
+		consumersRemoteStopFlag.set(true);
 		jcsmpSession.closeSession();
 	}
 
@@ -77,7 +81,8 @@ public class SolaceMessageChannelBinder
 	protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
 													 ExtendedConsumerProperties<SolaceConsumerProperties> properties) {
 		JCSMPInboundChannelAdapter adapter = new JCSMPInboundChannelAdapter(destination, jcsmpSession,
-				properties.getConcurrency(), getConsumerEndpointProperties(properties), getConsumerPostStart(properties));
+				properties.getConcurrency(), getConsumerEndpointProperties(properties),
+				getConsumerPostStart(properties), consumersRemoteStopFlag);
 
 		ErrorInfrastructure errorInfra = registerErrorInfrastructure(destination, group, properties);
 		if (properties.getMaxAttempts() > 1) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
@@ -3,6 +3,8 @@ package com.solace.spring.cloud.stream.binder.config;
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.SpringJCSMPFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
@@ -24,9 +26,12 @@ public class SolaceMessageChannelBinderConfiguration {
 
 	private JCSMPSession jcsmpSession;
 
+	private static final Log logger = LogFactory.getLog(SolaceMessageChannelBinderConfiguration.class);
+
 	@PostConstruct
 	private void initSession() throws JCSMPException {
 		jcsmpSession = springJCSMPFactory.createSession();
+		logger.info(String.format("Connecting JCSMP session %s", jcsmpSession.getSessionName()));
 		jcsmpSession.connect();
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicTest.java
@@ -618,4 +618,33 @@ public class SolaceBinderBasicTest extends SolaceBinderTestBase {
 		producerBinding.unbind();
 		consumerBinding.unbind();
 	}
+
+	@Test
+	public void testBinderDestroy() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = "testBinderDestroy";
+
+		binder.bindConsumer(destination0, group0, moduleInputChannel, createConsumerProperties());
+
+		binderBindUnbindLatency();
+
+		try {
+			logger.info("Destroy binder");
+			binder.getBinder().destroy();
+			Thread.sleep(3000);
+
+			//TODO Implement Test: Intercept InboundXMLMessageListener to check for any error
+
+		} finally {
+			binder = getBinder(); // Refresh binder instance if successfully destroyed
+			logger.info("Rebinding consumer so that we can properly clean it up");
+			Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+					destination0, group0, moduleInputChannel, createConsumerProperties());
+			consumerBinding.unbind();
+		}
+	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderTestBase.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderTestBase.java
@@ -78,7 +78,14 @@ public abstract class SolaceBinderTestBase
 
 	@Override
 	protected SolaceTestBinder getBinder() throws Exception {
-		if (testBinder == null) {
+		if (testBinder == null || jcsmpSession.isClosed()) {
+			if (testBinder != null) {
+				logger.info(String.format("Will recreate %s since %s is closed",
+						testBinder.getClass().getSimpleName(), jcsmpSession.getClass().getSimpleName()));
+				testBinder.getBinder().destroy();
+				testBinder = null;
+			}
+
 			logger.info(String.format("Getting new %s instance", SolaceTestBinder.class.getSimpleName()));
 			jcsmpSession = externalResource.assumeAndGetActiveSession(springJCSMPFactory, failOnConnectError);
 			testBinder = new SolaceTestBinder(jcsmpSession);


### PR DESCRIPTION
* Do a blocking poll instead of a non-blocking one on the SCSt consumers' flow handlers to fix high CPU usage. (Fixes #20 )
* Fix JCSMP error error during SCSt shutdown