### PR TITLE
Fix null payload error handling

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -124,7 +124,7 @@ abstract class InboundXMLMessageListener implements Runnable {
 	}
 
 	Message<?> createMessage(BytesXMLMessage bytesXMLMessage, AcknowledgmentCallback acknowledgmentCallback) {
-		setAttributesIfNecessary(bytesXMLMessage, null);
+		setAttributesIfNecessary(bytesXMLMessage, acknowledgmentCallback);
 		return xmlMessageMapper.map(bytesXMLMessage, acknowledgmentCallback);
 	}
 
@@ -137,7 +137,16 @@ abstract class InboundXMLMessageListener implements Runnable {
 		messageConsumer.accept(message);
 	}
 
+	void setAttributesIfNecessary(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback) {
+		setAttributesIfNecessary(xmlMessage, null, acknowledgmentCallback);
+	}
+
 	void setAttributesIfNecessary(XMLMessage xmlMessage, Message<?> message) {
+		setAttributesIfNecessary(xmlMessage, message, null);
+	}
+
+	private void setAttributesIfNecessary(XMLMessage xmlMessage, Message<?> message,
+								  AcknowledgmentCallback acknowledgmentCallback) {
 		if (needHolder) {
 			attributesHolder.set(ErrorMessageUtils.getAttributeAccessor(null, null));
 		}
@@ -147,6 +156,8 @@ abstract class InboundXMLMessageListener implements Runnable {
 			if (attributes != null) {
 				attributes.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, message);
 				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_RAW_MESSAGE, xmlMessage);
+				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_ACKNOWLEDGMENT_CALLBACK,
+						acknowledgmentCallback);
 			}
 		}
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueInfrastructure.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueInfrastructure.java
@@ -1,12 +1,12 @@
 package com.solace.spring.cloud.stream.binder.util;
 
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solacesystems.jcsmp.BytesXMLMessage;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.XMLMessage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 
 public class ErrorQueueInfrastructure {
@@ -26,7 +26,7 @@ public class ErrorQueueInfrastructure {
 		this.consumerProperties = consumerProperties;
 	}
 
-	public void send(Message<?> message) {
+	public void send(BytesXMLMessage message) {
 		XMLMessage xmlMessage = xmlMessageMapper.mapError(message, consumerProperties);
 		try {
 			Queue queue = JCSMPFactory.onlyInstance().createQueue(errorQueueName);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
@@ -5,7 +5,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.lang.Nullable;
-import org.springframework.messaging.Message;
 
 public class JCSMPAcknowledgementCallbackFactory {
 	private final FlowReceiverContainer flowReceiverContainer;
@@ -31,7 +30,6 @@ public class JCSMPAcknowledgementCallbackFactory {
 		private final FlowReceiverContainer flowReceiverContainer;
 		private final boolean hasTemporaryQueue;
 		private final ErrorQueueInfrastructure errorQueueInfrastructure;
-		private final XMLMessageMapper xmlMessageMapper = new XMLMessageMapper();
 		private boolean autoAckEnabled = true;
 
 		private static final Log logger = LogFactory.getLog(JCSMPAcknowledgementCallback.class);
@@ -112,8 +110,7 @@ public class JCSMPAcknowledgementCallbackFactory {
 						errorQueueInfrastructure.getErrorQueueName()));
 			}
 
-			Message<?> springMessage = xmlMessageMapper.map(messageContainer.getMessage(), null);
-			errorQueueInfrastructure.send(springMessage);
+			errorQueueInfrastructure.send(messageContainer.getMessage());
 			flowReceiverContainer.acknowledge(messageContainer); //TODO do in the pub ack or timeout and retry
 			return true;
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceMessageHeaderErrorMessageStrategy.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class SolaceMessageHeaderErrorMessageStrategy implements ErrorMessageStrategy {
 	public static final String ATTR_SOLACE_RAW_MESSAGE = "solace_sourceData";
+	public static final String ATTR_SOLACE_ACKNOWLEDGMENT_CALLBACK = "solace_acknowledgmentCallback";
 
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor attributeAccessor) {
@@ -24,6 +25,10 @@ public class SolaceMessageHeaderErrorMessageStrategy implements ErrorMessageStra
 			Object sourceData = attributeAccessor.getAttribute(ATTR_SOLACE_RAW_MESSAGE);
 			if (sourceData != null) {
 				headers.put(IntegrationMessageHeaderAccessor.SOURCE_DATA, sourceData);
+			}
+			Object ackCallback = attributeAccessor.getAttribute(ATTR_SOLACE_ACKNOWLEDGMENT_CALLBACK);
+			if (ackCallback != null) {
+				headers.put(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, ackCallback);
 			}
 		}
 		return inputMessage instanceof Message ? new ErrorMessage(throwable, headers, (Message<?>) inputMessage) :

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -10,6 +10,7 @@ import com.solace.spring.cloud.stream.binder.messaging.SolaceHeaderMeta;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solacesystems.common.util.ByteArray;
 import com.solacesystems.jcsmp.BytesMessage;
+import com.solacesystems.jcsmp.BytesXMLMessage;
 import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.MapMessage;
@@ -55,15 +56,15 @@ public class XMLMessageMapper {
 	private final ObjectWriter stringSetWriter = OBJECT_MAPPER.writerFor(new TypeReference<Set<String>>(){});
 	private final ObjectReader stringSetReader = OBJECT_MAPPER.readerFor(new TypeReference<Set<String>>(){});
 
-	public XMLMessage mapError(Message<?> message, SolaceConsumerProperties consumerProperties) {
-		XMLMessage xmlMessage = map(message, Collections.emptyList(), false);
+	public BytesXMLMessage mapError(BytesXMLMessage inputMessage, SolaceConsumerProperties consumerProperties) {
+		BytesXMLMessage errorMessage = JCSMPFactory.onlyInstance().createMessage(inputMessage);
 		if (consumerProperties.getErrorMsgDmqEligible() != null) {
-			xmlMessage.setDMQEligible(consumerProperties.getErrorMsgDmqEligible());
+			errorMessage.setDMQEligible(consumerProperties.getErrorMsgDmqEligible());
 		}
 		if (consumerProperties.getErrorMsgTtl() != null) {
-			xmlMessage.setTimeToLive(consumerProperties.getErrorMsgTtl());
+			errorMessage.setTimeToLive(consumerProperties.getErrorMsgTtl());
 		}
-		return xmlMessage;
+		return errorMessage;
 	}
 
 	public XMLMessage map(Message<?> message, Collection<String> excludedHeaders, boolean convertNonSerializableHeadersToString) {


### PR DESCRIPTION
Fixes #54

* Use JCSMP's clone feature to clone the message for republishing to the error queue
* Fix REJECT acknowledgment when receiving messages with no payload
  * does not send ErrorMessage to error channel for polled consumers due to SCSt limitations