### PR TITLE
Prevent polled consumers from throwing exceptions during shutdown

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -121,6 +121,7 @@ public class SolaceMessageChannelBinder
 		JCSMPMessageSource messageSource = new JCSMPMessageSource(destination, jcsmpSession, consumerProperties,
 				endpointProperties, provisioningProvider.hasTemporaryQueue(destination));
 
+		messageSource.setRemoteStopFlag(consumersRemoteStopFlag::get);
 		messageSource.setPostStart(getConsumerPostStart(consumerProperties));
 
 		if (consumerProperties.getExtension().isAutoBindErrorQueue()) {


### PR DESCRIPTION
* add locks and remote-shutdown-flag to fix polled-consumer shutdown errors, and to instead just return `null`