### PR TITLE
upgrade spring-boot from 2.3.0.RELEASE to 2.3.7.RELEASE to fix IT discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
         <!-- Must match ${project.parent.version} -->
         <solace.spring.boot.bom.version>1.1.0</solace.spring.boot.bom.version>
 
+        <!-- Override spring-boot version from solace-spring-boot to latest patch version -->
+        <!-- Remove this if the next version of solace-spring-boot works fine -->
+        <spring.boot.version>2.3.7.RELEASE</spring.boot.version>
+
         <solace.spring.cloud.connector.version>4.3.2-SNAPSHOT</solace.spring.cloud.connector.version>
         <solace.spring.cloud.stream-starter.version>3.0.0-SNAPSHOT</solace.spring.cloud.stream-starter.version>
 


### PR DESCRIPTION
Tests have been failing to be discovered to the JUnit upgrade:
```
WARNING: TestEngine with ID 'junit-vintage' failed to discover tests

org.junit.platform.commons.JUnitException: Failed to parse version of junit:junit: 4.13.1
```

Worked around this by overriding Spring-Boot from Solace-Spring-Boot to use the latest patch version.