### PR TITLE
Set DMQ Eligibility to true by default & add errorMsgDmqEligibility consumer config option

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -262,6 +262,11 @@ Whether the error queue respects Message TTL.
 +
 Default: `null`
 
+errorMsgDmqEligible::
+The eligibility for republished messages to be moved to a Dead Message Queue.
++
+Default: `null`
+
 errorMsgTtl::
 The number of milliseconds before republished messages are discarded or moved to a Dead Message Queue.
 +

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
@@ -16,7 +16,7 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 			{SolaceHeaders.CORRELATION_ID, new SolaceHeaderMeta<>(String.class, XMLMessage::getCorrelationId, XMLMessage::setCorrelationId)},
 			{SolaceHeaders.DESTINATION, new SolaceHeaderMeta<>(Destination.class, XMLMessage::getDestination, null)},
 			{SolaceHeaders.DISCARD_INDICATION, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::getDiscardIndication, null)},
-			{SolaceHeaders.DMQ_ELIGIBLE, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::isDMQEligible, XMLMessage::setDMQEligible)},
+			{SolaceHeaders.DMQ_ELIGIBLE, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::isDMQEligible, XMLMessage::setDMQEligible, true)},
 			{SolaceHeaders.EXPIRATION, new SolaceHeaderMeta<>(Long.class, XMLMessage::getExpiration, XMLMessage::setExpiration)},
 			{SolaceHeaders.HTTP_CONTENT_ENCODING, new SolaceHeaderMeta<>(String.class, XMLMessage::getHTTPContentEncoding, XMLMessage::setHTTPContentEncoding)},
 			{SolaceHeaders.PRIORITY, new SolaceHeaderMeta<>(Integer.class, XMLMessage::getPriority, XMLMessage::setPriority)},
@@ -33,11 +33,24 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 	private final Class<T> type;
 	private final Function<XMLMessage, T> readAction;
 	private final BiConsumer<XMLMessage, T> writeAction;
+	private final T defaultValueOverride;
+	private final boolean hasDefaultValueOverride;
+
+	private SolaceHeaderMeta(Class<T> type, Function<XMLMessage, T> readAction, BiConsumer<XMLMessage, T> writeAction,
+							 T defaultValueOverride) {
+		this.type = type;
+		this.readAction = readAction;
+		this.writeAction = writeAction;
+		this.defaultValueOverride = defaultValueOverride;
+		this.hasDefaultValueOverride = true;
+	}
 
 	private SolaceHeaderMeta(Class<T> type, Function<XMLMessage, T> readAction, BiConsumer<XMLMessage, T> writeAction) {
 		this.type = type;
 		this.readAction = readAction;
 		this.writeAction = writeAction;
+		this.defaultValueOverride = null;
+		this.hasDefaultValueOverride = false;
 	}
 
 	@Override
@@ -74,5 +87,18 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 						value.getClass()));
 			}
 		};
