### PR TITLE
Add config options to omit group name from queue names

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -165,6 +165,13 @@ Whether to add topic subscriptions to durable queues for non-anonymous consumer 
 +
 Default: `true`
 
+useGroupNameInQueueName::
+Whether to include the `group` name in the queue name for non-anonymous consumer groups. If set to `true`, the queue name will be `{prefix}{destination}.{group}`. If set to `false`, the queue name will be `{prefix}{destination}`.
++
+Default: `true`
++
+IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will consume from the same queue regardless of their configured `group` names.
+
 queueAccessType::
 Access type for the consumer group queue.
 +

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -172,13 +172,6 @@ Default: `true`
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will consume from the same queue regardless of their configured `group` names.
 
-useGroupNameInErrorQueueName::
-Whether to include the `group` name in the error queue name for non-anonymous consumer groups. If set to `true`, the error queue name will be `{prefix}{destination}.{group}.error`. If set to `false`, the error queue name will be `{prefix}{destination}.error`.
-+
-Default: `true`
-+
-IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will republish failed messages to the same error queue regardless of their configured `group` names.
-
 queueAccessType::
 Access type for the consumer group queue.
 +
@@ -242,6 +235,18 @@ provisionErrorQueue::
 Whether to provision durable queues for error queues when `autoBindErrorQueue` is `true`. This should only be set to `false` if you have externally pre-provisioned the required queue on the message broker. Typically, this queue's name should have a format of `{prefix}{destination}.{group}.error`.
 +
 Default: `true`
+
+errorQueueNameOverride::
+A custom error queue name.
++
+Default: `null`
+
+useGroupNameInErrorQueueName::
+Whether to include the `group` name in the error queue name for non-anonymous consumer groups. If set to `true`, the error queue name will be `{prefix}{destination}.{group}.error`. If set to `false`, the error queue name will be `{prefix}{destination}.error`.
++
+Default: `true`
++
+IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will republish failed messages to the same error queue regardless of their configured `group` names.
 
 errorQueueAccessType::
 Access type for the error queue.

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -172,6 +172,13 @@ Default: `true`
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will consume from the same queue regardless of their configured `group` names.
 
+useGroupNameInErrorQueueName::
+Whether to include the `group` name in the error queue name for non-anonymous consumer groups. If set to `true`, the error queue name will be `{prefix}{destination}.{group}.error`. If set to `false`, the error queue name will be `{prefix}{destination}.error`.
++
+Default: `true`
++
+IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will republish failed messages to the same error queue regardless of their configured `group` names.
+
 queueAccessType::
 Access type for the consumer group queue.
 +

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -7,6 +7,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	private int polledConsumerWaitTimeInMillis = 100;
 
 	private String[] queueAdditionalSubscriptions = new String[0];
+	private boolean useGroupNameInQueueName = true;
 
 	// Error Queue Properties ---------
 	private boolean autoBindErrorQueue = false;
@@ -46,6 +47,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setQueueAdditionalSubscriptions(String[] queueAdditionalSubscriptions) {
 		this.queueAdditionalSubscriptions = queueAdditionalSubscriptions;
+	}
+
+	public boolean isUseGroupNameInQueueName() {
+		return useGroupNameInQueueName;
+	}
+
+	public void setUseGroupNameInQueueName(boolean useGroupNameInQueueName) {
+		this.useGroupNameInQueueName = useGroupNameInQueueName;
 	}
 
 	public boolean isAutoBindErrorQueue() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -12,6 +12,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	// Error Queue Properties ---------
 	private boolean autoBindErrorQueue = false;
 	private boolean provisionErrorQueue = true;
+	private String errorQueueNameOverride = null;
 	private boolean useGroupNameInErrorQueueName = true;
 
 	private int errorQueueAccessType = EndpointProperties.ACCESSTYPE_NONEXCLUSIVE;
