### PR TITLE
add timeout to flow pre-rebind

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -224,6 +224,11 @@ Rate at which polled consumers will receive messages from their consumer group q
 +
 Default: `100`
 
+flowPreRebindWaitTimeout::
+The maximum time to wait for all unacknowledged messages to be acknowledged before a flow receiver rebind. Will wait forever if set to a value less than `0`.
++
+Default: `10000`
+
 autoBindErrorQueue::
 Whether to automatically create a durable error queue to which messages will be republished when message processing failures are encountered. Only applies once all internal retries have been exhausted.
 +
@@ -549,12 +554,15 @@ Message handlers can disable auto-acknowledgement and manually invoke the acknow
 public void consume(Message<?> message) {
     AcknowledgmentCallback acknowledgmentCallback = StaticMessageHeaderAccessor.getAcknowledgmentCallback(message); // <1>
     acknowledgmentCallback.noAutoAck(); // <2>
-    AckUtils.accept(acknowledgmentCallback); // <3>
+    try {
+        AckUtils.accept(acknowledgmentCallback); // <3>
+    } catch (SolaceAcknowledgmentException e) {} // <4>
 }
 ----
 <1> Get the message's acknowledgement callback header
 <2> Disable auto-acknowledgement
 <3> Acknowledge the message with the `ACCEPT` status
+<4> Handle any acknowledgment exceptions (mostly `SolaceStaleMessageException`)
 
 Refer to the https://docs.spring.io/spring-integration/api/org/springframework/integration/acks/AckUtils.html[AckUtils documentation] and https://javadoc.io/doc/org.springframework.integration/spring-integration-core/latest/org/springframework/integration/acks/AcknowledgmentCallback.html[AcknowledgmentCallback documentation] for more info on these objects.
 
@@ -581,6 +589,15 @@ Refer to <<Failed Message Error Handling>> for more info.
 Refer to <<Message Redelivery>> for more info.
 |===
 
+[IMPORTANT]
+====
+Acknowledgements may throw `SolaceAcknowledgmentException` depending on the current state of the consumer. Particularly if doing asynchronous acknowledgements, your invocation to acknowledge a message should catch `SolaceAcknowledgmentException` and deal with it accordingly.
+
+*Example:* +
+(refer to <<Message Redelivery>> for background info)
+
+A `SolaceAcknowledgmentException` with cause `SolaceStaleMessageException` may be thrown when trying to asynchronously `ACCEPT` a stale message after the timeout elapses for the `REQUEUE` of another message. Though for this particular example, since the message that failed to `ACCEPT` will be redelivered, this exception can be caught and ignored if you have no business logic to revert.
+====
 
 NOTE: Manual acknowledgements do not support any application-internal error handling strategies (i.e. retry template, error channel forwarding, etc). Also, throwing an exception in the message handler will always acknowledge the message in some way regardless if auto-acknowledgment is disabled.
 
@@ -637,10 +654,10 @@ The Solace API used in this binder implementation does not support individual me
 Here is what happens under the hood when this is triggered:
 
 1. The Solace flow receiver is stopped.
-2. Wait until all unacknowledged messages have been acknowledged.
+2. Wait until all unacknowledged messages have been acknowledged with a maximum timeout of `flowPreRebindWaitTimeout`. If timed out, the remaining unacknowledged messages will be stale and redelivered from the broker.
 3. Rebind the flow.
 
-Meaning if unacknowledged messages are not processed in a timely manner, this operation will stall.
+Meaning that if unacknowledged messages are not processed in a timely manner, this operation will stall and potentially cause unecessary message duplication.
 ====
 
 === Error Queue Republishing

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BasicInboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BasicInboundXMLMessageListener.java
@@ -2,6 +2,7 @@ package com.solace.spring.cloud.stream.binder.inbound;
 
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
 import com.solace.spring.cloud.stream.binder.util.JCSMPAcknowledgementCallbackFactory;
+import com.solace.spring.cloud.stream.binder.util.SolaceAcknowledgmentException;
 import com.solacesystems.jcsmp.BytesXMLMessage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,7 +35,7 @@ public class BasicInboundXMLMessageListener extends InboundXMLMessageListener {
 		this.errorHandlerFunction = errorHandlerFunction;
 	}
 
