### PR TITLE
use generic sourceData header instead of solace_scst_rawMessage header

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -512,14 +512,6 @@ TIP: Use link:../../solace-spring-cloud-stream-binder/solace-spring-cloud-stream
 | 1
 | A static number set by the publisher to indicate the Spring Cloud Stream Solace message version.
 
-| solace_scst_rawMessage
-| XMLMessage
-| Read
-|
-| The raw Solace message.
-
-*[.underline]#WARNING#:* *DO NOT* acknowledge this or make any other lasting changes. This should only be used for debugging.
-
 | solace_scst_serializedPayload
 | Boolean
 | Internal Binder Use Only

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -137,7 +137,7 @@ abstract class InboundXMLMessageListener implements Runnable {
 		messageConsumer.accept(message);
 	}
 
-	void setAttributesIfNecessary(XMLMessage xmlMessage, org.springframework.messaging.Message<?> message) {
+	void setAttributesIfNecessary(XMLMessage xmlMessage, Message<?> message) {
 		if (needHolder) {
 			attributesHolder.set(ErrorMessageUtils.getAttributeAccessor(null, null));
 		}
@@ -146,7 +146,7 @@ abstract class InboundXMLMessageListener implements Runnable {
 			AttributeAccessor attributes = attributesHolder.get();
 			if (attributes != null) {
 				attributes.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, message);
-				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE, xmlMessage);
+				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_RAW_MESSAGE, xmlMessage);
 			}
 		}
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
@@ -1,7 +1,5 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
-import com.solacesystems.jcsmp.XMLMessage;
-
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -9,7 +7,6 @@ import java.util.stream.Stream;
 public class SolaceBinderHeaderMeta<T> implements HeaderMeta<T> {
 	public static final Map<String, SolaceBinderHeaderMeta<?>> META = Stream.of(new Object[][] {
 			{SolaceBinderHeaders.MESSAGE_VERSION, new SolaceBinderHeaderMeta<>(Integer.class, true, false, Scope.WIRE)},
-			{SolaceBinderHeaders.RAW_MESSAGE, new SolaceBinderHeaderMeta<>(XMLMessage.class, true, false, Scope.LOCAL)},
 			{SolaceBinderHeaders.SERIALIZED_PAYLOAD, new SolaceBinderHeaderMeta<>(Boolean.class, false, false, Scope.WIRE)},
 			{SolaceBinderHeaders.SERIALIZED_HEADERS, new SolaceBinderHeaderMeta<>(String.class, false, false, Scope.WIRE)},
 			{SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, new SolaceBinderHeaderMeta<>(String.class, false, false, Scope.WIRE)}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
@@ -1,6 +1,5 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
-import com.solacesystems.jcsmp.XMLMessage;
 import org.springframework.messaging.Message;
 
 /**
@@ -31,16 +30,6 @@ public final class SolaceBinderHeaders {
 	 * <p>A static number set by the publisher to indicate the Spring Cloud Stream Solace message version.</p>
 	 */
 	public static final String MESSAGE_VERSION = PREFIX + "messageVersion";
-
-	/**
-	 * <p><b>Acceptable Value Type:</b> {@link XMLMessage}</p>
-	 * <p><b>Access:</b> Read</p>
-	 * <br>
-	 * <p>The raw Solace message.</p>
-	 * <p><b><u>WARNING</u>:</b> <b>DO NOT</b> acknowledge this or make any other lasting changes.
-	 * This should only be used for debugging.</p>
-	 */
-	public static final String RAW_MESSAGE = PREFIX + "rawMessage";
 
 	/**
 	 * <p><b>Acceptable Value Type:</b> {@link Boolean}</p>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandler.java
@@ -1,6 +1,5 @@
 package com.solace.spring.cloud.stream.binder.util;
 
-import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solacesystems.jcsmp.XMLMessage;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
@@ -57,12 +56,10 @@ public class SolaceErrorMessageHandler implements MessageHandler {
 		UUID failedSpringId = failedMsg.getHeaders().getId();
 		logger.info(String.format("Spring message %s contains failed Spring message %s", springId, failedSpringId));
 
-		if (message.getHeaders().containsKey(SolaceBinderHeaders.RAW_MESSAGE)) {
-			XMLMessage rawMessage = (XMLMessage) message.getHeaders().get(SolaceBinderHeaders.RAW_MESSAGE);
-			if (rawMessage != null) {
-				logger.info(String.format("Spring message %s contains raw %s %s",
-						springId, XMLMessage.class.getSimpleName(), rawMessage.getMessageId()));
-			}
+		Object sourceData = StaticMessageHeaderAccessor.getSourceData(message);
+		if (sourceData instanceof XMLMessage) {
+			logger.info(String.format("Spring message %s contains raw %s %s",
+					springId, XMLMessage.class.getSimpleName(), ((XMLMessage) sourceData).getMessageId()));
 		}
 
 		AcknowledgmentCallback acknowledgmentCallback = StaticMessageHeaderAccessor.getAcknowledgmentCallback(failedMsg);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
@@ -1,30 +1,30 @@
 package com.solace.spring.cloud.stream.binder.util;
 
-import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class SolaceMessageHeaderErrorMessageStrategy implements ErrorMessageStrategy {
-	public static final String SOLACE_RAW_MESSAGE = SolaceBinderHeaders.RAW_MESSAGE;
+	public static final String ATTR_SOLACE_RAW_MESSAGE = "solace_sourceData";
 
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor attributeAccessor) {
 		Object inputMessage;
-		Map<String, Object> headers;
+		Map<String, Object> headers = new HashMap<>();
 		if (attributeAccessor == null) {
 			inputMessage = null;
-			headers = new HashMap<>();
 		} else {
 			inputMessage = attributeAccessor.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
-			headers = Collections.singletonMap(SolaceBinderHeaders.RAW_MESSAGE,
-					attributeAccessor.getAttribute(SOLACE_RAW_MESSAGE));
+			Object sourceData = attributeAccessor.getAttribute(ATTR_SOLACE_RAW_MESSAGE);
+			if (sourceData != null) {
+				headers.put(IntegrationMessageHeaderAccessor.SOURCE_DATA, sourceData);
+			}
 		}
 		return inputMessage instanceof Message ? new ErrorMessage(throwable, headers, (Message<?>) inputMessage) :
 				new ErrorMessage(throwable, headers);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -215,7 +215,7 @@ public class XMLMessageMapper {
 		}
 
 		if (setRawMessageHeader) {
-			builder.setHeader(SolaceBinderHeaders.RAW_MESSAGE, xmlMessage);
+			builder.setHeader(IntegrationMessageHeaderAccessor.SOURCE_DATA, xmlMessage);
 		}
 
 		return builder.build();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -347,7 +347,6 @@ public class XMLMessageMapperTest {
 				case SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING:
 					assertEquals("base64", xmlMessage.getProperties().getString(header.getKey()));
 					break;
-				case SolaceBinderHeaders.RAW_MESSAGE:
 				case SolaceBinderHeaders.SERIALIZED_PAYLOAD:
 					assertNull(xmlMessage.getProperties().get(header.getKey()));
 					break;
@@ -777,7 +776,7 @@ public class XMLMessageMapperTest {
 		assertEquals(expectedPayload, springMessage.getPayload());
 		validateSpringMessage(springMessage, xmlMessage);
 
-		assertEquals(xmlMessage, springMessage.getHeaders().get(SolaceBinderHeaders.RAW_MESSAGE));
+		assertEquals(xmlMessage, StaticMessageHeaderAccessor.getSourceData(springMessage));
 	}
 
 	@Test
@@ -942,9 +941,6 @@ public class XMLMessageMapperTest {
 				case SolaceBinderHeaders.MESSAGE_VERSION:
 					assertEquals(xmlMessage.getProperties().get(header.getKey()), actualValue);
 					break;
-				case SolaceBinderHeaders.RAW_MESSAGE:
-					assertNull(actualValue);
-					break;
 				default:
 					fail(String.format("no test for header %s", header.getKey()));
 			}
@@ -1013,7 +1009,7 @@ public class XMLMessageMapperTest {
 				.filter(h -> h.getValue().isReadable())
 				.filter(h -> HeaderMeta.Scope.LOCAL.equals(h.getValue().getScope()))
 				.collect(Collectors.toSet());
-		assertNotEquals("Test header set was empty", 0, readableLocalHeaders.size());
+//		assertNotEquals("Test header set was empty", 0, readableLocalHeaders.size());
 
 		TextMessage xmlMessage = Mockito.mock(TextMessage.class);
 		SDTMap metadata = JCSMPFactory.onlyInstance().createMap();
@@ -1032,13 +1028,7 @@ public class XMLMessageMapperTest {
 		Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false);
 
 		for (Map.Entry<String, ? extends HeaderMeta<?>> header : readableLocalHeaders) {
-			switch (header.getKey()) {
-				case SolaceBinderHeaders.RAW_MESSAGE:
-					assertThat(springMessage.getHeaders(), not(hasKey(header)));
-					break;
-				default:
-					fail(String.format("no test for header %s", header.getKey()));
-			}
+			fail(String.format("no test for header %s", header.getKey()));
 		}
 
 		SDTMap filteredMetadata = JCSMPFactory.onlyInstance().createMap();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -2,7 +2,6 @@ package com.solace.spring.cloud.stream.binder;
 
 import com.solace.spring.cloud.stream.binder.inbound.JCSMPInboundChannelAdapter;
 import com.solace.spring.cloud.stream.binder.inbound.JCSMPMessageSource;
-import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.outbound.JCSMPOutboundMessageHandler;
 import com.solace.spring.cloud.stream.binder.util.ErrorQueueInfrastructure;
 import com.solace.spring.cloud.stream.binder.util.JCSMPSessionProducerManager;
@@ -12,6 +11,7 @@ import com.solace.spring.cloud.stream.binder.util.SolaceProvisioningUtil;
 import com.solacesystems.jcsmp.EndpointProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.Queue;
+import com.solacesystems.jcsmp.XMLMessage;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
@@ -25,6 +25,7 @@ import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties
 import com.solace.spring.cloud.stream.binder.provisioning.SolaceQueueProvisioner;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.support.DefaultErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageStrategy;
@@ -137,11 +138,9 @@ public class SolaceMessageChannelBinder
 	@Override
 	protected void postProcessPollableSource(DefaultPollableMessageSource bindingTarget) {
 		bindingTarget.setAttributesProvider((accessor, message) -> {
-			if (message.getHeaders().containsKey(SolaceBinderHeaders.RAW_MESSAGE)) {
-				Object rawMessage = message.getHeaders().get(SolaceBinderHeaders.RAW_MESSAGE);
-				if (rawMessage != null) {
-					accessor.setAttribute(SolaceMessageHeaderErrorMessageStrategy.SOLACE_RAW_MESSAGE, rawMessage);
-				}
+			Object sourceData = StaticMessageHeaderAccessor.getSourceData(message);
+			if (sourceData == null || sourceData instanceof XMLMessage) {
+				accessor.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_RAW_MESSAGE, sourceData);
 			}
 		});
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
@@ -1,13 +1,11 @@
 package com.solace.spring.cloud.stream.binder;
 
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
-import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
 import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredRunner;
 import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
 import com.solace.spring.cloud.stream.binder.util.SolaceErrorMessageHandler;
-import com.solace.spring.cloud.stream.binder.util.SolaceMessageHeaderErrorMessageStrategy;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.XMLMessage;
 import org.assertj.core.api.SoftAssertions;
@@ -18,6 +16,7 @@ import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.PollableSource;
 import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -243,7 +242,7 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		softAssertions.assertThat(errorMessage).isInstanceOf(ErrorMessage.class);
 		softAssertions.assertThat(((ErrorMessage) errorMessage).getOriginalMessage()).isNotNull();
 		softAssertions.assertThat(((ErrorMessage) errorMessage).getPayload()).isNotNull();
-		softAssertions.assertThat(errorMessage.getHeaders()
-				.get(SolaceBinderHeaders.RAW_MESSAGE)).isInstanceOf(XMLMessage.class);
+		softAssertions.assertThat((Object) StaticMessageHeaderAccessor.getSourceData(errorMessage))
+				.isInstanceOf(XMLMessage.class);
 	}
 }


### PR DESCRIPTION
* remove the `solace_scst_rawMessage` header in favor for Spring's generic `sourceData` header (#54)