### PR TITLE
pause and resume for inbound binders

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -677,6 +677,38 @@ Error Queues should not be used with anonymous consumer groups.
 Since the names of anonymous consumer groups, and in turn the name of their would-be Error Queues, are randomly generated at runtime, it would provide little value to create bindings to these Error Queues because of their unpredictable naming and temporary existence. Also, your environment will be polluted with orphaned Error Queues whenever these consumers rebind.
 ====
 
+=== Pause and resume
+
+If you use annotated binder or polled message receiver, the consumption of messages can be paused and resumed. The predefined spring @Pausable interface is implemented, and thus the following both method can be used on binder:
+[source.java]
+----
+import org.springframework.cloud.stream.binder.Binding
+Binding::pause()
+Binding::resume()
+----
+For the example for a pollable consumer, for a complete example see SolaceBinderBasicIT -> testPolledConsumerPauseAndResume
+[source,java]
+----
+    private final Binding<PollableSource<MessageHandler>> consumerBinding;
+
+    public void pollConsumerWorker() throws Exception {
+        while(run) { // <1>
+            gotMessage = moduleInputChannel.poll(message1 -> process(message1))
+        }
+    }
+
+    public void pause() throws Exception {
+        consumerBinding.pause(); // <2>
+    }
+
+    public void resume() throws Exception {
+        consumerBinding.resume(); // <3>
+    }
+----
+<1> Polling worker thread, note: thread safety is not shown in favor of simplicity.
+<2> pause the binder like this, could be done anywhere.
+<3> resume dito as pause, to let the worker fetch new messages again.
+
 == Resources
 
 For more information about Spring Cloud Streams try these resources:

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
@@ -19,6 +19,7 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.acks.AckUtils;
 import org.springframework.integration.acks.AcknowledgmentCallback;
+import org.springframework.integration.core.Pausable;
 import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.messaging.MessagingException;
 
@@ -30,7 +31,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class JCSMPMessageSource extends AbstractMessageSource<Object> implements Lifecycle {
+public class JCSMPMessageSource extends AbstractMessageSource<Object> implements Lifecycle, Pausable {
 	private final String id = UUID.randomUUID().toString();
 	private final String queueName;
 	private final JCSMPSession jcsmpSession;
@@ -184,5 +185,15 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 
 	public void setRemoteStopFlag(Supplier<Boolean> remoteStopFlag) {
 		this.remoteStopFlag = remoteStopFlag;
+	}
+
+	@Override
+	public void pause() {
+		this.flowReceiverContainer.pause();
+	}
+
+	@Override
+	public void resume() {
+		this.flowReceiverContainer.resume();
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainer.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainer.java
@@ -13,6 +13,7 @@ import com.solacesystems.jcsmp.JCSMPTransportException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.lang.Nullable;
+import org.springframework.messaging.MessagingException;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -320,6 +321,28 @@ public class FlowReceiverContainer {
 
 	public String getQueueName() {
 		return queueName;
+	}
+
+	public void pause() {
+		FlowReceiverReference flowReceiverReference = flowReceiverAtomicReference.get();
+		if(flowReceiverReference != null) {
+			flowReceiverReference.get().stop();
+		} else {
+			logger.warn("Binder was not started, pause has no effect.");
+		}
+	}
+
+	public void resume() {
+		FlowReceiverReference flowReceiverReference = flowReceiverAtomicReference.get();
+		if(flowReceiverReference != null) {
+			try {
+				flowReceiverReference.get().start();
+			} catch (JCSMPException e) {
+				throw new MessagingException("Could not resume", e);
+			}
+		} else {
+			throw new MessagingException("Receiver is not started, cannot resume");
+		}
 	}
 
 	static class FlowReceiverReference {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderITBase.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderITBase.java
@@ -60,13 +60,13 @@ public abstract class SolaceBinderITBase
 	@Autowired
 	private SpringJCSMPFactory springJCSMPFactory;
 
-	@Value("${test.solace.mgmt.host:#{null}}")
+	@Value("${test.solace.mgmt.host:localhost}")
 	private String solaceMgmtHost;
 
-	@Value("${test.solace.mgmt.username:#{null}}")
+	@Value("${test.solace.mgmt.username:admin}")
 	private String solaceMgmtUsername;
 
-	@Value("${test.solace.mgmt.password:#{null}}")
+	@Value("${test.solace.mgmt.password:admin}")
 	private String solaceMgmtPassword;
 
 	JCSMPSession jcsmpSession;


### PR DESCRIPTION
If multiple services want to pause their receiving repetitive, calculate something heavy, and resume all at once again, they don't want to create and stop a new connection. Therefore pause and resume is required at least on the inbound side. The part within InboundXMLMessageListener is tested and works.

Unit tests will be provided later, im still on that.

Can somebody provide an example how a user would actually use the "pollable binder" feature within class "JCSMPMessageSource"?
With that we could test the code in JCSMPMessageSource as well, but actually i see only the way with unit-tests.