### PR TITLE
#38 Fix build for java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
-            </plugin>
-
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
@@ -229,6 +223,10 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>8</source>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/pom.xml
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/pom.xml
@@ -32,18 +32,7 @@
 
     <build>
         <plugins>
-            <plugin>
-                <!-- JAR will always be empty - suppress build warning that JAR is empty -->
-                <!-- This warning is triggered when the target/classes directory does not exist -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <classesDirectory>.</classesDirectory>
-                    <excludes>
-                        <exclude>**</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
+
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Issue: #38

Fixing:
```
Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.2.0:jar (default-jar) on project spring-cloud-starter-stream-solace: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them. -> [Help 1]
```
This appear with java 1.8 and 11
I dont see why "maven-jar-plugin" was required here.

Fixing:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (attach-javadocs) on project solace-spring-cloud-connector: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[ERROR]
[ERROR] Command line was: C:\devsbb\java\jdk-11.0.7\bin\javadoc.exe @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in 'C:\devsbb\git\solace-spring-cloud\solace-spring-cloud-connector\target\apidocs' dir.
[ERROR]
```
This is a known issue for java >=11