@@ -72,6 +73,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setProvisionErrorQueue(boolean provisionErrorQueue) {
 		this.provisionErrorQueue = provisionErrorQueue;
+	}
+
+	public String getErrorQueueNameOverride() {
+		return errorQueueNameOverride;
+	}
+
+	public void setErrorQueueNameOverride(String errorQueueNameOverride) {
+		this.errorQueueNameOverride = errorQueueNameOverride;
 	}
 
 	public boolean isUseGroupNameInErrorQueueName() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -12,6 +12,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	// Error Queue Properties ---------
 	private boolean autoBindErrorQueue = false;
 	private boolean provisionErrorQueue = true;
+	private boolean useGroupNameInErrorQueueName = true;
 
 	private int errorQueueAccessType = EndpointProperties.ACCESSTYPE_NONEXCLUSIVE;
 	private int errorQueuePermission = EndpointProperties.PERMISSION_CONSUME;
@@ -71,6 +72,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setProvisionErrorQueue(boolean provisionErrorQueue) {
 		this.provisionErrorQueue = provisionErrorQueue;
+	}
+
+	public boolean isUseGroupNameInErrorQueueName() {
+		return useGroupNameInErrorQueueName;
+	}
+
+	public void setUseGroupNameInErrorQueueName(boolean useGroupNameInErrorQueueName) {
+		this.useGroupNameInErrorQueueName = useGroupNameInErrorQueueName;
 	}
 
 	public int getErrorQueueAccessType() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtil.java
