### PR TITLE
Option to exclude headers

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -299,6 +299,11 @@ The following properties are available for Solace producers only and must be pre
 
 See link:../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java[SolaceCommonProperties] and link:../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java[SolaceProducerProperties] for the most updated list.
 
+headerExclusions::
+The list of headers to exclude from the published message. This will not filter out any Solace message headers.
++
+Default: Empty `List&lt;String&gt;`
+
 prefix::
 Naming prefix for all topics and queues.
 +

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -1,10 +1,13 @@
 package com.solace.spring.cloud.stream.binder.properties;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class SolaceProducerProperties extends SolaceCommonProperties {
 	private Map<String,String[]> queueAdditionalSubscriptions = new HashMap<>();
+	private List<String> headerExclusions = new ArrayList<>();
 
 	public Map<String, String[]> getQueueAdditionalSubscriptions() {
 		return queueAdditionalSubscriptions;
@@ -12,5 +15,13 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 
 	public void setQueueAdditionalSubscriptions(Map<String, String[]> queueAdditionalSubscriptions) {
 		this.queueAdditionalSubscriptions = queueAdditionalSubscriptions;
+	}
+
+	public List<String> getHeaderExclusions() {
+		return headerExclusions;
+	}
+
+	public void setHeaderExclusions(List<String> headerExclusions) {
+		this.headerExclusions = headerExclusions;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -70,7 +70,7 @@ public class SolaceMessageChannelBinder
 														  ExtendedProducerProperties<SolaceProducerProperties> producerProperties,
 														  MessageChannel errorChannel) {
 		JCSMPOutboundMessageHandler handler = new JCSMPOutboundMessageHandler(
-				destination, jcsmpSession, errorChannel, sessionProducerManager);
+				destination, jcsmpSession, errorChannel, sessionProducerManager, producerProperties.getExtension());
 
 		if (errorChannel != null) {
 			handler.setErrorMessageStrategy(new DefaultErrorMessageStrategy());


### PR DESCRIPTION
As we played around with opentracing/Jäger we found that opentracing adds a header to all Messages that is not serializable and not have to transmitted via the broker.

This change add the possibility to:
- drop headers add by interception of 3rd party modules that can not be serialized
- drop header you dont want to transfer to reduce the data throughput

Sample config:
```
solace:
  bindings:
    emitTemperatureSensorSimple-out-0:
      producer:
        headerExclusions:
          - io.opentracing.contrib.spring.integration.messaging.OpenTracingChannelInterceptor.SCOPE
```