### PR TITLE
SCSt: add error-channel-sending correlation key during SCSt publish

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorChannelSendingCorrelationKey.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorChannelSendingCorrelationKey.java
@@ -1,0 +1,59 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.XMLMessage;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.support.ErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+
+public class ErrorChannelSendingCorrelationKey {
+	private final Message<?> inputMessage;
+	private final MessageChannel errorChannel;
+	private final ErrorMessageStrategy errorMessageStrategy;
+	private XMLMessage rawMessage;
+
+	private static final Log logger = LogFactory.getLog(ErrorChannelSendingCorrelationKey.class);
+
+	public ErrorChannelSendingCorrelationKey(Message<?> inputMessage, MessageChannel errorChannel,
+											 ErrorMessageStrategy errorMessageStrategy) {
+		this.inputMessage = inputMessage;
+		this.errorChannel = errorChannel;
+		this.errorMessageStrategy = errorMessageStrategy;
+	}
+
+	public Message<?> getInputMessage() {
+		return inputMessage;
+	}
+
+	public XMLMessage getRawMessage() {
+		return rawMessage;
+	}
+
+	public void setRawMessage(XMLMessage rawMessage) {
+		this.rawMessage = rawMessage;
+	}
+
+	/**
+	 * Send the message to the error channel if defined.
+	 * @param msg the failure description
+	 * @param cause the failure cause
+	 * @return the exception wrapper containing the failed input message
+	 */
+	public MessagingException send(String msg, Exception cause) {
+		MessagingException exception = new MessagingException(inputMessage, msg, cause);
+		if (errorChannel != null) {
+			AttributeAccessor attributes = ErrorMessageUtils.getAttributeAccessor(inputMessage, null);
+			if (rawMessage != null) {
+				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_RAW_MESSAGE, rawMessage);
+			}
+			logger.debug(String.format("Sending message %s to error channel %s", inputMessage.getHeaders().getId(),
+					errorChannel));
+			errorChannel.send(errorMessageStrategy.buildErrorMessage(exception, attributes));
+		}
+		return exception;
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
@@ -2,13 +2,18 @@ package com.solace.spring.cloud.stream.binder.util;
 
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public class JCSMPSessionProducerManager extends SharedResourceManager<XMLMessageProducer> {
-	private JCSMPSession session;
+	private final JCSMPSession session;
 
 	private static final Log logger = LogFactory.getLog(JCSMPSessionProducerManager.class);
 
@@ -27,15 +32,32 @@ public class JCSMPSessionProducerManager extends SharedResourceManager<XMLMessag
 		sharedResource.close();
 	}
 
-	private JCSMPStreamingPublishEventHandler publisherEventHandler = new JCSMPStreamingPublishEventHandler() {
-		@Override
-		public void responseReceived(String messageID) {
-			logger.debug("Producer received response for msg: " + messageID);
-		}
+	private final JCSMPStreamingPublishCorrelatingEventHandler publisherEventHandler =
+			new JCSMPStreamingPublishCorrelatingEventHandler() {
 
 		@Override
-		public void handleError(String messageID, JCSMPException e, long timestamp) {
-			logger.warn("Producer received error for msg: " + messageID + " - " + timestamp, e);
+		public void responseReceivedEx(Object correlationKey) {
+			logger.debug("Producer received response for correlation key: " + correlationKey);
+		}
+
+		@SuppressWarnings("ThrowableNotThrown")
+		@Override
+		public void handleErrorEx(Object correlationKey, JCSMPException cause, long timestamp) {
+			if (correlationKey instanceof ErrorChannelSendingCorrelationKey) {
+				ErrorChannelSendingCorrelationKey key = (ErrorChannelSendingCorrelationKey) correlationKey;
+				String messageId = key.getRawMessage() != null ? key.getRawMessage().getMessageId() : null;
+				UUID springMessageId = Optional.ofNullable(key.getInputMessage())
+						.map(Message::getHeaders)
+						.map(MessageHeaders::getId)
+						.orElse(null);
+				String msg = String.format("Producer received error for message %s (Spring message %s) at %s",
+						messageId, springMessageId, timestamp);
+				logger.warn(msg, cause);
+				key.send(msg, cause);
+			} else {
+				logger.warn(String.format("Producer received error for correlation key: %s at %s", correlationKey,
+						timestamp), cause);
+			}
 		}
 	};
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorChannelSendingCorrelationKeyTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorChannelSendingCorrelationKeyTest.java
@@ -1,0 +1,82 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.TextMessage;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.StaticMessageHeaderAccessor;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.support.ErrorMessageStrategy;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorChannelSendingCorrelationKeyTest {
+	private final ErrorMessageStrategy errorMessageStrategy = new SolaceMessageHeaderErrorMessageStrategy();
+
+	@Test
+	public void testNoErrorChannel() {
+		Message<?> message = MessageBuilder.withPayload("test").build();
+		ErrorChannelSendingCorrelationKey key = new ErrorChannelSendingCorrelationKey(message, null,
+				errorMessageStrategy);
+
+		String description = "some failure";
+		Exception cause = new RuntimeException("test");
+
+		MessagingException exception = key.send(description, cause);
+		assertThat(exception).hasMessageStartingWith(description);
+		assertThat(exception).hasCause(cause);
+		assertThat(exception.getFailedMessage()).isEqualTo(message);
+	}
+
+	@Test
+	public void testErrorChannel() {
+		Message<?> message = MessageBuilder.withPayload("test").build();
+		DirectChannel errorChannel = new DirectChannel();
+		ErrorChannelSendingCorrelationKey key = new ErrorChannelSendingCorrelationKey(message, errorChannel,
+				errorMessageStrategy);
+
+		String description = "some failure";
+		Exception cause = new RuntimeException("test");
+
+		SoftAssertions softly = new SoftAssertions();
+		errorChannel.subscribe(msg -> {
+			softly.assertThat(msg).isInstanceOf(ErrorMessage.class);
+			ErrorMessage errorMsg = (ErrorMessage) msg;
+			softly.assertThat(errorMsg.getOriginalMessage()).isEqualTo(message);
+			softly.assertThat(errorMsg.getPayload()).isInstanceOf(MessagingException.class);
+			softly.assertThat(errorMsg.getPayload()).hasMessageStartingWith(description);
+			softly.assertThat(errorMsg.getPayload()).hasCause(cause);
+			softly.assertThat(((MessagingException) errorMsg.getPayload()).getFailedMessage()).isEqualTo(message);
+		});
+
+		MessagingException exception = key.send(description, cause);
+		assertThat(exception).hasMessageStartingWith(description);
+		assertThat(exception).hasCause(cause);
+		assertThat(exception.getFailedMessage()).isEqualTo(message);
+		softly.assertAll();
+	}
+
+	@SuppressWarnings("ThrowableNotThrown")
+	@Test
+	public void testRawMessageHeader() {
+		Message<?> message = MessageBuilder.withPayload("test").build();
+		DirectChannel errorChannel = new DirectChannel();
+		ErrorChannelSendingCorrelationKey key = new ErrorChannelSendingCorrelationKey(message, errorChannel,
+				errorMessageStrategy);
+		key.setRawMessage(JCSMPFactory.onlyInstance().createMessage(TextMessage.class));
+
+		SoftAssertions softly = new SoftAssertions();
+		errorChannel.subscribe(msg -> {
+			softly.assertThat(msg.getHeaders()).containsKey(IntegrationMessageHeaderAccessor.SOURCE_DATA);
+			softly.assertThat((Object) StaticMessageHeaderAccessor.getSourceData(msg)).isEqualTo(key.getRawMessage());
+		});
+
+		key.send("some failure", new RuntimeException("test"));
+		softly.assertAll();
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -74,7 +74,7 @@ public class SolaceMessageChannelBinder
 				destination, jcsmpSession, errorChannel, sessionProducerManager, producerProperties.getExtension());
 
 		if (errorChannel != null) {
-			handler.setErrorMessageStrategy(new DefaultErrorMessageStrategy());
+			handler.setErrorMessageStrategy(errorMessageStrategy);
 		}
 
 		return handler;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
@@ -2,27 +2,38 @@ package com.solace.spring.cloud.stream.binder;
 
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
 import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredRunner;
 import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
 import com.solace.spring.cloud.stream.binder.util.SolaceErrorMessageHandler;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.XMLMessage;
+import org.apache.commons.lang.RandomStringUtils;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.PollableSource;
 import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.MimeTypeUtils;
@@ -31,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 /**
  * All tests regarding custom channel-specific error message handlers
@@ -42,11 +54,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IgnoreInheritedTests
 public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase {
 	@Test
-	public void testOverrideErrorMessageHandler() throws Exception {
+	public void testConsumerOverrideErrorMessageHandler() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testOverrideErrorMessageHandler";
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
 		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
 				getDestinationNameDelimiter() + "errors";
 		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
@@ -60,7 +72,7 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		SoftAssertions softly = new SoftAssertions();
 		createChannel(errorDestination0, DirectChannel.class, msg -> {
 			logger.info("Got error message: " + msg);
-			applyErrorMessageAssertions(msg, softly);
+			applyErrorMessageAssertions(msg, softly, true);
 			errorLatch.countDown();
 		});
 
@@ -108,11 +120,11 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 	}
 
 	@Test
-	public void testOverrideRetryableErrorMessageHandler() throws Exception {
+	public void testConsumerOverrideRetryableErrorMessageHandler() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testOverrideRetryableErrorMessageHandler";
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
 		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
 				getDestinationNameDelimiter() + "errors";
 		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
@@ -126,7 +138,7 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		SoftAssertions softly = new SoftAssertions();
 		createChannel(errorDestination0, DirectChannel.class, msg -> {
 			logger.info("Got error message: " + msg);
-			applyErrorMessageAssertions(msg, softly);
+			applyErrorMessageAssertions(msg, softly, true);
 			errorLatch.countDown();
 		});
 
@@ -174,11 +186,11 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 	}
 
 	@Test
-	public void testOverridePollableErrorMessageHandler() throws Exception {
+	public void testConsumerOverridePollableErrorMessageHandler() throws Exception {
 		SolaceTestBinder binder = getBinder();
 
-		String destination0 = String.format("foo%s0", getDestinationNameDelimiter());
-		String group0 = "testOverridePollableErrorMessageHandler";
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
 		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
 				getDestinationNameDelimiter() + "errors";
 		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
@@ -192,7 +204,7 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		SoftAssertions softly = new SoftAssertions();
 		createChannel(errorDestination0, DirectChannel.class, msg -> {
 			logger.info("Got error message: " + msg);
-			applyErrorMessageAssertions(msg, softly);
+			applyErrorMessageAssertions(msg, softly, true);
 			errorLatch.countDown();
 		});
 
@@ -238,11 +250,97 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		consumerBinding.unbind();
 	}
 
-	private void applyErrorMessageAssertions(Message<?> errorMessage, SoftAssertions softAssertions) {
+	@Test
+	public void testPublisherErrorMessageHandler() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + "errors";
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+
+		ExtendedProducerProperties<SolaceProducerProperties> producerProperties = createProducerProperties();
+		producerProperties.setErrorChannelEnabled(true);
+		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel,
+				producerProperties);
+
+		final CountDownLatch errorLatch = new CountDownLatch(1);
+		SoftAssertions softly = new SoftAssertions();
+		createChannel(errorDestination0, PublishSubscribeChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			applyErrorMessageAssertions(msg, softly, false);
+			errorLatch.countDown();
+		});
+
+		binderBindUnbindLatency();
+
+		assertThrows(MessagingException.class, () -> moduleOutputChannel.send(
+				MessageBuilder.withPayload("foo".getBytes())
+						.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+						.setHeader(BinderHeaders.TARGET_DESTINATION, new Object()) // force a publish error
+						.build()));
+		assertThat(errorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		softly.assertAll();
+
+		producerBinding.unbind();
+	}
+
+	@Test
+	public void testPublisherAsyncErrorMessageHandler() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + "errors";
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+
+		ExtendedProducerProperties<SolaceProducerProperties> producerProperties = createProducerProperties();
+		producerProperties.setErrorChannelEnabled(true);
+		Binding<MessageChannel> producerBinding = binder.bindProducer(destination0, moduleOutputChannel,
+				producerProperties);
+
+		final CountDownLatch errorLatch = new CountDownLatch(1);
+		SoftAssertions softly = new SoftAssertions();
+		createChannel(errorDestination0, PublishSubscribeChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			applyErrorMessageAssertions(msg, softly, true);
+			errorLatch.countDown();
+		});
+
+		binderBindUnbindLatency();
+
+		Queue queue = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(10));
+
+		try {
+			EndpointProperties endpointProperties = new EndpointProperties();
+			endpointProperties.setMaxMsgSize(1); // force async publish error
+			jcsmpSession.provision(queue, endpointProperties, JCSMPSession.WAIT_FOR_CONFIRM);
+			jcsmpSession.addSubscription(queue, JCSMPFactory.onlyInstance().createTopic(destination0),
+					JCSMPSession.WAIT_FOR_CONFIRM);
+
+			moduleOutputChannel.send(MessageBuilder.withPayload("foo".getBytes())
+					.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+					.build());
+			assertThat(errorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			softly.assertAll();
+		} finally {
+			jcsmpSession.deprovision(queue, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
+		}
+
+		producerBinding.unbind();
+	}
+
+	private void applyErrorMessageAssertions(Message<?> errorMessage, SoftAssertions softAssertions,
+											 boolean expectRawMessageHeader) {
 		softAssertions.assertThat(errorMessage).isInstanceOf(ErrorMessage.class);
 		softAssertions.assertThat(((ErrorMessage) errorMessage).getOriginalMessage()).isNotNull();
 		softAssertions.assertThat(((ErrorMessage) errorMessage).getPayload()).isNotNull();
-		softAssertions.assertThat((Object) StaticMessageHeaderAccessor.getSourceData(errorMessage))
-				.isInstanceOf(XMLMessage.class);
+		if (expectRawMessageHeader) {
+			softAssertions.assertThat((Object) StaticMessageHeaderAccessor.getSourceData(errorMessage))
+					.isInstanceOf(XMLMessage.class);
+		} else {
+			softAssertions.assertThat(errorMessage.getHeaders())
+					.doesNotContainKey(IntegrationMessageHeaderAccessor.SOURCE_DATA);
+		}
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderITBase.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderITBase.java
@@ -28,6 +28,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
@@ -129,9 +130,14 @@ public abstract class SolaceBinderITBase
 	<T extends AbstractSubscribableChannel> T createChannel(String channelName, Class<T> type,
 															MessageHandler messageHandler)
 			throws IllegalAccessException, InstantiationException {
-		T channel = type.newInstance();
-		channel.setComponentName(channelName);
-		testBinder.getApplicationContext().registerBean(channelName, type, () -> channel);
+		T channel;
+		if (testBinder.getApplicationContext().containsBean(channelName)) {
+			channel = testBinder.getApplicationContext().getBean(channelName, type);
+		} else {
+			channel = type.newInstance();
+			channel.setComponentName(channelName);
+			testBinder.getApplicationContext().registerBean(channelName, type, () -> channel);
+		}
 		channel.subscribe(messageHandler);
 		return channel;
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/resources/logback.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/resources/logback.xml
@@ -2,4 +2,5 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml" />
     <logger name="CONSOLE" level="INFO" />
+    <logger name="com.solace.spring.cloud.stream.binder" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
* send asynchronous publishing exceptions to `errorChannel`. (fixes #34 )
* Properly construct the `ErrorMessage` with the necessary Solace headers when receiving a producer error.