### PR TITLE
Refactor solace_raw_message header to solace_scst_rawMessage

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -476,6 +476,12 @@ TIP: Use link:../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream
 | 1
 | A static number set by the publisher to indicate the Spring Cloud Stream Solace message version.
 
+| solace_scst_rawMessage
+| XMLMessage
+| Read
+|
+| The raw Solace message.
+
 | solace_scst_serializedPayload
 | Boolean
 | Internal Binder Use Only

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -482,6 +482,8 @@ TIP: Use link:../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream
 |
 | The raw Solace message.
 
+*[.underline]#WARNING#:* *DO NOT* acknowledge this or make any other lasting changes. This should only be used for debugging.
+
 | solace_scst_serializedPayload
 | Boolean
 | Internal Binder Use Only

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -136,7 +136,7 @@ abstract class InboundXMLMessageListener implements Runnable {
 		if (needAttributes) {
 			AttributeAccessor attributes = attributesHolder.get();
 			if (attributes != null) {
-				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.INPUT_MESSAGE, message);
+				attributes.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, message);
 				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE, xmlMessage);
 			}
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/HeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/HeaderMeta.java
@@ -4,4 +4,9 @@ public interface HeaderMeta<T> {
 	Class<T> getType();
 	boolean isReadable();
 	boolean isWritable();
+	Scope getScope();
+
+	enum Scope {
+		LOCAL, WIRE
+	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
@@ -1,6 +1,6 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
-import com.solacesystems.jcsmp.SDTStream;
+import com.solacesystems.jcsmp.XMLMessage;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -8,20 +8,23 @@ import java.util.stream.Stream;
 
 public class SolaceBinderHeaderMeta<T> implements HeaderMeta<T> {
 	public static final Map<String, SolaceBinderHeaderMeta<?>> META = Stream.of(new Object[][] {
-			{SolaceBinderHeaders.MESSAGE_VERSION, new SolaceBinderHeaderMeta<>(Integer.class, true, false)},
-			{SolaceBinderHeaders.SERIALIZED_PAYLOAD, new SolaceBinderHeaderMeta<>(Boolean.class, false, false)},
-			{SolaceBinderHeaders.SERIALIZED_HEADERS, new SolaceBinderHeaderMeta<>(String.class, false, false)},
-			{SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, new SolaceBinderHeaderMeta<>(String.class, false, false)}
+			{SolaceBinderHeaders.MESSAGE_VERSION, new SolaceBinderHeaderMeta<>(Integer.class, true, false, Scope.WIRE)},
+			{SolaceBinderHeaders.RAW_MESSAGE, new SolaceBinderHeaderMeta<>(XMLMessage.class, true, false, Scope.LOCAL)},
+			{SolaceBinderHeaders.SERIALIZED_PAYLOAD, new SolaceBinderHeaderMeta<>(Boolean.class, false, false, Scope.WIRE)},
+			{SolaceBinderHeaders.SERIALIZED_HEADERS, new SolaceBinderHeaderMeta<>(String.class, false, false, Scope.WIRE)},
+			{SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, new SolaceBinderHeaderMeta<>(String.class, false, false, Scope.WIRE)}
 	}).collect(Collectors.toMap(d -> (String) d[0], d -> (SolaceBinderHeaderMeta<?>) d[1]));
 
 	private final Class<T> type;
 	private final boolean readable;
 	private final boolean writable;
+	private final Scope scope;
 
-	public SolaceBinderHeaderMeta(Class<T> type, boolean readable, boolean writable) {
+	public SolaceBinderHeaderMeta(Class<T> type, boolean readable, boolean writable, Scope scope) {
 		this.type = type;
 		this.readable = readable;
 		this.writable = writable;
+		this.scope = scope;
 	}
 
 	@Override
@@ -37,5 +40,10 @@ public class SolaceBinderHeaderMeta<T> implements HeaderMeta<T> {
 	@Override
 	public boolean isWritable() {
 		return writable;
+	}
+
+	@Override
+	public Scope getScope() {
+		return scope;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
@@ -37,6 +37,8 @@ public final class SolaceBinderHeaders {
 	 * <p><b>Access:</b> Read</p>
 	 * <br>
 	 * <p>The raw Solace message.</p>
+	 * <p><b><u>WARNING</u>:</b> <b>DO NOT</b> acknowledge this or make any other lasting changes.
+	 * This should only be used for debugging.</p>
 	 */
 	public static final String RAW_MESSAGE = PREFIX + "rawMessage";
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
@@ -1,5 +1,6 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
+import com.solacesystems.jcsmp.XMLMessage;
 import org.springframework.messaging.Message;
 
 /**
@@ -30,6 +31,14 @@ public final class SolaceBinderHeaders {
 	 * <p>A static number set by the publisher to indicate the Spring Cloud Stream Solace message version.</p>
 	 */
 	public static final String MESSAGE_VERSION = PREFIX + "messageVersion";
+
+	/**
+	 * <p><b>Acceptable Value Type:</b> {@link XMLMessage}</p>
+	 * <p><b>Access:</b> Read</p>
+	 * <br>
+	 * <p>The raw Solace message.</p>
+	 */
+	public static final String RAW_MESSAGE = PREFIX + "rawMessage";
 
 	/**
 	 * <p><b>Acceptable Value Type:</b> {@link Boolean}</p>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
@@ -55,6 +55,11 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 		return writeAction != null;
 	}
 
+	@Override
+	public Scope getScope() {
+		return Scope.WIRE;
+	}
+
 	public Function<XMLMessage, T> getReadAction() {
 		return readAction;
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
@@ -1,5 +1,6 @@
 package com.solace.spring.cloud.stream.binder.util;
 
+import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.messaging.Message;
@@ -11,12 +12,20 @@ import java.util.Map;
 
 public class SolaceMessageHeaderErrorMessageStrategy implements ErrorMessageStrategy {
 	public static final String INPUT_MESSAGE = "inputMessage";
-	public static final String SOLACE_RAW_MESSAGE = "solace_raw_message";
+	public static final String SOLACE_RAW_MESSAGE = SolaceBinderHeaders.RAW_MESSAGE;
 
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor attributeAccessor) {
-		Object inputMessage = attributeAccessor == null ? null : attributeAccessor.getAttribute(INPUT_MESSAGE);
-		Map<String, Object> headers = attributeAccessor == null ? new HashMap() : Collections.singletonMap(SOLACE_RAW_MESSAGE, attributeAccessor.getAttribute(SOLACE_RAW_MESSAGE));
-		return new ErrorMessage(throwable, headers, inputMessage instanceof Message ? (Message)inputMessage : null);
+		Object inputMessage;
+		Map<String, Object> headers;
+		if (attributeAccessor == null) {
+			inputMessage = null;
+			headers = new HashMap<>();
+		} else {
+			inputMessage = attributeAccessor.getAttribute(INPUT_MESSAGE);
+			headers = Collections.singletonMap(SolaceBinderHeaders.RAW_MESSAGE,
+					attributeAccessor.getAttribute(SOLACE_RAW_MESSAGE));
+		}
+		return new ErrorMessage(throwable, headers, inputMessage instanceof Message ? (Message<?>) inputMessage : null);
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
@@ -3,6 +3,7 @@ package com.solace.spring.cloud.stream.binder.util;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.support.ErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
 
@@ -11,7 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SolaceMessageHeaderErrorMessageStrategy implements ErrorMessageStrategy {
-	public static final String INPUT_MESSAGE = "inputMessage";
 	public static final String SOLACE_RAW_MESSAGE = SolaceBinderHeaders.RAW_MESSAGE;
 
 	@Override
@@ -22,10 +22,11 @@ public class SolaceMessageHeaderErrorMessageStrategy implements ErrorMessageStra
 			inputMessage = null;
 			headers = new HashMap<>();
 		} else {
-			inputMessage = attributeAccessor.getAttribute(INPUT_MESSAGE);
+			inputMessage = attributeAccessor.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
 			headers = Collections.singletonMap(SolaceBinderHeaders.RAW_MESSAGE,
 					attributeAccessor.getAttribute(SOLACE_RAW_MESSAGE));
 		}
-		return new ErrorMessage(throwable, headers, inputMessage instanceof Message ? (Message<?>) inputMessage : null);
+		return inputMessage instanceof Message ? new ErrorMessage(throwable, headers, (Message<?>) inputMessage) :
+				new ErrorMessage(throwable, headers);
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -203,7 +203,7 @@ public class XMLMessageMapper {
 		}
 
 		if (setRawMessageHeader) {
-			builder.setHeader(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE, xmlMessage);
+			builder.setHeader(SolaceBinderHeaders.RAW_MESSAGE, xmlMessage);
 		}
 
 		return builder.build();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
@@ -256,7 +256,8 @@ public class SolaceHeadersTest {
 			assertThat(headerName, not(startsWithIgnoringCase("JMSX")));
 			assertThat(headerName, not(startsWithIgnoringCase("JMS_")));
 
-			if (!(headersClass.equals(SolaceHeaders.class))) {
+			if (!headersClass.equals(SolaceHeaders.class)
+					&& HeaderMeta.Scope.WIRE.equals(headersMeta.get(headerName).getScope())) {
 				assertThat(headersMeta.get(headerName).getType(),
 						anyOf(equalToObject(boolean.class), equalToObject(Boolean.class),
 								equalToObject(byte.class), equalToObject(Byte.class),

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
 import com.solace.spring.cloud.stream.binder.ITBase;
+import com.solace.spring.cloud.stream.binder.messaging.HeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solacesystems.jcsmp.BytesMessage;
@@ -145,6 +146,7 @@ public class JmsCompatibilityIT extends ITBase {
 				.withPayload(new SerializableFoo("abc", "def"));
 
 		for (Map.Entry<String, SolaceBinderHeaderMeta<?>> headerMeta : SolaceBinderHeaderMeta.META.entrySet()) {
+			if (!HeaderMeta.Scope.WIRE.equals(headerMeta.getValue().getScope())) continue;
 			Class<?> type = headerMeta.getValue().getType();
 			Object value;
 			try {
@@ -172,7 +174,9 @@ public class JmsCompatibilityIT extends ITBase {
 		jmsConsumer.setMessageListener(msg -> {
 			logger.info("Got message " + msg);
 			try {
-				for (String headerName : SolaceBinderHeaderMeta.META.keySet()) {
+				for (Map.Entry<String, SolaceBinderHeaderMeta<?>> headerMeta : SolaceBinderHeaderMeta.META.entrySet()) {
+					if (!HeaderMeta.Scope.WIRE.equals(headerMeta.getValue().getScope())) continue;
+					String headerName = headerMeta.getKey();
 					// Everything should be receivable as a String in JMS
 					softly.assertThat(msg.getStringProperty(headerName))
 							.withFailMessage("Expecting JMS property %s to not be null", headerName)

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -2,6 +2,7 @@ package com.solace.spring.cloud.stream.binder;
 
 import com.solace.spring.cloud.stream.binder.inbound.JCSMPInboundChannelAdapter;
 import com.solace.spring.cloud.stream.binder.inbound.JCSMPMessageSource;
+import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.outbound.JCSMPOutboundMessageHandler;
 import com.solace.spring.cloud.stream.binder.util.ErrorQueueInfrastructure;
 import com.solace.spring.cloud.stream.binder.util.JCSMPSessionProducerManager;
@@ -136,9 +137,11 @@ public class SolaceMessageChannelBinder
 	@Override
 	protected void postProcessPollableSource(DefaultPollableMessageSource bindingTarget) {
 		bindingTarget.setAttributesProvider((accessor, message) -> {
-			Object rawMessage = message.getHeaders().get(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE);
-			if (rawMessage != null) {
-				accessor.setAttribute(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE, rawMessage);
+			if (message.getHeaders().containsKey(SolaceBinderHeaders.RAW_MESSAGE)) {
+				Object rawMessage = message.getHeaders().get(SolaceBinderHeaders.RAW_MESSAGE);
+				if (rawMessage != null) {
+					accessor.setAttribute(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE, rawMessage);
+				}
 			}
 		});
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder;
 
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
 import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredRunner;
@@ -243,6 +244,6 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		softAssertions.assertThat(((ErrorMessage) errorMessage).getOriginalMessage()).isNotNull();
 		softAssertions.assertThat(((ErrorMessage) errorMessage).getPayload()).isNotNull();
 		softAssertions.assertThat(errorMessage.getHeaders()
-				.get(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE)).isInstanceOf(XMLMessage.class);
+				.get(SolaceBinderHeaders.RAW_MESSAGE)).isInstanceOf(XMLMessage.class);
 	}
 }


### PR DESCRIPTION
* Renamed `solace_raw_message` to `solace_scst_rawMessage` (#54)
* Fix `SolaceErrorMessageHandler` so that it doesn't depend on having the raw Solace message
  * This shouldn't ever happen, but also no reason to keep that dependency