-	void handleMessage(BytesXMLMessage bytesXMLMessage, AcknowledgmentCallback acknowledgmentCallback) {
+	void handleMessage(BytesXMLMessage bytesXMLMessage, AcknowledgmentCallback acknowledgmentCallback) throws SolaceAcknowledgmentException {
 		Message<?> message;
 		try {
 			message = createMessage(bytesXMLMessage, acknowledgmentCallback);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
@@ -1,5 +1,6 @@
 package com.solace.spring.cloud.stream.binder.inbound;
 
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.ErrorQueueInfrastructure;
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
 import com.solace.spring.cloud.stream.binder.util.JCSMPAcknowledgementCallbackFactory;
@@ -35,6 +36,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 	private final String id = UUID.randomUUID().toString();
 	private final ConsumerDestination consumerDestination;
 	private final JCSMPSession jcsmpSession;
+	private final SolaceConsumerProperties consumerProperties;
 	private final EndpointProperties endpointProperties;
 	private final int concurrency;
 	private final boolean hasTemporaryQueue;
@@ -54,11 +56,13 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 									  JCSMPSession jcsmpSession,
 									  int concurrency,
 									  boolean hasTemporaryQueue,
+									  SolaceConsumerProperties consumerProperties,
 									  @Nullable EndpointProperties endpointProperties) {
 		this.consumerDestination = consumerDestination;
 		this.jcsmpSession = jcsmpSession;
 		this.concurrency = concurrency;
 		this.hasTemporaryQueue = hasTemporaryQueue;
+		this.consumerProperties = consumerProperties;
 		this.endpointProperties = endpointProperties;
 		this.consumerStopFlags = new HashSet<>(this.concurrency);
 	}
@@ -95,6 +99,8 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
 			for (int i = 0; i < concurrency; i++) {
 				logger.info(String.format("Creating consumer %s of %s for inbound adapter %s", i + 1, concurrency, id));
 				FlowReceiverContainer flowReceiverContainer = new FlowReceiverContainer(jcsmpSession, queueName, endpointProperties);
+				flowReceiverContainer.setRebindWaitTimeout(consumerProperties.getFlowPreRebindWaitTimeout(),
+						TimeUnit.MILLISECONDS);
 				flowReceiverContainer.bind();
 				flowReceivers.add(flowReceiverContainer);
 			}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
@@ -21,6 +21,7 @@ import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.messaging.MessagingException;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class JCSMPMessageSource extends AbstractMessageSource<Object> implements Lifecycle {
@@ -96,6 +97,8 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 
 		try {
 			flowReceiverContainer = new FlowReceiverContainer(jcsmpSession, queueName, endpointProperties);
+			flowReceiverContainer.setRebindWaitTimeout(consumerProperties.getExtension().getFlowPreRebindWaitTimeout(),
+					TimeUnit.MILLISECONDS);
 			flowReceiverContainer.bind();
 		} catch (JCSMPException e) {
 			String msg = String.format("Unable to get a message consumer for session %s", jcsmpSession.getSessionName());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -2,9 +2,12 @@ package com.solace.spring.cloud.stream.binder.properties;
 
 import com.solacesystems.jcsmp.EndpointProperties;
 
+import java.util.concurrent.TimeUnit;
+
 public class SolaceConsumerProperties extends SolaceCommonProperties {
 	private String anonymousGroupPostfix = "anon";
 	private int polledConsumerWaitTimeInMillis = 100;
+	private long flowPreRebindWaitTimeout = TimeUnit.SECONDS.toMillis(10);
 
 	private String[] queueAdditionalSubscriptions = new String[0];
 	private boolean useGroupNameInQueueName = true;
@@ -41,6 +44,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setPolledConsumerWaitTimeInMillis(int polledConsumerWaitTimeInMillis) {
 		this.polledConsumerWaitTimeInMillis = polledConsumerWaitTimeInMillis;
+	}
+
+	public long getFlowPreRebindWaitTimeout() {
+		return flowPreRebindWaitTimeout;
+	}
+
+	public void setFlowPreRebindWaitTimeout(long flowPreRebindWaitTimeout) {
+		this.flowPreRebindWaitTimeout = flowPreRebindWaitTimeout;
 	}
 
 	public String[] getQueueAdditionalSubscriptions() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/MessageContainer.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/MessageContainer.java
@@ -4,16 +4,20 @@ import com.solacesystems.jcsmp.BytesXMLMessage;
 
 import java.util.StringJoiner;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public class MessageContainer {
 	private final UUID id = UUID.randomUUID();
 	private final BytesXMLMessage message;
 	private final UUID flowReceiverReferenceId;
+	private final AtomicBoolean staleFlag;
 	private boolean acknowledged;
 
-	MessageContainer(BytesXMLMessage message, UUID flowReceiverReferenceId) {
+	MessageContainer(BytesXMLMessage message, UUID flowReceiverReferenceId, AtomicBoolean staleFlag) {
 		this.message = message;
 		this.flowReceiverReferenceId = flowReceiverReferenceId;
+		this.staleFlag = staleFlag;
 	}
 
 	public UUID getId() {
@@ -30,6 +34,10 @@ public class MessageContainer {
 
 	public boolean isAcknowledged() {
 		return acknowledged;
+	}
+
+	public boolean isStale() {
+		return staleFlag.get();
 	}
 
 	void setAcknowledged(boolean acknowledged) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceStaleMessageException.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceStaleMessageException.java
@@ -1,0 +1,7 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+public class SolaceStaleMessageException extends Exception {
+	public SolaceStaleMessageException(String message) {
+		super(message);
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandlerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandlerTest.java
@@ -1,0 +1,136 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.acks.AcknowledgmentCallback;
+import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.MessageBuilder;
+
+public class SolaceErrorMessageHandlerTest {
+	@Rule
+	public MockitoRule initRule = MockitoJUnit.rule();
+
+	@Mock
+	JCSMPAcknowledgementCallbackFactory.JCSMPAcknowledgementCallback acknowledgementCallback;
+
+	SolaceMessageHeaderErrorMessageStrategy errorMessageStrategy = new SolaceMessageHeaderErrorMessageStrategy();
+	SolaceErrorMessageHandler errorMessageHandler;
+	AttributeAccessor attributeAccessor;
+
+	@Before
+	public void setup() {
+		errorMessageHandler = new SolaceErrorMessageHandler();
+		attributeAccessor = ErrorMessageUtils.getAttributeAccessor(null, null);
+	}
+
+	@Test
+	public void testHandleAcknowledgmentCallback() {
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+				.build();
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new MessagingException(inputMessage),
+				attributeAccessor);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+
+	@Test
+	public void testNoFailedMessage() {
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new MessagingException("test"),
+				attributeAccessor);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback, Mockito.never()).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+
+	@Test
+	public void testNonMessagingException() {
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+				.build();
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new RuntimeException("test"),
+				attributeAccessor);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+
+	@Test
+	public void testMessagingExceptionContainingDifferentFailedMessage() {
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+				.build();
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY,
+				MessageBuilder.withPayload("some-other-message").build());
+
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new MessagingException(inputMessage),
+				attributeAccessor);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+
+	@Test
+	public void testMessagingExceptionWithNullFailedMessage() {
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+				.build();
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new MessagingException("test"),
+				attributeAccessor);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+
+	@Test
+	public void testStaleException() {
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+				.build();
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new MessagingException(inputMessage, new SolaceStaleMessageException("test")),
+				attributeAccessor);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback, Mockito.never()).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+
+	@Test
+	public void testStaleMessage() {
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+				.build();
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
+				new MessagingException(inputMessage),
+				attributeAccessor);
+
+		Mockito.doThrow(new SolaceAcknowledgmentException("ack-error", new SolaceStaleMessageException("stale")))
+				.when(acknowledgementCallback)
+				.acknowledge(AcknowledgmentCallback.Status.REJECT);
+
+		errorMessageHandler.handleMessage(errorMessage);
+		Mockito.verify(acknowledgementCallback).acknowledge(AcknowledgmentCallback.Status.REJECT);
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -84,7 +84,7 @@ public class SolaceMessageChannelBinder
 													 ExtendedConsumerProperties<SolaceConsumerProperties> properties) {
 		JCSMPInboundChannelAdapter adapter = new JCSMPInboundChannelAdapter(destination, jcsmpSession,
 				properties.getConcurrency(), provisioningProvider.hasTemporaryQueue(destination),
-				getConsumerEndpointProperties(properties));
+				properties.getExtension(), getConsumerEndpointProperties(properties));
 
 		adapter.setRemoteStopFlag(consumersRemoteStopFlag);
 		adapter.setPostStart(getConsumerPostStart(properties));


### PR DESCRIPTION
* Add `flowPreRebindWaitTimeout` consumer config option (from #36)
* Better document how to handle acknowledgment exceptions, since this will likely cause things to throw `SolaceStaleMessageException` when doing async acknowledgments.
* Add test to make sure messages cannot be received during the pre-rebind stage