### PR TITLE
Request reply support

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
@@ -23,6 +23,7 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 			{SolaceHeaders.RECEIVE_TIMESTAMP, new SolaceHeaderMeta<>(Long.class, XMLMessage::getReceiveTimestamp, null)},
 			{SolaceHeaders.REDELIVERED, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::getRedelivered, null)},
 			{SolaceHeaders.REPLY_TO, new SolaceHeaderMeta<>(Destination.class, XMLMessage::getReplyTo, XMLMessage::setReplyTo)},
+			{SolaceHeaders.REPLY_MESSAGE, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::isReplyMessage, XMLMessage::setAsReplyMessage)},
 			{SolaceHeaders.SENDER_ID, new SolaceHeaderMeta<>(String.class, XMLMessage::getSenderId, XMLMessage::setSenderId)},
 			{SolaceHeaders.SENDER_TIMESTAMP, new SolaceHeaderMeta<>(Long.class, XMLMessage::getSenderTimestamp, XMLMessage::setSenderTimestamp)},
 			{SolaceHeaders.SEQUENCE_NUMBER, new SolaceHeaderMeta<>(Long.class, XMLMessage::getSequenceNumber, XMLMessage::setSequenceNumber)},

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
@@ -117,6 +117,14 @@ public final class SolaceHeaders {
 	public static final String REPLY_TO = PREFIX + "replyTo";
 
 	/**
+	 * <p><b>Acceptable Value Type:</b> {@link Boolean}</p>
+	 * <p><b>Access:</b> Read/Write</p>
+	 * <br>
+	 * <p>Whether the message is a reply message of a request/reply.</p>
+	 */
+	public static final String REPLY_MESSAGE = PREFIX + "replyMessage";
+
+	/**
 	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
 	 * <p><b>Access:</b> Read/Write</p>
 	 * <br>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -207,6 +207,9 @@ public class XMLMessageMapperTest {
 				case SolaceHeaders.REPLY_TO:
 					value = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(10));
 					break;
+				case SolaceHeaders.REPLY_MESSAGE:
+					value = !defaultXmlMessage.isReplyMessage();
+					break;
 				case SolaceHeaders.USER_DATA:
 					value = RandomStringUtils.randomAlphanumeric(10).getBytes();
 					break;
@@ -247,6 +250,9 @@ public class XMLMessageMapperTest {
 					break;
 				case SolaceHeaders.REPLY_TO:
 					assertEquals(expectedValue, xmlMessage.getReplyTo());
+					break;
+				case SolaceHeaders.REPLY_MESSAGE:
+					assertEquals(expectedValue, xmlMessage.isReplyMessage());
 					break;
 				case SolaceHeaders.SENDER_ID:
 					assertEquals(expectedValue, xmlMessage.getSenderId());
@@ -630,6 +636,9 @@ public class XMLMessageMapperTest {
 					Mockito.when(xmlMessage.getReplyTo())
 							.thenReturn(JCSMPFactory.onlyInstance().createQueue(header.getKey()));
 					break;
+				case SolaceHeaders.REPLY_MESSAGE:
+					Mockito.when(xmlMessage.isReplyMessage()).thenReturn(!defaultXmlMessage.isReplyMessage());
+					break;
 				case SolaceHeaders.SENDER_ID:
 					Mockito.when(xmlMessage.getSenderId()).thenReturn(header.getKey());
 					break;
@@ -698,6 +707,9 @@ public class XMLMessageMapperTest {
 					break;
 				case SolaceHeaders.REPLY_TO:
 					assertEquals(xmlMessage.getReplyTo(), actualValue);
+					break;
+				case SolaceHeaders.REPLY_MESSAGE:
+					assertEquals(xmlMessage.isReplyMessage(), actualValue);
 					break;
 				case SolaceHeaders.SENDER_ID:
 					assertEquals(xmlMessage.getSenderId(), actualValue);


### PR DESCRIPTION
Add support for request reply.

### Example:

##### Requestor:

application yaml only contains "binders".
This cause that objectMapper has to be called manually and no automatic metrics will be generated.

```java

import ch.sbb.tms.springcloudstream.examples.pubsubsending.model.SensorReading;
import com.fasterxml.jackson.databind.ObjectMapper;
import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
import lombok.RequiredArgsConstructor;
import lombok.extern.log4j.Log4j2;
import org.springframework.cloud.stream.binder.BinderFactory;
import org.springframework.integration.channel.PublishSubscribeChannel;
import org.springframework.messaging.Message;
import org.springframework.messaging.support.MessageBuilder;
import org.springframework.web.bind.annotation.GetMapping;
import org.springframework.web.bind.annotation.PathVariable;
import org.springframework.web.bind.annotation.RestController;

import javax.annotation.PostConstruct;
import java.io.IOException;

@Log4j2
@RestController
@RequiredArgsConstructor
public class RequestReplyController {

    private final BinderFactory binderFactory;
    private final ObjectMapper objectMapper;
    private SolaceMessageChannelBinder binder;

    @PostConstruct
    void init() {
        binder = (SolaceMessageChannelBinder) (Object) binderFactory.getBinder("main_session", PublishSubscribeChannel.class);
    }
    
    @GetMapping(value = "/temperature/last_value/{location}")
    public SensorReading publishTemperatureDynamicTopic(
            @PathVariable("location") final String location
    ) throws IOException {
        SensorReading reading = new SensorReading();
        reading.setSensorID(location);

        log.info("Request " + reading);

        Message<byte[]> message = MessageBuilder
                // Without encoding solace lib will use java serializer.
                .withPayload(objectMapper.writeValueAsBytes(reading))
                .build();
        
        Message<byte[]> response = (Message<byte[]>) binder.sendRequest(
                "last_value/temperature/celsius/" + location,
                message);

        return objectMapper.readValue(response.getPayload(), SensorReading.class);
    }


}
```

##### Response:

application yaml contains "binders" and "bindings":
```yaml
        responseToRequest-in-0:
          destination: last_value/temperature/>
          contentType: "application/json"
          binder: main_session

        responseToRequest-out-0:
          contentType: "application/json"
          binder: main_session
```

```java
import ch.sbb.tms.springcloudstream.examples.pubsubreceiving.model.SensorReading;
import ch.sbb.tms.springcloudstream.examples.pubsubreceiving.model.SensorRequest;
import com.solace.spring.cloud.stream.binder.messaging.SolaceHeaders;
import com.solacesystems.jcsmp.Destination;
import lombok.extern.log4j.Log4j2;
import org.springframework.cloud.stream.binder.BinderHeaders;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;
import org.springframework.messaging.Message;
import org.springframework.messaging.support.MessageBuilder;

import java.util.function.Function;

@Log4j2
@Configuration
public class PingPongConfig {

    @Bean
    public Function<Message<SensorRequest>, Message<SensorReading>> responseToRequest() {
        return (msgIn) -> {
            log.info(msgIn);

            SensorReading reading = new SensorReading();
            reading.setSensorID(msgIn.getPayload().getSensorID());
            reading.setTimestamp(msgIn.getPayload().getTimestamp());
            reading.setBaseUnit(SensorReading.BaseUnit.CELSIUS);
            reading.setTemperature(Math.random() * 35d);

            return MessageBuilder
                    .withPayload(reading)
                    .setHeader(
                            BinderHeaders.TARGET_DESTINATION,
                            msgIn.getHeaders().get(SolaceHeaders.REPLY_TO, Destination.class).toString()
                    )
                    .setHeader(
                            SolaceHeaders.CORRELATION_ID,
                            msgIn.getHeaders().get(SolaceHeaders.CORRELATION_ID)
                    )
                    .setHeader(
                            SolaceHeaders.REPLY_MESSAGE,
                            Boolean.TRUE
                    )
                    .build();
        };
    }

}
```

Rebased to: #37 