### PR TITLE
health actuator for solace binder

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-binder-test</artifactId>
             <scope>test</scope>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
@@ -3,6 +3,7 @@ package com.solace.spring.cloud.stream.binder.config;
 import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
 import com.solace.spring.cloud.stream.binder.properties.SolaceExtendedBindingProperties;
 import com.solace.spring.cloud.stream.binder.provisioning.SolaceQueueProvisioner;
+import com.solace.spring.cloud.stream.binder.util.SolaceHealthIndicator;
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
@@ -10,6 +11,8 @@ import com.solacesystems.jcsmp.JCSMPSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,15 +30,18 @@ public class SolaceMessageChannelBinderConfiguration {
 
 	private JCSMPSession jcsmpSession;
 
+	private SolaceHealthIndicator solaceHealthIndicator = new SolaceHealthIndicator();
+
 	private static final Log logger = LogFactory.getLog(SolaceMessageChannelBinderConfiguration.class);
 
 	@PostConstruct
 	private void initSession() throws JCSMPException {
 		JCSMPProperties jcsmpProperties = (JCSMPProperties) this.jcsmpProperties.clone();
 		jcsmpProperties.setProperty(JCSMPProperties.CLIENT_INFO_PROVIDER, new SolaceBinderClientInfoProvider());
-		jcsmpSession = JCSMPFactory.onlyInstance().createSession(jcsmpProperties);
+		jcsmpSession = JCSMPFactory.onlyInstance().createSession(jcsmpProperties, null, solaceHealthIndicator);
 		logger.info(String.format("Connecting JCSMP session %s", jcsmpSession.getSessionName()));
 		jcsmpSession.connect();
+		solaceHealthIndicator.connected();
 	}
 
 	@Bean
@@ -49,4 +55,14 @@ public class SolaceMessageChannelBinderConfiguration {
 	SolaceQueueProvisioner provisioningProvider() {
 		return new SolaceQueueProvisioner(jcsmpSession);
 	}
+
+	@Configuration
+	@ConditionalOnClass(name = "org.springframework.boot.actuate.health.HealthIndicator")
+	public class SolaceHealthIndicatorConfiguration {
+		@Bean
+		public HealthIndicator binderHealthIndicator() {
+			return solaceHealthIndicator;
+		}
+	}
+
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceHealthIndicator.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceHealthIndicator.java
@@ -1,0 +1,44 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.SessionEventArgs;
+import com.solacesystems.jcsmp.SessionEventHandler;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class SolaceHealthIndicator extends AbstractHealthIndicator implements SessionEventHandler {
+
+    private final AtomicBoolean connected = new AtomicBoolean(false);
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) throws Exception {
+        if(connected.get()) {
+            builder.up();
+        } else {
+            builder.down();
+        }
+    }
+
+    @Override
+    public void handleEvent(SessionEventArgs sessionEventArgs) {
+        switch (sessionEventArgs.getEvent()) {
+            case DOWN_ERROR:
+                connected.set(false);
+                break;
+            case RECONNECTED:
+                connected.set(true);
+                break;
+            case RECONNECTING:
+            case SUBSCRIPTION_ERROR:
+            case UNKNOWN_TRANSACTED_SESSION_NAME:
+            case VIRTUAL_ROUTER_NAME_CHANGED:
+            default:
+                break;
+        }
+    }
+
+    public void connected() {
+        this.connected.set(true);
+    }
+}


### PR DESCRIPTION
# Spring cloud stream - spring health integration

## Scenario starting up

Try starting the application once with only main_session in application.yaml.
To do that remove all other sessions, except main_session part and specify main_session on second binder.
The application should start up without problem. Health page goes up.

Then do it again with a binder which has a connection but no working credentials. The application will not come up crash and health page is never on "up".

## Scenario user enabled changed / deleted while running

Use i.e. third session and create a user and put its credentials into that session.
Start application, it should come up normally. The health page shows "up".

If the health indicator is implemented, that health page is showing more information about the sessions:
`http://localhost:9003/actuator/health` shows:
```
{
  "status": "UP",
  "components": {
    "binders": {
      "status": "UP",
      "components": {
        "main_session": {
          "status": "UP"
        },
        "third_session": {
          "status": "UP"
        }
      }
    }
  }
}
```

Delete the user via solace management or deactivate it. As a result solace stops the connection and jcsmp tries to reconnect.
After the reconnection failed after several retries, the binder stops working entirely. But still the health page shows up.

You get a log error message like that: "403: Client Username Is Shutdown".

The binder is not able to recover from this situation.

Recreate the user or activate it again - the session remains closed and you get the same error message again.

With fixed health page the health page is down as a result like this:
Note: in this scenario only one of the session components is down, third_session.

```
{
  "status": "DOWN",
  "components": {
    "binders": {
      "status": "DOWN",
      "components": {
        "main_session": {
          "status": "UP"
        },
        "third_session": {
          "status": "DOWN"
        }
      }
    }
  }
}
```

## Scenario broker gets down for a time

The reconnect duration is taking a lot of time but eventually you get "Connection timed out: no further information"
and the health goes to down:

```
{
  "status": "DOWN",
  "components": {
    "binders": {
      "status": "DOWN",
      "components": {
        "main_session": {
          "status": "DOWN"
        },
        "third_session": {
          "status": "DOWN"
        }
      }
    }
  }
}
```

Note: in this scenario all sessions are down.

## Usage of the health indicator

Those health indicator can be used by [kubernetes](https://www.baeldung.com/spring-liveness-readiness-probes) to kill / restart the pod/application if there is no connection to broker any more (and will not recover). 
In this case we can leave the error reporting / disaster handling to kubernetes.