### PR TITLE
Base64-encode serialized headers and change solace_scst_serializedHeaders to JSON String (JMS Compatibility)

### DIFF
--- a/solace-spring-cloud-parent/pom.xml
+++ b/solace-spring-cloud-parent/pom.xml
@@ -23,7 +23,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <solace.jcsmp.version>10.8.1</solace.jcsmp.version>
+        <solace.jcsmp.version>10.10.0</solace.jcsmp.version>
+        <solace.jms.version>10.10.0</solace.jms.version>
     </properties>
 
     <dependencyManagement>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -462,27 +462,37 @@ These can be used for:
 
 TIP: Use link:../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java[SolaceBinderHeaders] instead of hardcoding the header names. This class also contains the same documentation that you see here.
 
-[cols="1m,1m,1,4", options="header"]
+[cols="1m,1m,1,1m,4", options="header"]
 |===
 | Header Name
 | Type
 | Access
+| Default Value
 | Description
 
 | solace_scst_messageVersion
 | Integer
 | Read
+| 1
 | A static number set by the publisher to indicate the Spring Cloud Stream Solace message version.
 
 | solace_scst_serializedPayload
 | Boolean
 | Internal Binder Use Only
+|
 | Is `true` if a Solace Spring Cloud Stream binder has serialized the payload before publishing it to a broker. Is undefined otherwise.
 
 | solace_scst_serializedHeaders
-| SDTStream
+| String
 | Internal Binder Use Only