+	}
+
+	/**
+	 * Get the overridden default value. Overridden default values may be {@code null}.
+	 * Check {@link #hasOverriddenDefaultValue()} to be sure.
+	 * @return new default value or null if does not exist
+	 */
+	public T getDefaultValueOverride() {
+		return hasDefaultValueOverride ? defaultValueOverride : null;
+	}
+
+	public boolean hasOverriddenDefaultValue() {
+		return hasDefaultValueOverride;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -20,6 +20,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	private Integer errorQueueQuota = null;
 	private Boolean errorQueueRespectsMsgTtl = null;
 
+	private Boolean errorMsgDmqEligible = null;
 	private Long errorMsgTtl = null;
 	// ------------------------
 
@@ -117,6 +118,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setErrorQueueRespectsMsgTtl(Boolean errorQueueRespectsMsgTtl) {
 		this.errorQueueRespectsMsgTtl = errorQueueRespectsMsgTtl;
+	}
+
+	public Boolean getErrorMsgDmqEligible() {
+		return errorMsgDmqEligible;
+	}
+
+	public void setErrorMsgDmqEligible(Boolean errorMsgDmqEligible) {
+		this.errorMsgDmqEligible = errorMsgDmqEligible;
 	}
 
 	public Long getErrorMsgTtl() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -56,6 +56,9 @@ public class XMLMessageMapper {
 
 	public XMLMessage mapError(Message<?> message, SolaceConsumerProperties consumerProperties) {
 		XMLMessage xmlMessage = map(message);
+		if (consumerProperties.getErrorMsgDmqEligible() != null) {
+			xmlMessage.setDMQEligible(consumerProperties.getErrorMsgDmqEligible());
+		}
 		if (consumerProperties.getErrorMsgTtl() != null) {
 			xmlMessage.setTimeToLive(consumerProperties.getErrorMsgTtl());
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -126,16 +126,20 @@ public class XMLMessageMapper {
 					logger.warn(msg, exception);
 					throw exception;
 				}
+			} else if (header.getValue().hasOverriddenDefaultValue()) {
+					value = header.getValue().getDefaultValueOverride();
+			} else {
+				continue;
+			}
 
-				try {
-					header.getValue().getWriteAction().accept(xmlMessage, value);
-				} catch (Exception e) {
-					String msg = String.format("Could not set %s property from header %s of message %s",
-							XMLMessage.class.getSimpleName(), header.getKey(), message.getHeaders().getId());
-					SolaceMessageConversionException exception = new SolaceMessageConversionException(msg, e);
-					logger.warn(msg, exception);
-					throw exception;
-				}
+			try {
+				header.getValue().getWriteAction().accept(xmlMessage, value);
+			} catch (Exception e) {
+				String msg = String.format("Could not set %s property from header %s of message %s",
+						XMLMessage.class.getSimpleName(), header.getKey(), message.getHeaders().getId());
+				SolaceMessageConversionException exception = new SolaceMessageConversionException(msg, e);
+				logger.warn(msg, exception);
+				throw exception;
 			}
 		}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -200,7 +200,6 @@ public class XMLMessageMapperTest {
 				.withPayload("")
 				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE);
 
-		XMLMessage defaultXmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
 		Set<Map.Entry<String, ? extends HeaderMeta<?>>> writeableHeaders = Stream.of(
 					SolaceHeaderMeta.META.entrySet().stream(),
 					SolaceBinderHeaderMeta.META.entrySet().stream())
@@ -220,7 +219,7 @@ public class XMLMessageMapperTest {
 					value = RandomStringUtils.randomAlphanumeric(10);
 					break;
 				case SolaceHeaders.DMQ_ELIGIBLE:
-					value = !defaultXmlMessage.isDMQEligible();
+					value = !(Boolean) ((SolaceHeaderMeta<?>) header.getValue()).getDefaultValueOverride();
 					break;
 				case SolaceHeaders.EXPIRATION:
 				case SolaceHeaders.SENDER_TIMESTAMP:
@@ -393,6 +392,35 @@ public class XMLMessageMapperTest {
 				.readValue(serializedHeadersJson);
 		assertThat(serializedHeaders, not(empty()));
 		assertThat(serializedHeaders, hasItem("solace_foo2"));
+
+		validateXMLMessage(xmlMessage, testSpringMessage);
+	}
+
+	@Test
+	public void testMapSpringMessageToXMLMessage_OverrideDefaultSolaceProperties() throws Exception {
+		Set<Map.Entry<String, ? extends SolaceHeaderMeta<?>>> overriddenWriteableHeaders = SolaceHeaderMeta.META
+				.entrySet()
+				.stream()
+				.filter(h -> h.getValue().isWritable())
+				.filter(h -> h.getValue().hasOverriddenDefaultValue())
+				.collect(Collectors.toSet());
+		assertNotEquals("Test header set was empty", 0, overriddenWriteableHeaders.size());
+
+		Message<?> testSpringMessage = new DefaultMessageBuilderFactory()
+				.withPayload("")
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+		XMLMessage xmlMessage = xmlMessageMapper.map(testSpringMessage);
+
+		for (Map.Entry<String, ? extends HeaderMeta<?>> header : overriddenWriteableHeaders) {
+			switch (header.getKey()) {
+				case SolaceHeaders.DMQ_ELIGIBLE:
+					assertTrue(xmlMessage.isDMQEligible());
+					break;
+				default:
+					fail(String.format("no test for header %s", header.getKey()));
+			}
+		}
 
 		validateXMLMessage(xmlMessage, testSpringMessage);
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -471,13 +471,16 @@ public class XMLMessageMapperTest {
 	@Test
 	public void testMapConsumerErrorSpringMessageToXMLMessage_WithProperties() {
 		String testPayload = "testPayload";
+		XMLMessage defaultXmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
 		Message<?> testSpringMessage = new DefaultMessageBuilderFactory().withPayload(testPayload).build();
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setErrorMsgDmqEligible(!defaultXmlMessage.isDMQEligible());
 		consumerProperties.setErrorMsgTtl(100L);
 
 		XMLMessage xmlMessage = xmlMessageMapper.mapError(testSpringMessage, consumerProperties);
 		Mockito.verify(xmlMessageMapper).map(testSpringMessage);
 
+		assertEquals(consumerProperties.getErrorMsgDmqEligible(), xmlMessage.isDMQEligible());
 		assertEquals(consumerProperties.getErrorMsgTtl().longValue(), xmlMessage.getTimeToLive());
 	}
 


### PR DESCRIPTION
* Override the default DMQ eligibility when publishing to be `true` (fixes #9 )
* Add `errorMsgDmqEligibility` consumer config option to override failed input messages' DMQ eligibility property when republishing to error queues.