@@ -57,10 +57,17 @@ public class SolaceProvisioningUtil {
 
 	public static QueueNames getQueueNames(String topicName, String groupName,
 										   SolaceConsumerProperties consumerProperties, boolean isAnonymous) {
-		return getQueueNames(topicName, groupName, consumerProperties,
+		QueueNames queueNames = getQueueNames(topicName, groupName, consumerProperties,
 				isAnonymous, consumerProperties.getAnonymousGroupPostfix(),
 				consumerProperties.isUseGroupNameInQueueName(),
 				consumerProperties.isUseGroupNameInErrorQueueName());
+
+		if (StringUtils.hasText(consumerProperties.getErrorQueueNameOverride())) {
+			return new QueueNames(queueNames.getConsumerGroupQueueName(),
+					consumerProperties.getErrorQueueNameOverride());
+		} else {
+			return queueNames;
+		}
 	}
 
 	private static QueueNames getQueueNames(String topicName, String groupName, SolaceCommonProperties properties,

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtil.java
@@ -51,18 +51,21 @@ public class SolaceProvisioningUtil {
 
 	public static String getQueueName(String topicName, String groupName,
 									  SolaceProducerProperties producerProperties) {
-		return getQueueNames(topicName, groupName, producerProperties, true, false, null)
+		return getQueueNames(topicName, groupName, producerProperties, false, null, true, true)
 				.getConsumerGroupQueueName();
 	}
 
 	public static QueueNames getQueueNames(String topicName, String groupName,
 										   SolaceConsumerProperties consumerProperties, boolean isAnonymous) {
-		return getQueueNames(topicName, groupName, consumerProperties, consumerProperties.isUseGroupNameInQueueName(),
-				isAnonymous, consumerProperties.getAnonymousGroupPostfix());
+		return getQueueNames(topicName, groupName, consumerProperties,
+				isAnonymous, consumerProperties.getAnonymousGroupPostfix(),
+				consumerProperties.isUseGroupNameInQueueName(),
+				consumerProperties.isUseGroupNameInErrorQueueName());
 	}
 
 	private static QueueNames getQueueNames(String topicName, String groupName, SolaceCommonProperties properties,
-											boolean useGroupName, boolean isAnonymous, String anonGroupPostfix) {
+											boolean isAnonymous, String anonGroupPostfix,
+											boolean useGroupName, boolean useGroupNameInErrorQueue) {
 		String commonPrefix = properties.getPrefix() + replaceTopicWildCards(topicName, "_");
 		StringBuilder groupQueueName = new StringBuilder(commonPrefix);
 		StringBuilder errorQueueName = new StringBuilder(commonPrefix);
@@ -75,7 +78,9 @@ public class SolaceProvisioningUtil {
 			if (useGroupName) {
 				groupQueueName.append(QUEUE_NAME_DELIM).append(groupName);
 			}
-			errorQueueName.append(QUEUE_NAME_DELIM).append(groupName);
+			if (useGroupNameInErrorQueue) {
+				errorQueueName.append(QUEUE_NAME_DELIM).append(groupName);
+			}
 		}
 
 		errorQueueName.append(QUEUE_NAME_DELIM).append(ERROR_QUEUE_POSTFIX);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtilQueueNameTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtilQueueNameTest.java
@@ -9,8 +9,9 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class SolaceProvisioningUtilQueueNameTest {
@@ -19,76 +20,102 @@ public class SolaceProvisioningUtilQueueNameTest {
     private final String groupName;
     private final boolean isAnonymous;
     private final String expected;
-    private final boolean expectSuffix;
     private final SolaceConsumerProperties consumerProperties;
 
-    @Parameters(name = "topic: {0}, group: {1}, prefix: {2}, suffix: {3}, useGroup: {4} == {5}")
+    @Parameters(name = "topic: {0}, group: {1}, prefix: {2}, suffix: {3}, useGroup: {4}, useGroupInEQ: {5} == {6}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "simple/destination",       "simpleGroup", "", null, true,                "simple/destination.simpleGroup" },
-                { "wildcard/*/destination/>", "simpleGroup", "", null, true,                "wildcard/_/destination/_.simpleGroup" },
+                { "simple/destination",       "simpleGroup", "", null, true, true,                "simple/destination.simpleGroup" },
+                { "wildcard/*/destination/>", "simpleGroup", "", null, true, true,                "wildcard/_/destination/_.simpleGroup" },
 
-                { "simple/destination",       "simpleGroup", "prefix", null, true,          "prefixsimple/destination.simpleGroup" },
-                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, true,          "prefixwildcard/_/destination/_.simpleGroup" },
+                { "simple/destination",       "simpleGroup", "prefix", null, true, true,          "prefixsimple/destination.simpleGroup" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, true, true,          "prefixwildcard/_/destination/_.simpleGroup" },
 
-                { "simple/destination",       "simpleGroup", "", "annoPostix", true,        "simple/destination.annoPostix" },
-                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", true,        "wildcard/_/destination/_.annoPostix" },
+                { "simple/destination",       "simpleGroup", "", "annoPostix", true, true,        "simple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", true, true,        "wildcard/_/destination/_.annoPostix" },
 
-                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", true,  "prefixsimple/destination.annoPostix" },
-                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", true,  "prefixwildcard/_/destination/_.annoPostix" },
+                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", true, true,  "prefixsimple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", true, true,  "prefixwildcard/_/destination/_.annoPostix" },
 
-                { "simple/destination",       "simpleGroup", "", null, false,               "simple/destination" },
-                { "wildcard/*/destination/>", "simpleGroup", "", null, false,               "wildcard/_/destination/_" },
+                { "simple/destination",       "simpleGroup", "", null, false, true,               "simple/destination" },
+                { "wildcard/*/destination/>", "simpleGroup", "", null, false, true,               "wildcard/_/destination/_" },
 
-                { "simple/destination",       "simpleGroup", "prefix", null, false,         "prefixsimple/destination" },
-                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, false,         "prefixwildcard/_/destination/_" },
+                { "simple/destination",       "simpleGroup", "prefix", null, false, true,         "prefixsimple/destination" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, false, true,         "prefixwildcard/_/destination/_" },
 
-                { "simple/destination",       "simpleGroup", "", "annoPostix", false,       "simple/destination.annoPostix" },
-                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", false,       "wildcard/_/destination/_.annoPostix" },
+                { "simple/destination",       "simpleGroup", "", "annoPostix", false, true,       "simple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", false, true,       "wildcard/_/destination/_.annoPostix" },
 
-                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", false, "prefixsimple/destination.annoPostix" },
-                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", false, "prefixwildcard/_/destination/_.annoPostix" }
+                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", false, true, "prefixsimple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", false, true, "prefixwildcard/_/destination/_.annoPostix" },
+                // ----
+
+                { "simple/destination",       "simpleGroup", "", null, true, false,                "simple/destination.simpleGroup" },
+                { "wildcard/*/destination/>", "simpleGroup", "", null, true, false,                "wildcard/_/destination/_.simpleGroup" },
+
+                { "simple/destination",       "simpleGroup", "prefix", null, true, false,          "prefixsimple/destination.simpleGroup" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, true, false,          "prefixwildcard/_/destination/_.simpleGroup" },
+
+                { "simple/destination",       "simpleGroup", "", "annoPostix", true, false,        "simple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", true, false,        "wildcard/_/destination/_.annoPostix" },
+
+                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", true, false,  "prefixsimple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", true, false,  "prefixwildcard/_/destination/_.annoPostix" },
+
+                { "simple/destination",       "simpleGroup", "", null, false, false,               "simple/destination" },
+                { "wildcard/*/destination/>", "simpleGroup", "", null, false, false,               "wildcard/_/destination/_" },
+
+                { "simple/destination",       "simpleGroup", "prefix", null, false, false,         "prefixsimple/destination" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, false, false,         "prefixwildcard/_/destination/_" },
+
+                { "simple/destination",       "simpleGroup", "", "annoPostix", false, false,       "simple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", false, false,       "wildcard/_/destination/_.annoPostix" },
+
+                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", false, false, "prefixsimple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", false, false, "prefixwildcard/_/destination/_.annoPostix" }
         });
     }
 
     public SolaceProvisioningUtilQueueNameTest(String destination, String groupName, String prefix,
-                                               String anonymousGroupPostfix, boolean useGroupName, String expected) {
+                                               String anonymousGroupPostfix, boolean useGroupName,
+                                               boolean useGroupNameInErrorQueue, String expected) {
         this.destination = destination;
         this.groupName = groupName;
         this.isAnonymous = anonymousGroupPostfix != null;
         this.expected = expected;
-        this.expectSuffix = anonymousGroupPostfix != null;
 
         this.consumerProperties = new SolaceConsumerProperties();
         this.consumerProperties.setAnonymousGroupPostfix(anonymousGroupPostfix);
         this.consumerProperties.setPrefix(prefix);
         this.consumerProperties.setUseGroupNameInQueueName(useGroupName);
+        this.consumerProperties.setUseGroupNameInErrorQueueName(useGroupNameInErrorQueue);
     }
 
     @Test
     public void getQueueName() {
-        if (expectSuffix) {
-            assertTrue(SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
-                    .getConsumerGroupQueueName().startsWith(expected));
+        String actual = SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+                .getConsumerGroupQueueName();
+        if (isAnonymous) {
+            assertThat(actual, startsWith(expected));
         } else {
-            assertEquals(expected, SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties,
-                    isAnonymous).getConsumerGroupQueueName());
+            assertEquals(expected, actual);
         }
     }
 
     @Test
     public void getErrorQueueName() {
-        if (expectSuffix) {
-            assertTrue(SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
-                    .getErrorQueueName().startsWith(expected));
-        } else if (!consumerProperties.isUseGroupNameInQueueName()) {
-            assertEquals(expected + '.' + groupName + ".error",
-                    SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
-                            .getErrorQueueName());
+        String actual = SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+                .getErrorQueueName();
+        if (isAnonymous) {
+            assertThat(actual, startsWith(expected));
+        } else if (!consumerProperties.isUseGroupNameInQueueName() &&
+                consumerProperties.isUseGroupNameInErrorQueueName()) {
+            assertEquals(expected + '.' + groupName + ".error", actual);
+        } else if (consumerProperties.isUseGroupNameInQueueName() &&
+                !consumerProperties.isUseGroupNameInErrorQueueName()) {
+            assertEquals(expected.replace('.' + groupName, "") + ".error", actual);
         } else {
-            assertEquals(expected + ".error",
-                    SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
-                            .getErrorQueueName());
+            assertEquals(expected + ".error", actual);
         }
     }
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtilQueueNameTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtilQueueNameTest.java
@@ -22,24 +22,37 @@ public class SolaceProvisioningUtilQueueNameTest {
     private final boolean expectSuffix;
     private final SolaceConsumerProperties consumerProperties;
 
-    @Parameters(name = "topic: {0}, group: {1}, prefix: {2}, suffix: {3} == {4}")
+    @Parameters(name = "topic: {0}, group: {1}, prefix: {2}, suffix: {3}, useGroup: {4} == {5}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "simple/destination",       "simpleGroup", "", null,                "simple/destination.simpleGroup" },
-                { "wildcard/*/destination/>", "simpleGroup", "", null,                "wildcard/_/destination/_.simpleGroup" },
+                { "simple/destination",       "simpleGroup", "", null, true,                "simple/destination.simpleGroup" },
+                { "wildcard/*/destination/>", "simpleGroup", "", null, true,                "wildcard/_/destination/_.simpleGroup" },
 
-                { "simple/destination",       "simpleGroup", "prefix", null,          "prefixsimple/destination.simpleGroup" },
-                { "wildcard/*/destination/>", "simpleGroup", "prefix", null,          "prefixwildcard/_/destination/_.simpleGroup" },
+                { "simple/destination",       "simpleGroup", "prefix", null, true,          "prefixsimple/destination.simpleGroup" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, true,          "prefixwildcard/_/destination/_.simpleGroup" },
 
-                { "simple/destination",       "simpleGroup", "", "annoPostix",        "simple/destination.annoPostix" },
-                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix",        "wildcard/_/destination/_.annoPostix" },
+                { "simple/destination",       "simpleGroup", "", "annoPostix", true,        "simple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", true,        "wildcard/_/destination/_.annoPostix" },
 
-                { "simple/destination",       "simpleGroup", "prefix", "annoPostix",  "prefixsimple/destination.annoPostix" },
-                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix",  "prefixwildcard/_/destination/_.annoPostix" }
+                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", true,  "prefixsimple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", true,  "prefixwildcard/_/destination/_.annoPostix" },
+
+                { "simple/destination",       "simpleGroup", "", null, false,               "simple/destination" },
+                { "wildcard/*/destination/>", "simpleGroup", "", null, false,               "wildcard/_/destination/_" },
+
+                { "simple/destination",       "simpleGroup", "prefix", null, false,         "prefixsimple/destination" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", null, false,         "prefixwildcard/_/destination/_" },
+
+                { "simple/destination",       "simpleGroup", "", "annoPostix", false,       "simple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "", "annoPostix", false,       "wildcard/_/destination/_.annoPostix" },
+
+                { "simple/destination",       "simpleGroup", "prefix", "annoPostix", false, "prefixsimple/destination.annoPostix" },
+                { "wildcard/*/destination/>", "simpleGroup", "prefix", "annoPostix", false, "prefixwildcard/_/destination/_.annoPostix" }
         });
     }
 
-    public SolaceProvisioningUtilQueueNameTest(String destination, String groupName, String prefix, String anonymousGroupPostfix, String expected) {
+    public SolaceProvisioningUtilQueueNameTest(String destination, String groupName, String prefix,
+                                               String anonymousGroupPostfix, boolean useGroupName, String expected) {
         this.destination = destination;
         this.groupName = groupName;
         this.isAnonymous = anonymousGroupPostfix != null;
@@ -49,15 +62,33 @@ public class SolaceProvisioningUtilQueueNameTest {
         this.consumerProperties = new SolaceConsumerProperties();
         this.consumerProperties.setAnonymousGroupPostfix(anonymousGroupPostfix);
         this.consumerProperties.setPrefix(prefix);
+        this.consumerProperties.setUseGroupNameInQueueName(useGroupName);
     }
 
     @Test
     public void getQueueName() {
         if (expectSuffix) {
-            assertTrue(SolaceProvisioningUtil.getQueueName(destination, groupName, consumerProperties, isAnonymous).startsWith(expected));
+            assertTrue(SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+                    .getConsumerGroupQueueName().startsWith(expected));
         } else {
-            assertEquals(expected, SolaceProvisioningUtil.getQueueName(destination, groupName, consumerProperties, isAnonymous));
+            assertEquals(expected, SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties,
+                    isAnonymous).getConsumerGroupQueueName());
         }
+    }
 
+    @Test
+    public void getErrorQueueName() {
+        if (expectSuffix) {
+            assertTrue(SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+                    .getErrorQueueName().startsWith(expected));
+        } else if (!consumerProperties.isUseGroupNameInQueueName()) {
+            assertEquals(expected + '.' + groupName + ".error",
+                    SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+                            .getErrorQueueName());
+        } else {
+            assertEquals(expected + ".error",
+                    SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+                            .getErrorQueueName());
+        }
     }
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtilTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceProvisioningUtilTest.java
@@ -1,0 +1,27 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.util.SolaceProvisioningUtil.QueueNames;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SolaceProvisioningUtilTest {
+	@Test
+	public void testConsumerErrorQueueNameOverride() {
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setErrorQueueNameOverride("some-custom-named-error-queue-name");
+		QueueNames queueNames = SolaceProvisioningUtil.getQueueNames("topic", "group",
+				consumerProperties, false);
+		assertEquals(consumerProperties.getErrorQueueNameOverride(), queueNames.getErrorQueueName());
+	}
+
+	@Test
+	public void testAnonConsumerErrorQueueNameOverride() {
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setErrorQueueNameOverride("some-custom-named-error-queue-name");
+		QueueNames queueNames = SolaceProvisioningUtil.getQueueNames("topic", null,
+				consumerProperties, true);
+		assertEquals(consumerProperties.getErrorQueueNameOverride(), queueNames.getErrorQueueName());
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
@@ -1265,4 +1265,206 @@ public class SolaceBinderProvisioningLifecycleIT extends SolaceBinderITBase {
 			if (consumerBinding != null) consumerBinding.unbind();
 		}
 	}
+
+	@Test
+	public void testConsumerProvisionIgnoreGroupNameInQueueName() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setUseGroupNameInQueueName(false);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		String queueName = binder.getConsumerQueueName(consumerBinding);
+		assertThat(queueName).isEqualTo(destination0);
+
+		String errorQueueName = binder.getConsumerErrorQueueName(consumerBinding);
+		assertThat(errorQueueName).isEqualTo(destination0 + "." + group0 + ".error");
+
+		CountDownLatch latch = new CountDownLatch(consumerProperties.getMaxAttempts());
+		moduleInputChannel.subscribe(message1 -> {
+			latch.countDown();
+			throw new RuntimeException("Throwing expected exception!");
+		});
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+
+		final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+		errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(errorQueueName));
+		errorQueueFlowProperties.setStartState(true);
+		FlowReceiver flowReceiver = null;
+		try {
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		// Give some time for the message to actually ack off the original queue
+		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+
+		List<MonitorMsgVpnQueueMsg> enqueuedMessages = sempV2Api.monitor()
+				.getMsgVpnQueueMsgs(msgVpnName, queueName, 2, null, null, null)
+				.getData();
+		assertThat(enqueuedMessages).hasSize(0);
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testPolledConsumerProvisionIgnoreGroupNameInQueueName() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setUseGroupNameInQueueName(false);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		String queueName = binder.getConsumerQueueName(consumerBinding);
+		assertThat(queueName).isEqualTo(destination0);
+
+		String errorQueueName = binder.getConsumerErrorQueueName(consumerBinding);
+		assertThat(errorQueueName).isEqualTo(destination0 + "." + group0 + ".error");
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		boolean gotMessage = false;
+		for (int i = 0; !gotMessage && i < 100; i++) {
+			gotMessage = moduleInputChannel.poll(message1 -> {
+				throw new RuntimeException("Throwing expected exception!");
+			});
+		}
+		assertThat(gotMessage).isTrue();
+
+		final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+		errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(errorQueueName));
+		errorQueueFlowProperties.setStartState(true);
+		FlowReceiver flowReceiver = null;
+		try {
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		// Give some time for the message to actually ack off the original queue
+		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+
+		List<MonitorMsgVpnQueueMsg> enqueuedMessages = sempV2Api.monitor()
+				.getMsgVpnQueueMsgs(msgVpnName, queueName, 2, null, null, null)
+				.getData();
+		assertThat(enqueuedMessages).hasSize(0);
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testAnonConsumerProvisionIgnoreGroupNameInQueueName() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setUseGroupNameInQueueName(false);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, null, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		String queueName = binder.getConsumerQueueName(consumerBinding);
+		assertThat(queueName).contains('/' + destination0 + ".anon/");
+		assertThat(queueName).hasSizeGreaterThan(('/' + destination0 + ".anon/").length());
+
+		String errorQueueName = binder.getConsumerErrorQueueName(consumerBinding);
+		assertThat(errorQueueName).startsWith(destination0 + ".anon/");
+		assertThat(errorQueueName).endsWith(".error");
+
+		CountDownLatch latch = new CountDownLatch(consumerProperties.getMaxAttempts());
+		moduleInputChannel.subscribe(message1 -> {
+			latch.countDown();
+			throw new RuntimeException("Throwing expected exception!");
+		});
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+
+		final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+		errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(errorQueueName));
+		errorQueueFlowProperties.setStartState(true);
+		FlowReceiver flowReceiver = null;
+		try {
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		// Give some time for the message to actually ack off the original queue
+		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+
+		List<MonitorMsgVpnQueueMsg> enqueuedMessages = sempV2Api.monitor()
+				.getMsgVpnQueueMsgs(msgVpnName, queueName, 2, null, null, null)
+				.getData();
+		assertThat(enqueuedMessages).hasSize(0);
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
@@ -1467,4 +1467,139 @@ public class SolaceBinderProvisioningLifecycleIT extends SolaceBinderITBase {
 		producerBinding.unbind();
 		consumerBinding.unbind();
 	}
+
+	@Test
+	public void testConsumerProvisionIgnoreGroupNameInErrorQueueName() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setUseGroupNameInErrorQueueName(false);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		String queueName = binder.getConsumerQueueName(consumerBinding);
+		assertThat(queueName).isEqualTo(destination0 + '.' + group0);
+
+		String errorQueueName = binder.getConsumerErrorQueueName(consumerBinding);
+		assertThat(errorQueueName).isEqualTo(destination0 + ".error");
+
+		CountDownLatch latch = new CountDownLatch(consumerProperties.getMaxAttempts());
+		moduleInputChannel.subscribe(message1 -> {
+			latch.countDown();
+			throw new RuntimeException("Throwing expected exception!");
+		});
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+
+		final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+		errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(errorQueueName));
+		errorQueueFlowProperties.setStartState(true);
+		FlowReceiver flowReceiver = null;
+		try {
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		// Give some time for the message to actually ack off the original queue
+		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+
+		List<MonitorMsgVpnQueueMsg> enqueuedMessages = sempV2Api.monitor()
+				.getMsgVpnQueueMsgs(msgVpnName, queueName, 2, null, null, null)
+				.getData();
+		assertThat(enqueuedMessages).hasSize(0);
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testAnonConsumerProvisionIgnoreGroupNameInErrorQueueName() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setUseGroupNameInErrorQueueName(false);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, null, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		String queueName = binder.getConsumerQueueName(consumerBinding);
+		assertThat(queueName).contains('/' + destination0 + ".anon/");
+		assertThat(queueName).hasSizeGreaterThan(('/' + destination0 + ".anon/").length());
+
+		String errorQueueName = binder.getConsumerErrorQueueName(consumerBinding);
+		assertThat(errorQueueName).startsWith(destination0 + ".anon/");
+		assertThat(errorQueueName).endsWith(".error");
+
+		CountDownLatch latch = new CountDownLatch(consumerProperties.getMaxAttempts());
+		moduleInputChannel.subscribe(message1 -> {
+			latch.countDown();
+			throw new RuntimeException("Throwing expected exception!");
+		});
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+
+		final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+		errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(errorQueueName));
+		errorQueueFlowProperties.setStartState(true);
+		FlowReceiver flowReceiver = null;
+		try {
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		// Give some time for the message to actually ack off the original queue
+		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+
+		List<MonitorMsgVpnQueueMsg> enqueuedMessages = sempV2Api.monitor()
+				.getMsgVpnQueueMsgs(msgVpnName, queueName, 2, null, null, null)
+				.getData();
+		assertThat(enqueuedMessages).hasSize(0);
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
@@ -113,7 +113,8 @@ public class SolaceTestBinder
 			queues.add(queueName);
 		}
 		if (consumerProperties.isAutoBindErrorQueue()) {
-			String errorQueueName = extractErrorQueueName(binding, name, group);
+			String errorQueueName = extractErrorQueueName(binding, name, group,
+					consumerProperties.isUseGroupNameInErrorQueueName());
 			queues.add(errorQueueName);
 			bindingNameToErrorQueueName.put(binding.getBindingName(), errorQueueName);
 		}
@@ -132,13 +133,15 @@ public class SolaceTestBinder
 		return matcher.group(1);
 	}
 
-	private String extractErrorQueueName(Binding<?> binding, String destination, String group) {
+	private String extractErrorQueueName(Binding<?> binding, String destination, String group, boolean includeGroup) {
 		String fullQueueName = extractBindingDestination(binding);
 		String prefix;
 		if (fullQueueName.startsWith("#P2P/QTMP/")) {
 			prefix = fullQueueName.substring(fullQueueName.indexOf(destination));
-		} else if (!fullQueueName.endsWith('.' + group)) {
+		} else if (includeGroup && !fullQueueName.endsWith('.' + group)) {
 			prefix = fullQueueName + '.' + group;
+		} else if (!includeGroup && fullQueueName.endsWith('.' + group)) {
+			prefix = fullQueueName.replace('.' + group, "");
 		} else {
 			prefix = fullQueueName;
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -113,8 +114,9 @@ public class SolaceTestBinder
 			queues.add(queueName);
 		}
 		if (consumerProperties.isAutoBindErrorQueue()) {
-			String errorQueueName = extractErrorQueueName(binding, name, group,
-					consumerProperties.isUseGroupNameInErrorQueueName());
+			String errorQueueName = StringUtils.hasText(consumerProperties.getErrorQueueNameOverride()) ?
+					consumerProperties.getErrorQueueNameOverride() :
+					extractErrorQueueName(binding, name, group, consumerProperties.isUseGroupNameInErrorQueueName());
 			queues.add(errorQueueName);
 			bindingNameToErrorQueueName.put(binding.getBindingName(), errorQueueName);
 		}


### PR DESCRIPTION
Fixes #28
* added `useGroupNameInQueueName` consumer config option to omit group name from the consumer group queue's name
* added `useGroupNameInErrorQueueName` consumer config option to omit group name from the error queue's name
* added `errorQueueNameOverride` consumer config option to override the generated error queue name with a custom config-provided one.