-| A stream of header names where each entry indicates that that header’s value was serialized by a Solace Spring Cloud Stream binder before publishing it to a broker.
+|
+| A JSON String array of header names where each entry indicates that that header’s value was serialized by a Solace Spring Cloud Stream binder before publishing it to a broker.
+
+| solace_scst_serializedHeadersEncoding
+| String
+| Internal Binder Use Only
+| "base64"
+| The encoding algorithm used to encode the headers indicated by `solace_scst_serializedHeaders`.
 |===
 
 == Consumer Concurrency

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
@@ -59,6 +59,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.solacesystems</groupId>
+            <artifactId>sol-jms</artifactId>
+            <version>${solace.jms.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-binder-test</artifactId>
             <scope>test</scope>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
@@ -10,7 +10,8 @@ public class SolaceBinderHeaderMeta<T> implements HeaderMeta<T> {
 	public static final Map<String, SolaceBinderHeaderMeta<?>> META = Stream.of(new Object[][] {
 			{SolaceBinderHeaders.MESSAGE_VERSION, new SolaceBinderHeaderMeta<>(Integer.class, true, false)},
 			{SolaceBinderHeaders.SERIALIZED_PAYLOAD, new SolaceBinderHeaderMeta<>(Boolean.class, false, false)},
-			{SolaceBinderHeaders.SERIALIZED_HEADERS, new SolaceBinderHeaderMeta<>(SDTStream.class, false, false)}
+			{SolaceBinderHeaders.SERIALIZED_HEADERS, new SolaceBinderHeaderMeta<>(String.class, false, false)},
+			{SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, new SolaceBinderHeaderMeta<>(String.class, false, false)}
 	}).collect(Collectors.toMap(d -> (String) d[0], d -> (SolaceBinderHeaderMeta<?>) d[1]));
 
 	private final Class<T> type;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
@@ -1,6 +1,5 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
-import com.solacesystems.jcsmp.SDTStream;
 import org.springframework.messaging.Message;
 
 /**
@@ -26,6 +25,7 @@ public final class SolaceBinderHeaders {
 	/**
 	 * <p><b>Acceptable Value Type:</b> {@link Integer}</p>
 	 * <p><b>Access:</b> Read</p>
+	 * <p><b>Default Value: </b>{@code 1}</p>
 	 * <br>
 	 * <p>A static number set by the publisher to indicate the Spring Cloud Stream Solace message version.</p>
 	 */
@@ -41,11 +41,20 @@ public final class SolaceBinderHeaders {
 	public static final String SERIALIZED_PAYLOAD = PREFIX + "serializedPayload";
 
 	/**
-	 * <p><b>Acceptable Value Type:</b> {@link SDTStream}</p>
+	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
 	 * <p><b>Access:</b> Internal Binder Use Only</p>
 	 * <br>
-	 * <p>A stream of header names where each entry indicates that that header’s value was serialized by a
+	 * <p>A JSON String array of header names where each entry indicates that that header’s value was serialized by a
 	 * Solace Spring Cloud Stream binder before publishing it to a broker.</p>
 	 */
 	public static final String SERIALIZED_HEADERS = PREFIX + "serializedHeaders";
+
+	/**
+	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
+	 * <p><b>Access:</b> Internal Binder Use Only</p>
+	 * <p><b>Default Value: </b>{@code "base64"}</p>
+	 * <br>
+	 * <p>The encoding algorithm used to encode the headers indicated by {@link #SERIALIZED_HEADERS}.</p>
+	 */
+	public static final String SERIALIZED_HEADERS_ENCODING = PREFIX + "serializedHeadersEncoding";
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
@@ -31,11 +31,11 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.CoreMatchers.startsWithIgnoringCase;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -229,6 +229,31 @@ public class SolaceHeadersTest {
 				assertThat(e.getMessage(), containsString(String.format("Expected type %s, but got %s",
 						headerMeta.getValue().getType(), Object.class)));
 			}
+		}
+	}
+
+	@Test
+	public void testNameJmsCompatibility() {
+		for (String headerName : getAllHeaders()) {
+			assertTrue(Character.isJavaIdentifierStart(headerName.charAt(0)));
+			for (int i = 1; i < headerName.length(); i++) {
+				assertTrue(Character.isJavaIdentifierPart(headerName.charAt(i)));
+			}
+
+			assertNotEquals("NULL", headerName.toUpperCase());
+			assertNotEquals("TRUE", headerName.toUpperCase());
+			assertNotEquals("FALSE", headerName.toUpperCase());
+			assertNotEquals("NOT", headerName.toUpperCase());
+			assertNotEquals("AND", headerName.toUpperCase());
+			assertNotEquals("OR", headerName.toUpperCase());
+			assertNotEquals("BETWEEN", headerName.toUpperCase());
+			assertNotEquals("LIKE", headerName.toUpperCase());
+			assertNotEquals("IN", headerName.toUpperCase());
+			assertNotEquals("IS", headerName.toUpperCase());
+			assertNotEquals("ESCAPE", headerName.toUpperCase());
+
+			assertThat(headerName, not(startsWithIgnoringCase("JMSX")));
+			assertThat(headerName, not(startsWithIgnoringCase("JMS_")));
 		}
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalToObject;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
@@ -254,6 +255,19 @@ public class SolaceHeadersTest {
 
 			assertThat(headerName, not(startsWithIgnoringCase("JMSX")));
 			assertThat(headerName, not(startsWithIgnoringCase("JMS_")));
+
+			if (!(headersClass.equals(SolaceHeaders.class))) {
+				assertThat(headersMeta.get(headerName).getType(),
+						anyOf(equalToObject(boolean.class), equalToObject(Boolean.class),
+								equalToObject(byte.class), equalToObject(Byte.class),
+								equalToObject(short.class), equalToObject(Short.class),
+								equalToObject(int.class), equalToObject(Integer.class),
+								equalToObject(long.class), equalToObject(Long.class),
+								equalToObject(float.class), equalToObject(Float.class),
+								equalToObject(double.class), equalToObject(Double.class),
+								equalToObject(String.class)
+						));
+			}
 		}
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -7,7 +7,6 @@ import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
-import com.solacesystems.jcsmp.SDTStream;
 import com.solacesystems.jcsmp.XMLMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 import com.solacesystems.jms.SolConnectionFactory;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -1,0 +1,173 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.ITBase;
+import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
+import com.solacesystems.jcsmp.SDTStream;
+import com.solacesystems.jcsmp.XMLMessage;
+import com.solacesystems.jcsmp.XMLMessageProducer;
+import com.solacesystems.jms.SolConnectionFactory;
+import com.solacesystems.jms.SolJmsUtility;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(classes = SolaceJavaAutoConfiguration.class,
+		initializers = ConfigFileApplicationContextInitializer.class)
+public class JmsCompatibilityIT extends ITBase {
+	private Connection jmsConnection;
+	private Session jmsSession;
+	private MessageConsumer jmsConsumer;
+	private com.solacesystems.jcsmp.Topic jcsmpTopic;
+	private XMLMessageProducer jcsmpProducer;
+	private final XMLMessageMapper xmlMessageMapper = new XMLMessageMapper();
+
+	private static final Log logger = LogFactory.getLog(JmsCompatibilityIT.class);
+
+	@Before
+	public void setup() throws Exception {
+		String topicName = RandomStringUtils.randomAlphabetic(10);
+
+		SolConnectionFactory solConnectionFactory = SolJmsUtility.createConnectionFactory();
+		solConnectionFactory.setHost((String) jcsmpSession.getProperty(JCSMPProperties.HOST));
+		solConnectionFactory.setVPN((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME));
+		solConnectionFactory.setUsername((String) jcsmpSession.getProperty(JCSMPProperties.USERNAME));
+		solConnectionFactory.setPassword((String) jcsmpSession.getProperty(JCSMPProperties.PASSWORD));
+		jmsConnection = solConnectionFactory.createConnection();
+		jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+		jmsConsumer = jmsSession.createConsumer(jmsSession.createTopic(topicName));
+
+		jcsmpTopic = JCSMPFactory.onlyInstance().createTopic(topicName);
+		jcsmpProducer = jcsmpSession.getMessageProducer(new JCSMPStreamingPublishCorrelatingEventHandler() {
+
+			@Override
+			public void handleError(String s, JCSMPException e, long l) {
+				//never called
+			}
+
+			@Override
+			public void responseReceived(String s) {
+				//never called
+			}
+
+			@Override
+			public void responseReceivedEx(Object key) {
+				logger.debug("Got message with key: " + key);
+			}
+
+			@Override
+			public void handleErrorEx(Object o, JCSMPException e, long l) {
+				logger.error(e);
+			}
+		});
+	}
+
+	@After
+	public void cleanup() throws Exception {
+		if (jmsConnection != null) {
+			jmsConnection.stop();
+		}
+
+		if (jcsmpProducer != null) {
+			jcsmpProducer.close();
+		}
+
+		if (jmsSession != null) {
+			jmsSession.close();
+		}
+
+		if (jmsConnection != null) {
+			jmsConnection.close();
+		}
+	}
+
+	@Test
+	public void testBinderHeaders() throws Exception {
+		MessageBuilder<SerializableFoo> springMessageBuilder = new DefaultMessageBuilderFactory()
+				.withPayload(new SerializableFoo("abc", "def"));
+
+		for (Map.Entry<String, SolaceBinderHeaderMeta<?>> headerMeta : SolaceBinderHeaderMeta.META.entrySet()) {
+			Class<?> type = headerMeta.getValue().getType();
+			Object value;
+			try {
+				if (Number.class.isAssignableFrom(type)) {
+					value = type.getConstructor(String.class).newInstance("" + RandomUtils.nextInt(100));
+				} else if (Boolean.class.isAssignableFrom(type)) {
+					value = true;
+				} else if (String.class.isAssignableFrom(type)) {
+					value = RandomStringUtils.randomAlphanumeric(10);
+				} else {
+					value = type.newInstance();
+				}
+			} catch (Exception e) {
+				throw new Exception(String.format("Failed to generate test value for %s", headerMeta.getKey()), e);
+			}
+
+			springMessageBuilder.setHeader(headerMeta.getKey(), value);
+		}
+
+		XMLMessage jcsmpMessage = xmlMessageMapper.map(springMessageBuilder.build());
+
+		SoftAssertions softly = new SoftAssertions();
+		AtomicReference<Exception> exceptionAtomicReference = new AtomicReference<>();
+		CountDownLatch latch = new CountDownLatch(1);
+		jmsConsumer.setMessageListener(msg -> {
+			try {
+				for (String headerName : SolaceBinderHeaderMeta.META.keySet()) {
+					// Everything should be receivable as a String in JMS
+					softly.assertThat(msg.getStringProperty(headerName))
+							.withFailMessage("Expecting JMS property %s to not be null", headerName)
+							.isNotNull();
+				}
+
+				@SuppressWarnings("unchecked")
+				Enumeration<String> propertyNames = msg.getPropertyNames();
+				while (propertyNames.hasMoreElements()) {
+					String headerName = propertyNames.nextElement();
+					// Everything should be receivable as a String in JMS
+					softly.assertThat(msg.getStringProperty(headerName))
+							.withFailMessage("Expecting JMS property %s to not be null", headerName)
+							.isNotNull();
+				}
+			} catch (JMSException e) {
+				exceptionAtomicReference.set(e);
+				throw new RuntimeException(e);
+			} finally {
+				latch.countDown();
+			}
+		});
+
+		jmsConnection.start();
+		jcsmpProducer.send(jcsmpMessage, jcsmpTopic);
+
+		assertTrue(latch.await(1, TimeUnit.MINUTES));
+		assertNull(exceptionAtomicReference.get());
+		softly.assertAll();
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -886,7 +886,7 @@ public class XMLMessageMapperTest {
 
 	@Test
 	public void testMapMessageHeadersToSDTMap_NonJmsCompatible() throws Exception {
-		byte[] value = "test".getBytes();
+		byte[] value = "test".getBytes(); // byte[] values are not supported by JMS
 		Map<String,Object> headers = new HashMap<>();
 		JMS_INVALID_HEADER_NAMES.forEach(h -> headers.put(h, value));
 
@@ -991,7 +991,7 @@ public class XMLMessageMapperTest {
 
 	@Test
 	public void testMapSDTMapToMessageHeaders_NonJmsCompatible() throws Exception {
-		byte[] value = "test".getBytes();
+		byte[] value = "test".getBytes(); // byte[] values are not supported by JMS
 		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
 		for (String header : JMS_INVALID_HEADER_NAMES) {
 			sdtMap.putBytes(header, value);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -1,5 +1,10 @@
 package com.solace.spring.cloud.stream.binder.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.solace.spring.cloud.stream.binder.messaging.HeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
@@ -40,6 +45,8 @@ import org.springframework.util.SerializationUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,18 +59,27 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class XMLMessageMapperTest {
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+	private final ObjectWriter objectWriter = OBJECT_MAPPER.writer();
+	private final ObjectReader objectReader = OBJECT_MAPPER.reader();
+
 	@Spy
 	private final XMLMessageMapper xmlMessageMapper = new XMLMessageMapper();
 
@@ -131,7 +147,7 @@ public class XMLMessageMapperTest {
 		assertEquals(testSpringMessage.getPayload(),
 				SerializationUtils.deserialize(((BytesMessage) xmlMessage).getData()));
 		assertThat(xmlMessage.getProperties().keySet(),
-				CoreMatchers.hasItem(SolaceBinderHeaders.SERIALIZED_PAYLOAD));
+				hasItem(SolaceBinderHeaders.SERIALIZED_PAYLOAD));
 		assertEquals(true, xmlMessage.getProperties().getBoolean(SolaceBinderHeaders.SERIALIZED_PAYLOAD));
 		validateXMLMessage(xmlMessage, testSpringMessage);
 	}
@@ -323,7 +339,13 @@ public class XMLMessageMapperTest {
 							xmlMessage.getProperties().getInteger(header.getKey()));
 					break;
 				case SolaceBinderHeaders.SERIALIZED_HEADERS:
-					assertThat(xmlMessage.getProperties().get(header.getKey()), instanceOf(SDTStream.class));
+					String serializedHeadersJson = xmlMessage.getProperties().getString(header.getKey());
+					assertThat(serializedHeadersJson, not(emptyString()));
+					assertThat(objectReader.forType(new TypeReference<Set<String>>() {})
+							.readValue(serializedHeadersJson), not(empty()));
+					break;
+				case SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING:
+					assertEquals("base64", xmlMessage.getProperties().getString(header.getKey()));
 					break;
 				case SolaceBinderHeaders.SERIALIZED_PAYLOAD:
 					assertNull(xmlMessage.getProperties().get(header.getKey()));
@@ -360,13 +382,16 @@ public class XMLMessageMapperTest {
 		XMLMessage xmlMessage = xmlMessageMapper.map(testSpringMessage);
 
 		assertEquals(undefinedSolaceHeader1, xmlMessage.getProperties().getString("solace_foo1"));
-		assertEquals(undefinedSolaceHeader2,
-				SerializationUtils.deserialize(xmlMessage.getProperties().getBytes("solace_foo2")));
+		assertEquals(undefinedSolaceHeader2, SerializationUtils.deserialize(Base64.getDecoder()
+				.decode(xmlMessage.getProperties().getString("solace_foo2"))));
 
-		SDTStream serializedHeaders = xmlMessage.getProperties().getStream(SolaceBinderHeaders.SERIALIZED_HEADERS);
-		assertTrue(serializedHeaders.hasRemaining());
-		assertTrue(String.format("Could not find solace_foo2 in %s", SolaceBinderHeaders.SERIALIZED_HEADERS),
-				sdtStreamHasString(serializedHeaders, "solace_foo2"));
+		assertEquals("base64", xmlMessage.getProperties().getString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING));
+		String serializedHeadersJson = xmlMessage.getProperties().getString(SolaceBinderHeaders.SERIALIZED_HEADERS);
+		assertThat(serializedHeadersJson, not(emptyString()));
+		Set<String> serializedHeaders = objectReader.forType(new TypeReference<Set<String>>() {})
+				.readValue(serializedHeadersJson);
+		assertThat(serializedHeaders, not(empty()));
+		assertThat(serializedHeaders, hasItem("solace_foo2"));
 
 		validateXMLMessage(xmlMessage, testSpringMessage);
 	}
@@ -761,7 +786,10 @@ public class XMLMessageMapperTest {
 		for (Map.Entry<String, ? extends HeaderMeta<?>> header : nonReadableHeaders) {
 			switch (header.getKey()) {
 				case SolaceBinderHeaders.SERIALIZED_HEADERS:
-					metadata.putStream(header.getKey(), JCSMPFactory.onlyInstance().createStream());
+					metadata.putString(header.getKey(), objectWriter.writeValueAsString(Collections.emptyList()));
+					break;
+				case SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING:
+					metadata.putString(header.getKey(), "base64");
 					break;
 				case SolaceBinderHeaders.SERIALIZED_PAYLOAD:
 					metadata.putBoolean(header.getKey(), false);
@@ -799,12 +827,11 @@ public class XMLMessageMapperTest {
 		SerializableFoo undefinedSolaceHeader2 = new SerializableFoo("a", "b");
 		TextMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
 		xmlMessage.setText("test");
-		SDTStream serializedHeaders = JCSMPFactory.onlyInstance().createStream();
-		serializedHeaders.writeString("solace_foo2");
+		Set<String> serializedHeaders = Collections.singleton("solace_foo2");
 		SDTMap metadata = JCSMPFactory.onlyInstance().createMap();
 		metadata.putString("solace_foo1", undefinedSolaceHeader1);
 		metadata.putBytes("solace_foo2", SerializationUtils.serialize(undefinedSolaceHeader2));
-		metadata.putStream(SolaceBinderHeaders.SERIALIZED_HEADERS, serializedHeaders);
+		metadata.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 		metadata.putString(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE);
 		xmlMessage.setProperties(metadata);
 
@@ -833,15 +860,28 @@ public class XMLMessageMapperTest {
 
 		SDTMap sdtMap = xmlMessageMapper.map(new MessageHeaders(headers));
 
-		assertThat(sdtMap.keySet(), CoreMatchers.hasItem(key));
-		assertThat(sdtMap.keySet(), CoreMatchers.hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS));
-		assertThat(sdtMap.keySet(), not(CoreMatchers.hasItem(BinderHeaders.TARGET_DESTINATION)));
-		assertEquals(value, SerializationUtils.deserialize(sdtMap.getBytes(key)));
-		SDTStream serializedHeaders = sdtMap.getStream(SolaceBinderHeaders.SERIALIZED_HEADERS);
-		assertTrue(serializedHeaders.hasRemaining());
-		assertEquals(key, serializedHeaders.readString());
-		assertEquals(MessageHeaders.ID, serializedHeaders.readString());
-		assertFalse(serializedHeaders.hasRemaining());
+		assertThat(sdtMap.keySet(), hasItem(key));
+		assertThat(sdtMap.keySet(), hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS));
+		assertThat(sdtMap.keySet(), hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING));
+		assertEquals("base64", sdtMap.getString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING));
+		assertThat(sdtMap.keySet(), not(hasItem(BinderHeaders.TARGET_DESTINATION)));
+		assertEquals(value, SerializationUtils.deserialize(Base64.getDecoder().decode(sdtMap.getString(key))));
+		String serializedHeadersJson = sdtMap.getString(SolaceBinderHeaders.SERIALIZED_HEADERS);
+		assertThat(serializedHeadersJson, not(emptyString()));
+		Set<String> serializedHeaders = objectReader.forType(new TypeReference<Set<String>>() {})
+				.readValue(serializedHeadersJson);
+		assertThat(serializedHeaders, hasSize(2));
+		assertThat(serializedHeaders, hasItem(key));
+		assertThat(serializedHeaders, hasItem(MessageHeaders.ID));
+	}
+
+	@Test
+	public void testMapMessageHeadersToSDTMap_Null() throws Exception {
+		String key = "a";
+		Map<String,Object> headers = Collections.singletonMap(key, null);
+		SDTMap sdtMap = xmlMessageMapper.map(new MessageHeaders(headers));
+		assertThat(sdtMap.keySet(), hasItem(key));
+		assertNull(sdtMap.get(key));
 	}
 
 	@Test
@@ -853,7 +893,7 @@ public class XMLMessageMapperTest {
 		SDTMap sdtMap = xmlMessageMapper.map(new MessageHeaders(headers));
 
 		for (String header : JMS_INVALID_HEADER_NAMES) {
-			assertThat(sdtMap.keySet(), CoreMatchers.hasItem(header));
+			assertThat(sdtMap.keySet(), hasItem(header));
 			assertEquals(value, sdtMap.getBytes(header));
 		}
 	}
@@ -864,17 +904,89 @@ public class XMLMessageMapperTest {
 		SerializableFoo value = new SerializableFoo("abc123", "HOOPLA!");
 		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
 		sdtMap.putObject(key, SerializationUtils.serialize(value));
-		SDTStream serializedHeaders = JCSMPFactory.onlyInstance().createStream();
-		serializedHeaders.writeString(key);
-		sdtMap.putStream(SolaceBinderHeaders.SERIALIZED_HEADERS, serializedHeaders);
+		List<String> serializedHeaders = Arrays.asList(key, key);
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 
 		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
 
-		assertThat(messageHeaders.keySet(), CoreMatchers.hasItem(key));
-		assertThat(messageHeaders.keySet(),
-				not(CoreMatchers.hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
+		assertThat(messageHeaders.keySet(), hasItem(key));
+		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
 		assertEquals(value, messageHeaders.get(key));
 		assertNull(messageHeaders.get(SolaceBinderHeaders.SERIALIZED_HEADERS));
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_Null() throws Exception {
+		String key = "a";
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		sdtMap.putObject(key, null);
+
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+
+		assertThat(messageHeaders.keySet(), hasItem(key));
+		assertNull(messageHeaders.get(key));
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_EncodedSerializable() throws Exception {
+		String key = "a";
+		SerializableFoo value = new SerializableFoo("abc123", "HOOPLA!");
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		sdtMap.putString(key, Base64.getEncoder().encodeToString(SerializationUtils.serialize(value)));
+		Set<String> serializedHeaders = Collections.singleton(key);
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "base64");
+
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+
+		assertThat(messageHeaders.keySet(), hasItem(key));
+		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
+		assertEquals(value, messageHeaders.get(key));
+		assertNull(messageHeaders.get(SolaceBinderHeaders.SERIALIZED_HEADERS));
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_ExtraSerializableHeader() throws Exception {
+		String key = "a";
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		Set<String> serializedHeaders = Collections.singleton(key);
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
+
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+
+		assertThat(messageHeaders.keySet(), not(hasItem(key)));
+		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_NullSerializableHeader() throws Exception {
+		String key = "a";
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		sdtMap.putObject(key, null);
+		Set<String> serializedHeaders = Collections.singleton(key);
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "base64");
+
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+
+		assertThat(messageHeaders.keySet(), hasItem(key));
+		assertNull(messageHeaders.get(key));
+		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
+	}
+
+	@Test
+	public void testFailMapSDTMapToMessageHeaders_InvalidEncoding() throws Exception {
+		String key = "a";
+		SerializableFoo value = new SerializableFoo("abc123", "HOOPLA!");
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		sdtMap.putString(key, Base64.getEncoder().encodeToString(SerializationUtils.serialize(value)));
+		Set<String> serializedHeaders = Collections.singleton(key);
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
+		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "abc");
+
+		SolaceMessageConversionException exception = assertThrows(SolaceMessageConversionException.class,
+				() -> xmlMessageMapper.map(sdtMap));
+		assertThat(exception.getMessage(), containsString("encoding is not supported"));
 	}
 
 	@Test
@@ -888,7 +1000,7 @@ public class XMLMessageMapperTest {
 		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
 
 		for (String header : JMS_INVALID_HEADER_NAMES) {
-			assertThat(messageHeaders.keySet(), CoreMatchers.hasItem(header));
+			assertThat(messageHeaders.keySet(), hasItem(header));
 			assertEquals(value, messageHeaders.get(header, byte[].class));
 		}
 	}
@@ -923,8 +1035,6 @@ public class XMLMessageMapperTest {
 			AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(JCSMPAcknowledgementCallbackFactory.JCSMPAcknowledgementCallback.class);
 			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
 			validateSpringMessage(springMessage, expectedXmlMessage);
-			assertTrue("Stream should be rewinded after being processed by the mapper",
-					xmlMessage.getProperties().getStream(SolaceBinderHeaders.SERIALIZED_HEADERS).hasRemaining());
 
 			// Update the expected default spring headers
 			springHeaders.put(MessageHeaders.ID, springMessage.getHeaders().getId());
@@ -953,20 +1063,22 @@ public class XMLMessageMapperTest {
 		Set<String> serializedHeaders = new HashSet<>();
 
 		if (metadata.containsKey(SolaceBinderHeaders.SERIALIZED_HEADERS)) {
-			SDTStream serializedHeaderStream = metadata.getStream(SolaceBinderHeaders.SERIALIZED_HEADERS);
-			assertTrue(serializedHeaderStream.hasRemaining());
-			while (serializedHeaderStream.hasRemaining()) {
-				String serializedHeader = serializedHeaderStream.readString();
+			XMLMessageMapper.Encoder encoder = XMLMessageMapper.Encoder
+					.getByName(metadata.getString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING));
+			Set<String> serializedHeadersSet = objectReader.forType(new TypeReference<Set<String>>(){})
+					.readValue(metadata.getString(SolaceBinderHeaders.SERIALIZED_HEADERS));
+			assertThat(serializedHeadersSet, not(empty()));
+			for (String serializedHeader : serializedHeadersSet) {
 				serializedHeaders.add(serializedHeader);
-				assertThat(metadata.keySet(), CoreMatchers.hasItem(serializedHeader));
+				assertThat(metadata.keySet(), hasItem(serializedHeader));
+				Object headerValue = SerializationUtils.deserialize(encoder != null ?
+						encoder.decode(metadata.getString(serializedHeader)) : metadata.getBytes(serializedHeader));
 				if (expectedHeaders.containsKey(serializedHeader)) {
-					assertEquals(expectedHeaders.get(serializedHeader),
-							SerializationUtils.deserialize(metadata.getBytes(serializedHeader)));
+					assertEquals(expectedHeaders.get(serializedHeader), headerValue);
 				} else {
-					assertNotNull(SerializationUtils.deserialize(metadata.getBytes(serializedHeader)));
+					assertNotNull(headerValue);
 				}
 			}
-			serializedHeaderStream.rewind();
 		}
 
 		Map<String, SolaceHeaderMeta<?>> readWriteableSolaceHeaders = SolaceHeaderMeta.META
@@ -981,17 +1093,19 @@ public class XMLMessageMapperTest {
 				Object value = readWriteableSolaceHeaders.get(header.getKey()).getReadAction().apply(xmlMessage);
 				assertEquals(header.getValue(), value);
 			} else if (!serializedHeaders.contains(header.getKey())) {
-				assertThat(metadata.keySet(), CoreMatchers.hasItem(header.getKey()));
+				assertThat(metadata.keySet(), hasItem(header.getKey()));
 				assertEquals(header.getValue(), metadata.get(header.getKey()));
 			}
 		}
 	}
 
-	private void validateSpringMessage(Message<?> message, XMLMessage xmlMessage) throws SDTException {
+	private void validateSpringMessage(Message<?> message, XMLMessage xmlMessage)
+			throws SDTException, JsonProcessingException {
 		validateSpringMessage(message, xmlMessage, xmlMessage.getProperties());
 	}
 
-	private void validateSpringMessage(Message<?> message, XMLMessage xmlMessage, SDTMap expectedHeaders) throws SDTException {
+	private void validateSpringMessage(Message<?> message, XMLMessage xmlMessage, SDTMap expectedHeaders)
+			throws SDTException, JsonProcessingException {
 		MessageHeaders messageHeaders = message.getHeaders();
 
 		List<String> nonReadableBinderHeaderMeta = SolaceBinderHeaderMeta.META
@@ -1002,21 +1116,23 @@ public class XMLMessageMapperTest {
 				.collect(Collectors.toList());
 
 		for (String customHeaderName : nonReadableBinderHeaderMeta) {
-			assertThat(messageHeaders.keySet(), not(CoreMatchers.hasItem(customHeaderName)));
+			assertThat(messageHeaders.keySet(), not(hasItem(customHeaderName)));
 		}
 
 		Set<String> serializedHeaders = new HashSet<>();
 		if (expectedHeaders.containsKey(SolaceBinderHeaders.SERIALIZED_HEADERS)) {
-			SDTStream serializedHeaderStream = expectedHeaders.getStream(SolaceBinderHeaders.SERIALIZED_HEADERS);
-			while (serializedHeaderStream.hasRemaining()) {
-				String serializedHeader = serializedHeaderStream.readString();
+			String serializedHeaderJson = expectedHeaders.getString(SolaceBinderHeaders.SERIALIZED_HEADERS);
+			assertThat(serializedHeaderJson, not(emptyString()));
+			Set<String> serializedHeaderSet = objectReader.forType(new TypeReference<Set<String>>() {})
+					.readValue(serializedHeaderJson);
+			assertThat(serializedHeaderSet, not(empty()));
+			for (String serializedHeader : serializedHeaderSet) {
 				serializedHeaders.add(serializedHeader);
-				assertThat(expectedHeaders.keySet(), CoreMatchers.hasItem(serializedHeader));
-				assertThat(messageHeaders.keySet(), CoreMatchers.hasItem(serializedHeader));
+				assertThat(expectedHeaders.keySet(), hasItem(serializedHeader));
+				assertThat(messageHeaders.keySet(), hasItem(serializedHeader));
 				assertEquals(SerializationUtils.deserialize(expectedHeaders.getBytes(serializedHeader)),
 						messageHeaders.get(serializedHeader));
 			}
-			serializedHeaderStream.rewind();
 		}
 
 		for (String headerName : expectedHeaders.keySet()) {
@@ -1039,19 +1155,5 @@ public class XMLMessageMapperTest {
 		if (!expectedHeaders.containsKey(MessageHeaders.CONTENT_TYPE)) {
 			assertEquals(xmlMessage.getHTTPContentType(), contentType.toString());
 		}
-	}
-
-	private boolean sdtStreamHasString(SDTStream stream, String headerName) throws Exception {
-		assertTrue(stream.hasRemaining());
-		boolean found = false;
-		while (stream.hasRemaining()) {
-			Object value = stream.read();
-			if (value instanceof String && value.equals(headerName)) {
-				found = true;
-				break;
-			}
-		}
-		stream.rewind();
-		return found;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -93,9 +93,9 @@ public class XMLMessageMapperTest {
 			"TRUE", "FALSE", "NOT", "AND", "OR", "BETWEEN", "LIKE", "IN", "IS", "ESCAPE", "JMSX_abc", "JMS_abc"));
 
 	static {
-		assertTrue(JMS_INVALID_HEADER_NAMES.stream().anyMatch(h -> Character.isJavaIdentifierStart(h.charAt(0))));
+		assertTrue(JMS_INVALID_HEADER_NAMES.stream().anyMatch(h -> !Character.isJavaIdentifierStart(h.charAt(0))));
 		assertTrue(JMS_INVALID_HEADER_NAMES.stream().map(CharSequence::chars)
-				.anyMatch(c -> c.skip(1).anyMatch(Character::isJavaIdentifierPart)));
+				.anyMatch(c -> c.skip(1).anyMatch(c1 -> !Character.isJavaIdentifierPart(c1))));
 		assertTrue(JMS_INVALID_HEADER_NAMES.stream().anyMatch(h -> h.startsWith("JMSX")));
 		assertTrue(JMS_INVALID_HEADER_NAMES.stream().anyMatch(h -> h.startsWith("JMS_")));
 	}


### PR DESCRIPTION
* base64 encode all serialized headers before sending them to the broker (vice versa on consumption)
* add `solace_scst_serializedHeadersEncoding` header to contain the encoding algorithm
* change `solace_scst_serializedHeaders` from a `SDTStream` to a JSON String array
* Add JMS-compatibility tests
* Upgrade `sol-jcsmp` and `sol-jms` to `10.10.0`