### PR TITLE
Add Error Handling for the Error Handing

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -220,7 +220,7 @@ Naming postfix for the anonymous consumer group queue.
 Default: `"anon"`
 
 polledConsumerWaitTimeInMillis::
-Rate at which polled consumers will receive messages from their consumer group queue.
+Maximum wait time for polled consumers to receive a message from their consumer group queue.
 +
 Default: `100`
 
@@ -252,6 +252,11 @@ Whether to include the `group` name in the error queue name for non-anonymous co
 Default: `true`
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will republish failed messages to the same error queue regardless of their configured `group` names.
+
+errorQueueMaxDeliveryAttempts::
+Maximum number of attempts to send a failed message to the error queue. When all delivery attempts have been exhausted, the failed message will be requeued.
++
+Default: `3`
 
 errorQueueAccessType::
 Access type for the error queue.

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -16,9 +16,11 @@ import com.solacesystems.jcsmp.XMLMessage;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.stream.binder.RequeueCurrentMessageException;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
+import org.springframework.integration.acks.AckUtils;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.lang.Nullable;
@@ -110,10 +112,22 @@ abstract class InboundXMLMessageListener implements Runnable {
 		try {
 			handleMessage(bytesXMLMessage, acknowledgmentCallback);
 		} catch (SolaceAcknowledgmentException e) {
-			if (ExceptionUtils.indexOfType(e, SolaceStaleMessageException.class) > -1) {
-				logger.warn(String.format("Cannot acknowledge stale XMLMessage %s", bytesXMLMessage.getMessageId()), e);
-			} else {
-				throw e;
+			swallowStaleException(e, bytesXMLMessage);
+		} catch (Exception e) {
+			try {
+				if (ExceptionUtils.indexOfType(e, RequeueCurrentMessageException.class) > -1) {
+					logger.warn(String.format(
+							"Exception thrown while processing XMLMessage %s. Message will be requeued.",
+							bytesXMLMessage.getMessageId()), e);
+					AckUtils.requeue(acknowledgmentCallback);
+				} else {
+					logger.warn(String.format(
+							"Exception thrown while processing XMLMessage %s. Message will be rejected.",
+							bytesXMLMessage.getMessageId()), e);
+					AckUtils.reject(acknowledgmentCallback);
+				}
+			} catch (SolaceAcknowledgmentException e1) {
+				swallowStaleException(e1, bytesXMLMessage);
 			}
 		} finally {
 			if (needHolder) {
@@ -158,6 +172,14 @@ abstract class InboundXMLMessageListener implements Runnable {
 				attributes.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_ACKNOWLEDGMENT_CALLBACK,
 						acknowledgmentCallback);
 			}
+		}
+	}
+
+	private void swallowStaleException(SolaceAcknowledgmentException e, BytesXMLMessage bytesXMLMessage) {
+		if (ExceptionUtils.indexOfType(e, SolaceStaleMessageException.class) > -1) {
+			logger.info(String.format("Cannot acknowledge stale XMLMessage %s", bytesXMLMessage.getMessageId()), e);
+		} else {
+			throw e;
 		}
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -6,6 +6,7 @@ import com.solace.spring.cloud.stream.binder.util.MessageContainer;
 import com.solace.spring.cloud.stream.binder.util.SolaceAcknowledgmentException;
 import com.solace.spring.cloud.stream.binder.util.SolaceMessageHeaderErrorMessageStrategy;
 import com.solace.spring.cloud.stream.binder.util.SolaceStaleMessageException;
+import com.solace.spring.cloud.stream.binder.util.UnboundFlowReceiverContainerException;
 import com.solace.spring.cloud.stream.binder.util.XMLMessageMapper;
 import com.solacesystems.jcsmp.BytesXMLMessage;
 import com.solacesystems.jcsmp.ClosedFacilityException;
@@ -68,9 +69,7 @@ abstract class InboundXMLMessageListener implements Runnable {
 			while (keepPolling()) {
 				try {
 					receive();
-				} catch (RuntimeException e) {
-					// Shouldn't ever come in here.
-					// Doing this just in case since the message consumers shouldn't ever stop unless interrupted.
+				} catch (RuntimeException | UnboundFlowReceiverContainerException e) {
 					logger.warn(String.format("Exception received while consuming messages from destination %s",
 							consumerDestination.getName()), e);
 				}
@@ -85,7 +84,7 @@ abstract class InboundXMLMessageListener implements Runnable {
 		return !stopFlag.get() && !remoteStopFlag.get();
 	}
 
-	public void receive() {
+	private void receive() throws UnboundFlowReceiverContainerException {
 		MessageContainer messageContainer;
 
 		try {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -17,6 +17,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	private boolean provisionErrorQueue = true;
 	private String errorQueueNameOverride = null;
 	private boolean useGroupNameInErrorQueueName = true;
+	private long errorQueueMaxDeliveryAttempts = 3;
 
 	private int errorQueueAccessType = EndpointProperties.ACCESSTYPE_NONEXCLUSIVE;
 	private int errorQueuePermission = EndpointProperties.PERMISSION_CONSUME;
@@ -100,6 +101,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setUseGroupNameInErrorQueueName(boolean useGroupNameInErrorQueueName) {
 		this.useGroupNameInErrorQueueName = useGroupNameInErrorQueueName;
+	}
+
+	public long getErrorQueueMaxDeliveryAttempts() {
+		return errorQueueMaxDeliveryAttempts;
+	}
+
+	public void setErrorQueueMaxDeliveryAttempts(long errorQueueMaxDeliveryAttempts) {
+		this.errorQueueMaxDeliveryAttempts = errorQueueMaxDeliveryAttempts;
 	}
 
 	public int getErrorQueueAccessType() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueInfrastructure.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueInfrastructure.java
@@ -1,10 +1,11 @@
 package com.solace.spring.cloud.stream.binder.util;
 
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
-import com.solacesystems.jcsmp.BytesXMLMessage;
+import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.XMLMessage;
+import com.solacesystems.jcsmp.XMLMessageProducer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.messaging.MessagingException;
@@ -14,32 +15,50 @@ public class ErrorQueueInfrastructure {
 	private final String producerKey;
 	private final String errorQueueName;
 	private final SolaceConsumerProperties consumerProperties;
+	private final RetryableTaskService retryableTaskService;
 	private final XMLMessageMapper xmlMessageMapper = new XMLMessageMapper();
 
 	private static final Log logger = LogFactory.getLog(ErrorQueueInfrastructure.class);
 
 	public ErrorQueueInfrastructure(JCSMPSessionProducerManager producerManager, String producerKey,
-									String errorQueueName, SolaceConsumerProperties consumerProperties) {
+									String errorQueueName, SolaceConsumerProperties consumerProperties,
+									RetryableTaskService retryableTaskService) {
 		this.producerManager = producerManager;
 		this.producerKey = producerKey;
 		this.errorQueueName = errorQueueName;
 		this.consumerProperties = consumerProperties;
+		this.retryableTaskService = retryableTaskService;
 	}
 
-	public void send(BytesXMLMessage message) {
-		XMLMessage xmlMessage = xmlMessageMapper.mapError(message, consumerProperties);
+	public void send(MessageContainer messageContainer, ErrorQueueRepublishCorrelationKey key) throws JCSMPException {
+		XMLMessage xmlMessage = xmlMessageMapper.mapError(messageContainer.getMessage(), consumerProperties);
+		xmlMessage.setCorrelationKey(key);
+		Queue queue = JCSMPFactory.onlyInstance().createQueue(errorQueueName);
+		XMLMessageProducer producer;
 		try {
-			Queue queue = JCSMPFactory.onlyInstance().createQueue(errorQueueName);
-			producerManager.get(producerKey).send(xmlMessage, queue);
+			producer = producerManager.get(producerKey);
 		} catch (Exception e) {
-			String msg = String.format("Failed to send message %s to queue %s", xmlMessage.getMessageId(),
-					errorQueueName);
+			String msg = String.format("Failed to get producer to send message %s to queue %s",
+					xmlMessage.getMessageId(), errorQueueName);
 			logger.warn(msg, e);
 			throw new MessagingException(msg, e);
 		}
+
+		producer.send(xmlMessage, queue);
+	}
+
+	public ErrorQueueRepublishCorrelationKey createCorrelationKey(MessageContainer messageContainer,
+																  FlowReceiverContainer flowReceiverContainer,
+																  boolean hasTemporaryQueue) {
+		return new ErrorQueueRepublishCorrelationKey(this, messageContainer, flowReceiverContainer,
+				hasTemporaryQueue, retryableTaskService);
 	}
 
 	public String getErrorQueueName() {
 		return errorQueueName;
+	}
+
+	public long getMaxDeliveryAttempts() {
+		return consumerProperties.getErrorQueueMaxDeliveryAttempts();
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
@@ -67,7 +67,7 @@ public class ErrorQueueRepublishCorrelationKey {
 					"Exceeded max error queue delivery attempts. XMLMessage %s will be re-queued onto queue %s",
 					messageContainer.getMessage().getMessageId(), flowReceiverContainer.getQueueName()));
 
-			RetryableRebindTask rebindTask = new RetryableRebindTask(flowReceiverContainer, messageContainer,
+			RetryableAckRebindTask rebindTask = new RetryableAckRebindTask(flowReceiverContainer, messageContainer,
 					retryableTaskService);
 			try {
 				if (skipSyncAttempt || !rebindTask.run(0)) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
@@ -1,0 +1,94 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.XMLMessage;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class ErrorQueueRepublishCorrelationKey {
+	private final ErrorQueueInfrastructure errorQueueInfrastructure;
+	private final MessageContainer messageContainer;
+	private final FlowReceiverContainer flowReceiverContainer;
+	private final boolean hasTemporaryQueue;
+	private final RetryableTaskService retryableTaskService;
+	private long errorQueueDeliveryAttempt = 0;
+
+	private static final Log logger = LogFactory.getLog(ErrorQueueRepublishCorrelationKey.class);
+
+	public ErrorQueueRepublishCorrelationKey(ErrorQueueInfrastructure errorQueueInfrastructure,
+											 MessageContainer messageContainer,
+											 FlowReceiverContainer flowReceiverContainer,
+											 boolean hasTemporaryQueue,
+											 RetryableTaskService retryableTaskService) {
+		this.errorQueueInfrastructure = errorQueueInfrastructure;
+		this.messageContainer = messageContainer;
+		this.flowReceiverContainer = flowReceiverContainer;
+		this.hasTemporaryQueue = hasTemporaryQueue;
+		this.retryableTaskService = retryableTaskService;
+	}
+
+	public void handleSuccess() throws SolaceStaleMessageException {
+		flowReceiverContainer.acknowledge(messageContainer);
+	}
+
+	public void handleError() throws SolaceStaleMessageException {
+		while (true) {
+			if (errorQueueDeliveryAttempt >= errorQueueInfrastructure.getMaxDeliveryAttempts()) {
+				fallback();
+				break;
+			} else if (messageContainer.isStale()) {
+				throw new SolaceStaleMessageException(String.format("Message container %s (XMLMessage %s) is stale",
+						messageContainer.getId(), messageContainer.getMessage().getMessageId()));
+			} else {
+				errorQueueDeliveryAttempt++;
+				logger.info(String.format("Republishing XMLMessage %s to error queue %s - attempt %s of %s",
+						messageContainer.getMessage().getMessageId(), errorQueueInfrastructure.getErrorQueueName(),
+						errorQueueDeliveryAttempt, errorQueueInfrastructure.getMaxDeliveryAttempts()));
+				try {
+					errorQueueInfrastructure.send(messageContainer, this);
+					break;
+				} catch (JCSMPException e) {
+					logger.warn(String.format("Could not send XMLMessage %s to error queue %s",
+							messageContainer.getMessage().getMessageId(),
+							errorQueueInfrastructure.getErrorQueueName()));
+				}
+			}
+		}
+	}
+
+	private void fallback() throws SolaceStaleMessageException {
+		if (hasTemporaryQueue) {
+			logger.info(String.format(
+					"Exceeded max error queue delivery attempts and cannot requeue %s %s since this flow is " +
+							"bound to a temporary queue, failed message will be discarded",
+					XMLMessage.class.getSimpleName(), messageContainer.getMessage().getMessageId()));
+			flowReceiverContainer.acknowledge(messageContainer);
+		} else {
+			logger.info(String.format(
+					"Exceeded max error queue delivery attempts. XMLMessage %s will be re-queued onto queue %s",
+					messageContainer.getMessage().getMessageId(), flowReceiverContainer.getQueueName()));
+			retryableTaskService.submit(() -> {
+				try {
+					flowReceiverContainer.acknowledgeRebind(messageContainer);
+					return true;
+				} catch (JCSMPException e) {
+					logger.warn(String.format("failed to rebind queue %s. Will retry",
+							flowReceiverContainer.getQueueName()), e);
+					return false;
+				} catch (SolaceStaleMessageException e) {
+					// Nothing to do.
+					logger.debug(String.format("Message container %s (XMLMessage %s) is stale",
+							messageContainer.getId(), messageContainer.getMessage().getMessageId()), e);
+					return true;
+				}
+			});
+		}
+	}
+
+	public String getSourceMessageId() {
+		return messageContainer.getMessage().getMessageId();
+	}
+	public String getErrorQueueName() {
+		return errorQueueInfrastructure.getErrorQueueName();
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
@@ -1,6 +1,5 @@
 package com.solace.spring.cloud.stream.binder.util;
 
-import com.solacesystems.jcsmp.JCSMPException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -46,7 +45,7 @@ public class ErrorQueueRepublishCorrelationKey {
 				try {
 					errorQueueInfrastructure.send(messageContainer, this);
 					break;
-				} catch (JCSMPException e) {
+				} catch (Exception e) {
 					logger.warn(String.format("Could not send XMLMessage %s to error queue %s",
 							messageContainer.getMessage().getMessageId(),
 							errorQueueInfrastructure.getErrorQueueName()));

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainer.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainer.java
@@ -375,7 +375,7 @@ public class FlowReceiverContainer {
 
 	/**
 	 * Same as {@link #acknowledge(MessageContainer)}, but with the option to return immediately with if the lock
-	 * cannot be acquired.
+	 * cannot be acquired. Even if immediately returned, the message container will still be marked as acknowledged.
 	 * @param messageContainer The message.
 	 * @param returnImmediately Return {@code null} if {@code true} and the lock cannot be acquired.
 	 * @return The new flow reference ID, or the current flow reference ID if message was already acknowledge,

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
@@ -9,11 +9,14 @@ import org.springframework.lang.Nullable;
 public class JCSMPAcknowledgementCallbackFactory {
 	private final FlowReceiverContainer flowReceiverContainer;
 	private final boolean hasTemporaryQueue;
+	private final RetryableTaskService taskService;
 	private ErrorQueueInfrastructure errorQueueInfrastructure;
 
-	public JCSMPAcknowledgementCallbackFactory(FlowReceiverContainer flowReceiverContainer, boolean hasTemporaryQueue) {
+	public JCSMPAcknowledgementCallbackFactory(FlowReceiverContainer flowReceiverContainer, boolean hasTemporaryQueue,
+											   RetryableTaskService taskService) {
 		this.flowReceiverContainer = flowReceiverContainer;
 		this.hasTemporaryQueue = hasTemporaryQueue;
+		this.taskService = taskService;
 	}
 
 	public void setErrorQueueInfrastructure(ErrorQueueInfrastructure errorQueueInfrastructure) {
@@ -22,7 +25,7 @@ public class JCSMPAcknowledgementCallbackFactory {
 
 	public AcknowledgmentCallback createCallback(MessageContainer messageContainer) {
 		return new JCSMPAcknowledgementCallback(messageContainer, flowReceiverContainer, hasTemporaryQueue,
-				errorQueueInfrastructure);
+				taskService, errorQueueInfrastructure);
 	}
 
 	static class JCSMPAcknowledgementCallback implements AcknowledgmentCallback {
@@ -30,6 +33,7 @@ public class JCSMPAcknowledgementCallbackFactory {
 		private final FlowReceiverContainer flowReceiverContainer;
 		private final boolean hasTemporaryQueue;
 		private final ErrorQueueInfrastructure errorQueueInfrastructure;
+		private final RetryableTaskService taskService;
 		private boolean acknowledged = false;
 		private boolean autoAckEnabled = true;
 
@@ -37,10 +41,12 @@ public class JCSMPAcknowledgementCallbackFactory {
 
 		JCSMPAcknowledgementCallback(MessageContainer messageContainer, FlowReceiverContainer flowReceiverContainer,
 									 boolean hasTemporaryQueue,
+									 RetryableTaskService taskService,
 									 @Nullable ErrorQueueInfrastructure errorQueueInfrastructure) {
 			this.messageContainer = messageContainer;
 			this.flowReceiverContainer = flowReceiverContainer;
 			this.hasTemporaryQueue = hasTemporaryQueue;
+			this.taskService = taskService;
 			this.errorQueueInfrastructure = errorQueueInfrastructure;
 		}
 
@@ -77,11 +83,16 @@ public class JCSMPAcknowledgementCallbackFactory {
 							throw new UnsupportedOperationException(String.format(
 									"Cannot %s XMLMessage %s, this operation is not supported with temporary queues",
 									status, messageContainer.getMessage().getMessageId()));
+						} else if (messageContainer.isStale()) {
+							throw new SolaceStaleMessageException(String.format(
+									"Message container %s (XMLMessage %s) is stale",
+									messageContainer.getId(), messageContainer.getMessage().getMessageId()));
 						} else {
 							logger.info(String.format("%s %s: Will be re-queued onto queue %s",
 									XMLMessage.class.getSimpleName(), messageContainer.getMessage().getMessageId(),
 									flowReceiverContainer.getQueueName()));
-							flowReceiverContainer.acknowledgeRebind(messageContainer);
+							taskService.submit(new RetryableRebindTask(flowReceiverContainer, messageContainer,
+									taskService));
 						}
 				}
 			} catch (SolaceAcknowledgmentException e) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
@@ -91,8 +91,11 @@ public class JCSMPAcknowledgementCallbackFactory {
 							logger.info(String.format("%s %s: Will be re-queued onto queue %s",
 									XMLMessage.class.getSimpleName(), messageContainer.getMessage().getMessageId(),
 									flowReceiverContainer.getQueueName()));
-							taskService.submit(new RetryableRebindTask(flowReceiverContainer, messageContainer,
-									taskService));
+							RetryableRebindTask rebindTask = new RetryableRebindTask(flowReceiverContainer,
+									messageContainer, taskService);
+							if (!rebindTask.run(0)) {
+								taskService.submit(rebindTask);
+							}
 						}
 				}
 			} catch (SolaceAcknowledgmentException e) {
@@ -126,7 +129,7 @@ public class JCSMPAcknowledgementCallbackFactory {
 			}
 
 			errorQueueInfrastructure.createCorrelationKey(messageContainer, flowReceiverContainer, hasTemporaryQueue)
-					.handleError();
+					.handleError(false);
 			return true;
 		}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPAcknowledgementCallbackFactory.java
@@ -91,7 +91,7 @@ public class JCSMPAcknowledgementCallbackFactory {
 							logger.info(String.format("%s %s: Will be re-queued onto queue %s",
 									XMLMessage.class.getSimpleName(), messageContainer.getMessage().getMessageId(),
 									flowReceiverContainer.getQueueName()));
-							RetryableRebindTask rebindTask = new RetryableRebindTask(flowReceiverContainer,
+							RetryableAckRebindTask rebindTask = new RetryableAckRebindTask(flowReceiverContainer,
 									messageContainer, taskService);
 							if (!rebindTask.run(0)) {
 								taskService.submit(rebindTask);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
@@ -69,7 +69,7 @@ public class JCSMPSessionProducerManager extends SharedResourceManager<XMLMessag
 			} else if (correlationKey instanceof ErrorQueueRepublishCorrelationKey) {
 				ErrorQueueRepublishCorrelationKey key = (ErrorQueueRepublishCorrelationKey) correlationKey;
 				try {
-					key.handleError();
+					key.handleError(true);
 				} catch (SolaceStaleMessageException e) { // unlikely to happen
 					logger.warn(String.format("Cannot republish message %s to error queue %s. " +
 									"It was/will be redelivered on the original queue",

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableAckRebindTask.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableAckRebindTask.java
@@ -1,0 +1,77 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.JCSMPException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class RetryableAckRebindTask implements RetryableTaskService.RetryableTask {
+	private final FlowReceiverContainer flowReceiverContainer;
+	private final MessageContainer messageContainer;
+	private final RetryableTaskService taskService;
+
+	private static final Log logger = LogFactory.getLog(RetryableAckRebindTask.class);
+
+	public RetryableAckRebindTask(FlowReceiverContainer flowReceiverContainer, MessageContainer messageContainer,
+								  RetryableTaskService taskService) {
+		this.flowReceiverContainer = flowReceiverContainer;
+		this.messageContainer = messageContainer;
+		this.taskService = taskService;
+	}
+
+	@Override
+	public boolean run(int attempt) throws InterruptedException {
+		try {
+			if (flowReceiverContainer.acknowledgeRebind(messageContainer, true) != null) {
+				return true;
+			} else if (messageContainer.isAcknowledged()) {
+				taskService.submit(new RetryableRebindTask(flowReceiverContainer,
+						messageContainer.getFlowReceiverReferenceId(), taskService));
+				return true;
+			} else {
+				return false;
+			}
+		} catch (JCSMPException | UnboundFlowReceiverContainerException e) {
+			if (messageContainer.isStale() && !flowReceiverContainer.isBound()) {
+				logger.warn(String.format(
+						"failed to rebind queue %s and flow container %s is now unbound. Attempting to bind.",
+						flowReceiverContainer.getId(), flowReceiverContainer.getQueueName()), e);
+				taskService.submit(new RetryableBindTask(flowReceiverContainer));
+				return true;
+			} else {
+				logger.warn(String.format("failed to rebind flow container %s queue %s. Will retry",
+						flowReceiverContainer.getId(), flowReceiverContainer.getQueueName()), e);
+				return false;
+			}
+		} catch (SolaceStaleMessageException e) {
+			logger.info(String.format("Message container %s (XMLMessage %s) is stale and was already redelivered",
+					messageContainer.getId(), messageContainer.getMessage().getMessageId()), e);
+			return true;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", RetryableAckRebindTask.class.getSimpleName() + "[", "]")
+				.add("flowReceiverContainer=" + flowReceiverContainer.getId())
+				.add("messageContainer=" + messageContainer.getId())
+				.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RetryableAckRebindTask that = (RetryableAckRebindTask) o;
+		return Objects.equals(flowReceiverContainer, that.flowReceiverContainer) &&
+				Objects.equals(messageContainer, that.messageContainer) &&
+				Objects.equals(taskService, that.taskService);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(flowReceiverContainer, messageContainer, taskService);
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableBindTask.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableBindTask.java
@@ -10,7 +10,7 @@ import java.util.StringJoiner;
 public class RetryableBindTask implements RetryableTaskService.RetryableTask {
 	private final FlowReceiverContainer flowReceiverContainer;
 
-	private static final Log logger = LogFactory.getLog(RetryableRebindTask.class);
+	private static final Log logger = LogFactory.getLog(RetryableBindTask.class);
 
 	public RetryableBindTask(FlowReceiverContainer flowReceiverContainer) {
 		this.flowReceiverContainer = flowReceiverContainer;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableBindTask.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableBindTask.java
@@ -1,0 +1,49 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.JCSMPException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class RetryableBindTask implements RetryableTaskService.RetryableTask {
+	private final FlowReceiverContainer flowReceiverContainer;
+
+	private static final Log logger = LogFactory.getLog(RetryableRebindTask.class);
+
+	public RetryableBindTask(FlowReceiverContainer flowReceiverContainer) {
+		this.flowReceiverContainer = flowReceiverContainer;
+	}
+
+	@Override
+	public boolean run(int attempt) {
+		try {
+			flowReceiverContainer.bind();
+			return true;
+		} catch (JCSMPException e) {
+			logger.warn(String.format("failed to bind queue %s. Will retry", flowReceiverContainer.getQueueName()), e);
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", RetryableBindTask.class.getSimpleName() + "[", "]")
+				.add("flowReceiverContainer=" + flowReceiverContainer.getId())
+				.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RetryableBindTask that = (RetryableBindTask) o;
+		return Objects.equals(flowReceiverContainer.getId(), that.flowReceiverContainer.getId());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(flowReceiverContainer);
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTask.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTask.java
@@ -24,8 +24,7 @@ public class RetryableRebindTask implements RetryableTaskService.RetryableTask {
 	@Override
 	public boolean run(int attempt) throws InterruptedException {
 		try {
-			flowReceiverContainer.acknowledgeRebind(messageContainer);
-			return true;
+			return flowReceiverContainer.acknowledgeRebind(messageContainer, true) != null;
 		} catch (JCSMPException | UnboundFlowReceiverContainerException e) {
 			if (messageContainer.isStale() && !flowReceiverContainer.isBound()) {
 				logger.warn(String.format(

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTask.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTask.java
@@ -6,27 +6,27 @@ import org.apache.commons.logging.LogFactory;
 
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.UUID;
 
 public class RetryableRebindTask implements RetryableTaskService.RetryableTask {
 	private final FlowReceiverContainer flowReceiverContainer;
-	private final MessageContainer messageContainer;
+	private final UUID flowReceiverContainerId;
 	private final RetryableTaskService taskService;
 
 	private static final Log logger = LogFactory.getLog(RetryableRebindTask.class);
 
-	public RetryableRebindTask(FlowReceiverContainer flowReceiverContainer, MessageContainer messageContainer,
-							   RetryableTaskService taskService) {
+	public RetryableRebindTask(FlowReceiverContainer flowReceiverContainer, UUID flowReceiverContainerId, RetryableTaskService taskService) {
 		this.flowReceiverContainer = flowReceiverContainer;
-		this.messageContainer = messageContainer;
+		this.flowReceiverContainerId = flowReceiverContainerId;
 		this.taskService = taskService;
 	}
 
 	@Override
 	public boolean run(int attempt) throws InterruptedException {
 		try {
-			return flowReceiverContainer.acknowledgeRebind(messageContainer, true) != null;
+			return flowReceiverContainer.rebind(flowReceiverContainerId, true) != null;
 		} catch (JCSMPException | UnboundFlowReceiverContainerException e) {
-			if (messageContainer.isStale() && !flowReceiverContainer.isBound()) {
+			if (!flowReceiverContainer.isBound()) {
 				logger.warn(String.format(
 						"failed to rebind queue %s and flow container %s is now unbound. Attempting to bind.",
 						flowReceiverContainer.getId(), flowReceiverContainer.getQueueName()), e);
@@ -37,18 +37,15 @@ public class RetryableRebindTask implements RetryableTaskService.RetryableTask {
 						flowReceiverContainer.getId(), flowReceiverContainer.getQueueName()), e);
 				return false;
 			}
-		} catch (SolaceStaleMessageException e) {
-			logger.info(String.format("Message container %s (XMLMessage %s) is stale and was already redelivered",
-					messageContainer.getId(), messageContainer.getMessage().getMessageId()), e);
-			return true;
 		}
 	}
 
 	@Override
 	public String toString() {
 		return new StringJoiner(", ", RetryableRebindTask.class.getSimpleName() + "[", "]")
-				.add("flowReceiverContainer=" + flowReceiverContainer.getId())
-				.add("messageContainer=" + messageContainer.getId())
+				.add("flowReceiverContainer=" + flowReceiverContainer)
+				.add("flowReceiverContainerId=" + flowReceiverContainerId)
+				.add("taskService=" + taskService)
 				.toString();
 	}
 
@@ -58,12 +55,12 @@ public class RetryableRebindTask implements RetryableTaskService.RetryableTask {
 		if (o == null || getClass() != o.getClass()) return false;
 		RetryableRebindTask that = (RetryableRebindTask) o;
 		return Objects.equals(flowReceiverContainer, that.flowReceiverContainer) &&
-				Objects.equals(messageContainer, that.messageContainer) &&
+				Objects.equals(flowReceiverContainerId, that.flowReceiverContainerId) &&
 				Objects.equals(taskService, that.taskService);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(flowReceiverContainer, messageContainer, taskService);
+		return Objects.hash(flowReceiverContainer, flowReceiverContainerId, taskService);
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTask.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTask.java
@@ -1,0 +1,70 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.JCSMPException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class RetryableRebindTask implements RetryableTaskService.RetryableTask {
+	private final FlowReceiverContainer flowReceiverContainer;
+	private final MessageContainer messageContainer;
+	private final RetryableTaskService taskService;
+
+	private static final Log logger = LogFactory.getLog(RetryableRebindTask.class);
+
+	public RetryableRebindTask(FlowReceiverContainer flowReceiverContainer, MessageContainer messageContainer,
+							   RetryableTaskService taskService) {
+		this.flowReceiverContainer = flowReceiverContainer;
+		this.messageContainer = messageContainer;
+		this.taskService = taskService;
+	}
+
+	@Override
+	public boolean run(int attempt) throws InterruptedException {
+		try {
+			flowReceiverContainer.acknowledgeRebind(messageContainer);
+			return true;
+		} catch (JCSMPException | UnboundFlowReceiverContainerException e) {
+			if (messageContainer.isStale() && !flowReceiverContainer.isBound()) {
+				logger.warn(String.format(
+						"failed to rebind queue %s and flow container %s is now unbound. Attempting to bind.",
+						flowReceiverContainer.getId(), flowReceiverContainer.getQueueName()), e);
+				taskService.submit(new RetryableBindTask(flowReceiverContainer));
+				return true;
+			} else {
+				logger.warn(String.format("failed to rebind flow container %s queue %s. Will retry",
+						flowReceiverContainer.getId(), flowReceiverContainer.getQueueName()), e);
+				return false;
+			}
+		} catch (SolaceStaleMessageException e) {
+			logger.info(String.format("Message container %s (XMLMessage %s) is stale and was already redelivered",
+					messageContainer.getId(), messageContainer.getMessage().getMessageId()), e);
+			return true;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return new StringJoiner(", ", RetryableRebindTask.class.getSimpleName() + "[", "]")
+				.add("flowReceiverContainer=" + flowReceiverContainer.getId())
+				.add("messageContainer=" + messageContainer.getId())
+				.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RetryableRebindTask that = (RetryableRebindTask) o;
+		return Objects.equals(flowReceiverContainer, that.flowReceiverContainer) &&
+				Objects.equals(messageContainer, that.messageContainer) &&
+				Objects.equals(taskService, that.taskService);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(flowReceiverContainer, messageContainer, taskService);
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskService.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskService.java
@@ -29,14 +29,13 @@ public class RetryableTaskService {
 			return;
 		}
 
-		if (hasTask(task)) {
+		if (!tasks.add(task)) {
 			if (logger.isDebugEnabled()) {
 				logger.debug(String.format("Skipping task submission. Task already exists: %s", task));
 			}
 			return;
 		}
 
-		tasks.add(task);
 		scheduler.execute(new RetryableTaskWrapper(this, task, retryInterval, unit));
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskService.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskService.java
@@ -1,0 +1,65 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service for delegating retryable tasks.
+ */
+public class RetryableTaskService {
+	private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+	private static final Log logger = LogFactory.getLog(RetryableTaskService.class);
+
+	public void submit(RetryableTask task) {
+		submit(task, 5L, TimeUnit.SECONDS);
+	}
+
+	public void submit(RetryableTask task, long retryInterval, TimeUnit unit) {
+		executorService.submit(new RetryableTaskWrapper(executorService, task, retryInterval, unit));
+	}
+
+	public void close() {
+		executorService.shutdownNow();
+	}
+
+	private static class RetryableTaskWrapper implements Runnable {
+		private final RetryableTask task;
+		private final ScheduledExecutorService executorService;
+		private final long retryInterval;
+		private final TimeUnit unit;
+
+		public RetryableTaskWrapper(ScheduledExecutorService executorService, RetryableTask task, long retryInterval,
+									TimeUnit unit) {
+			this.task = task;
+			this.executorService = executorService;
+			this.retryInterval = retryInterval;
+			this.unit = unit;
+		}
+
+		@Override
+		public void run() {
+			try {
+				if (!task.run()) {
+					executorService.schedule(this, retryInterval, unit);
+				}
+			} catch (InterruptedException e) {
+				logger.warn("Interrupt received. Aborting task.", e);
+			}
+		}
+	}
+
+	@FunctionalInterface
+	public interface RetryableTask {
+
+		/**
+		 *
+		 * @return true if successful, false to retry
+		 * @throws InterruptedException abort
+		 */
+		boolean run() throws InterruptedException;
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskService.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskService.java
@@ -3,9 +3,12 @@ package com.solace.spring.cloud.stream.binder.util;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Service for delegating retryable tasks.
@@ -13,41 +16,72 @@ import java.util.concurrent.TimeUnit;
 public class RetryableTaskService {
 	private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 	private static final Log logger = LogFactory.getLog(RetryableTaskService.class);
+	private final Set<RetryableTask> tasks = ConcurrentHashMap.newKeySet();
 
 	public void submit(RetryableTask task) {
 		submit(task, 5L, TimeUnit.SECONDS);
 	}
 
 	public void submit(RetryableTask task, long retryInterval, TimeUnit unit) {
-		executorService.submit(new RetryableTaskWrapper(executorService, task, retryInterval, unit));
+		if (task == null) {
+			return;
+		}
+
+		if (hasTask(task)) {
+			if (logger.isDebugEnabled()) {
+				logger.debug(String.format("Skipping task submission. Task already exists: %s", task));
+			}
+			return;
+		}
+
+		tasks.add(task);
+		executorService.execute(new RetryableTaskWrapper(this, task, retryInterval, unit));
 	}
 
 	public void close() {
 		executorService.shutdownNow();
+		if (!tasks.isEmpty()) {
+			logger.info(String.format("Task service shutdown. Cancelling tasks: %s", tasks));
+		}
+		tasks.clear();
+	}
+
+	public boolean hasTask(RetryableTask task) {
+		return tasks.contains(task);
 	}
 
 	private static class RetryableTaskWrapper implements Runnable {
 		private final RetryableTask task;
-		private final ScheduledExecutorService executorService;
+		private final RetryableTaskService taskService;
 		private final long retryInterval;
 		private final TimeUnit unit;
+		private final AtomicInteger attempt = new AtomicInteger(0);
 
-		public RetryableTaskWrapper(ScheduledExecutorService executorService, RetryableTask task, long retryInterval,
+		public RetryableTaskWrapper(RetryableTaskService taskService, RetryableTask task, long retryInterval,
 									TimeUnit unit) {
 			this.task = task;
-			this.executorService = executorService;
+			this.taskService = taskService;
 			this.retryInterval = retryInterval;
 			this.unit = unit;
 		}
 
 		@Override
 		public void run() {
+			if (Thread.currentThread().isInterrupted()) {
+				logger.info(String.format("Interrupt received. Aborting task: %s", task));
+				taskService.tasks.remove(task);
+				return;
+			}
+
 			try {
-				if (!task.run()) {
-					executorService.schedule(this, retryInterval, unit);
+				if (task.run(attempt.incrementAndGet())) {
+					taskService.tasks.remove(task);
+				} else {
+					taskService.executorService.schedule(this, retryInterval, unit);
 				}
 			} catch (InterruptedException e) {
-				logger.warn("Interrupt received. Aborting task.", e);
+				logger.info(String.format("Interrupt received. Aborting task: %s", task), e);
+				taskService.tasks.remove(task);
 			}
 		}
 	}
@@ -56,10 +90,11 @@ public class RetryableTaskService {
 	public interface RetryableTask {
 
 		/**
-		 *
+		 * The action to perform on each attempt.
+		 * @param attempt the attempt count. Starts at 1.
 		 * @return true if successful, false to retry
 		 * @throws InterruptedException abort
 		 */
-		boolean run() throws InterruptedException;
+		boolean run(int attempt) throws InterruptedException;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SharedResourceManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SharedResourceManager.java
@@ -34,7 +34,7 @@ abstract class SharedResourceManager<T> {
 				logger.info(String.format("No %s exists, a new one will be created", type));
 				sharedResource = create();
 			} else {
-				logger.info(String.format("A message %s already exists, reusing it", type));
+				logger.debug(String.format("A message %s already exists, reusing it", type));
 			}
 
 			registeredIds.add(key);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/UnboundFlowReceiverContainerException.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/UnboundFlowReceiverContainerException.java
@@ -1,0 +1,18 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import java.util.UUID;
+
+/**
+ * <p>Flow receiver container is not bound to a flow receiver.</p>
+ * <p>Typically caused by one of:</p>
+ * <ul>
+ * <li>{@link FlowReceiverContainer#unbind()}</li>
+ * <li>An error during {@link FlowReceiverContainer#rebind(UUID)}</li>
+ * <li>An error during {@link FlowReceiverContainer#acknowledgeRebind(MessageContainer)}</li>
+ * </ul>
+ */
+public class UnboundFlowReceiverContainerException extends Exception {
+	public UnboundFlowReceiverContainerException(String message) {
+		super(message);
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/UnsignedCounterBarrier.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/UnsignedCounterBarrier.java
@@ -64,7 +64,7 @@ class UnsignedCounterBarrier {
 		try {
 			if (timeout > 0) {
 				logger.info(String.format("Waiting for %s items, time remaining: %s %s", counter.get(), timeout, unit));
-				long expiry = unit.toMillis(timeout) + System.currentTimeMillis();
+				final long expiry = unit.toMillis(timeout) + System.currentTimeMillis();
 				while (isGreaterThanZero()) {
 					long realTimeout = expiry - System.currentTimeMillis();
 					if (realTimeout <= 0) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -64,6 +64,9 @@ public class XMLMessageMapper {
 		if (consumerProperties.getErrorMsgTtl() != null) {
 			errorMessage.setTimeToLive(consumerProperties.getErrorMsgTtl());
 		}
+		if (DeliveryMode.DIRECT.equals(errorMessage.getDeliveryMode())) {
+			errorMessage.setDeliveryMode(DeliveryMode.PERSISTENT);
+		}
 		return errorMessage;
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
@@ -1,0 +1,266 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.ITBase;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.test.integration.semp.v2.config.model.ConfigMsgVpnQueue;
+import com.solacesystems.jcsmp.Consumer;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.Queue;
+import com.solacesystems.jcsmp.TextMessage;
+import com.solacesystems.jcsmp.XMLMessageProducer;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@ContextConfiguration(classes = SolaceJavaAutoConfiguration.class,
+		initializers = ConfigFileApplicationContextInitializer.class)
+public class ErrorQueueRepublishCorrelationKeyIT extends ITBase {
+	@Parameterized.Parameter
+	public String parameterSetName; // Only used for parameter set naming
+
+	@Parameterized.Parameter(1)
+	public boolean isDurable;
+
+	private String vpnName;
+	private Queue queue;
+	private Queue errorQueue;
+	private XMLMessageProducer producer;
+	private FlowReceiverContainer flowReceiverContainer;
+	private ErrorQueueInfrastructure errorQueueInfrastructure;
+	private RetryableTaskService retryableTaskService;
+
+	private static final Log logger = LogFactory.getLog(ErrorQueueRepublishCorrelationKeyIT.class);
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<?> headerSets() {
+		return Arrays.asList(new Object[][]{
+				{"Durable", true},
+				{"Temporary", false}
+		});
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		retryableTaskService = Mockito.spy(new RetryableTaskService());
+
+		if (isDurable) {
+			queue = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(20));
+			jcsmpSession.provision(queue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+		} else {
+			queue = jcsmpSession.createTemporaryQueue(RandomStringUtils.randomAlphanumeric(20));
+		}
+
+		flowReceiverContainer = new FlowReceiverContainer(jcsmpSession, queue.getName(), new EndpointProperties());
+		flowReceiverContainer.bind();
+
+		String producerManagerKey = UUID.randomUUID().toString();
+		JCSMPSessionProducerManager producerManager = new JCSMPSessionProducerManager(jcsmpSession);
+		producer = producerManager.get(producerManagerKey);
+
+		errorQueueInfrastructure = Mockito.spy(new ErrorQueueInfrastructure(producerManager, producerManagerKey,
+				RandomStringUtils.randomAlphanumeric(20), new SolaceConsumerProperties(),
+				retryableTaskService));
+		errorQueue = JCSMPFactory.onlyInstance().createQueue(errorQueueInfrastructure.getErrorQueueName());
+		jcsmpSession.provision(errorQueue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (producer != null) {
+			producer.close();
+		}
+
+		if (flowReceiverContainer != null) {
+			Optional.ofNullable(flowReceiverContainer.getFlowReceiverReference())
+					.map(FlowReceiverContainer.FlowReceiverReference::get)
+					.ifPresent(Consumer::close);
+		}
+
+		if (jcsmpSession != null && !jcsmpSession.isClosed()) {
+			if (isDurable) {
+				jcsmpSession.deprovision(queue, JCSMPSession.WAIT_FOR_CONFIRM);
+			}
+			jcsmpSession.deprovision(errorQueue, JCSMPSession.WAIT_FOR_CONFIRM);
+		}
+	}
+
+	@Test
+	public void testHandleSuccess() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		key.handleSuccess();
+		assertTrue(messageContainer.isAcknowledged());
+	}
+
+	@Test
+	public void testHandleSuccessStale() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = Mockito.spy(flowReceiverContainer.receive(5000));
+		Mockito.when(messageContainer.isStale()).thenReturn(true);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		assertThrows(SolaceStaleMessageException.class, key::handleSuccess);
+		assertEquals(0, key.getErrorQueueDeliveryAttempt());
+	}
+
+	@Test
+	public void testHandleError() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		key.handleError();
+
+		Mockito.verify(errorQueueInfrastructure, Mockito.times(1)).send(messageContainer, key);
+		assertEquals(1, key.getErrorQueueDeliveryAttempt());
+		validateNumEnqueuedMessages(queue, 0);
+		validateNumEnqueuedMessages(errorQueue, 1);
+	}
+
+	@Test
+	public void testHandleErrorRetry() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		Mockito.doAnswer(invocation -> {
+			if (key.getErrorQueueDeliveryAttempt() < errorQueueInfrastructure.getMaxDeliveryAttempts()) {
+				throw new JCSMPException("Test");
+			} else {
+				return invocation.callRealMethod();
+			}
+		}).when(errorQueueInfrastructure).send(messageContainer, key);
+
+		key.handleError();
+
+		int maxDeliveryAttempts = Math.toIntExact(errorQueueInfrastructure.getMaxDeliveryAttempts());
+		Mockito.verify(errorQueueInfrastructure, Mockito.times(maxDeliveryAttempts)).send(messageContainer, key);
+		assertEquals(maxDeliveryAttempts, key.getErrorQueueDeliveryAttempt());
+		validateNumEnqueuedMessages(queue, 0);
+		validateNumEnqueuedMessages(errorQueue, 1);
+	}
+
+	@Test
+	public void testHandleErrorAsyncRetry() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		logger.info(String.format("Shutting down ingress for queue %s", errorQueue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, errorQueue.getName(),
+				new ConfigMsgVpnQueue().ingressEnabled(false), null);
+		retryAssert(() -> assertFalse(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, errorQueue.getName(), null)
+				.getData()
+				.isIngressEnabled()));
+
+		CountDownLatch latch = new CountDownLatch(1);
+		Mockito.doAnswer(invocation -> {
+			if (key.getErrorQueueDeliveryAttempt() == errorQueueInfrastructure.getMaxDeliveryAttempts()) {
+				logger.info(String.format("Starting ingress for queue %s", errorQueue.getName()));
+				sempV2Api.config().updateMsgVpnQueue(vpnName, errorQueue.getName(),
+						new ConfigMsgVpnQueue().ingressEnabled(true), null);
+				retryAssert(() -> assertTrue(sempV2Api.monitor()
+						.getMsgVpnQueue(vpnName, errorQueue.getName(), null)
+						.getData()
+						.isIngressEnabled()));
+				latch.countDown();
+			}
+
+			return invocation.callRealMethod();
+		}).when(errorQueueInfrastructure).send(messageContainer, key);
+
+		key.handleError();
+		assertTrue(latch.await(1, TimeUnit.MINUTES));
+
+		int maxDeliveryAttempts = Math.toIntExact(errorQueueInfrastructure.getMaxDeliveryAttempts());
+		Mockito.verify(errorQueueInfrastructure, Mockito.times(maxDeliveryAttempts)).send(messageContainer, key);
+		assertEquals(maxDeliveryAttempts, key.getErrorQueueDeliveryAttempt());
+		validateNumEnqueuedMessages(queue, 0);
+		validateNumEnqueuedMessages(errorQueue, 1);
+	}
+
+	@Test
+	public void testHandleErrorRequeueFallback() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		Mockito.doThrow(new JCSMPException("test")).when(errorQueueInfrastructure).send(messageContainer, key);
+
+		key.handleError();
+
+		int maxDeliveryAttempts = Math.toIntExact(errorQueueInfrastructure.getMaxDeliveryAttempts());
+		Mockito.verify(errorQueueInfrastructure, Mockito.times(maxDeliveryAttempts)).send(messageContainer, key);
+		assertEquals(maxDeliveryAttempts, key.getErrorQueueDeliveryAttempt());
+		validateNumEnqueuedMessages(errorQueue, 0);
+
+		if (isDurable) {
+			validateNumEnqueuedMessages(queue, 1);
+			Mockito.verify(retryableTaskService, Mockito.times(1))
+					.submit(new RetryableRebindTask(flowReceiverContainer, messageContainer, retryableTaskService));
+			assertEquals((Long) 2L, sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queue.getName(), null)
+					.getData()
+					.getBindSuccessCount());
+		} else {
+			validateNumEnqueuedMessages(queue, 0);
+		}
+	}
+
+	@Test
+	public void testHandleErrorStale() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = Mockito.spy(flowReceiverContainer.receive(5000));
+		Mockito.when(messageContainer.isStale()).thenReturn(true);
+		ErrorQueueRepublishCorrelationKey key = createKey(messageContainer);
+
+		assertThrows(SolaceStaleMessageException.class, key::handleError);
+		assertEquals(0, key.getErrorQueueDeliveryAttempt());
+	}
+
+	private ErrorQueueRepublishCorrelationKey createKey(MessageContainer messageContainer) {
+		return new ErrorQueueRepublishCorrelationKey(errorQueueInfrastructure,
+				messageContainer,
+				flowReceiverContainer,
+				!isDurable,
+				retryableTaskService);
+	}
+
+	private void validateNumEnqueuedMessages(Queue queue, int expectedCount) throws InterruptedException {
+		retryAssert(() -> assertThat(sempV2Api.monitor()
+				.getMsgVpnQueueMsgs(vpnName, queue.getName(), null, null, null, null)
+				.getData())
+				.hasSize(expectedCount));
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
@@ -156,7 +156,7 @@ public class ErrorQueueRepublishCorrelationKeyIT extends ITBase {
 
 		Mockito.doAnswer(invocation -> {
 			if (key.getErrorQueueDeliveryAttempt() < errorQueueInfrastructure.getMaxDeliveryAttempts()) {
-				throw new JCSMPException("Test");
+				throw new Exception("Test");
 			} else {
 				return invocation.callRealMethod();
 			}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
@@ -256,7 +256,7 @@ public class ErrorQueueRepublishCorrelationKeyIT extends ITBase {
 		if (isDurable) {
 			validateNumEnqueuedMessages(queue, 1);
 			Mockito.verify(retryableTaskService)
-					.submit(new RetryableRebindTask(flowReceiverContainer, messageContainer, retryableTaskService));
+					.submit(new RetryableAckRebindTask(flowReceiverContainer, messageContainer, retryableTaskService));
 			Mockito.verify(flowReceiverContainer).acknowledgeRebind(messageContainer, true);
 			retryAssert(() -> assertEquals((Long) 2L, sempV2Api.monitor()
 					.getMsgVpnQueue(vpnName, queue.getName(), null)
@@ -287,7 +287,7 @@ public class ErrorQueueRepublishCorrelationKeyIT extends ITBase {
 		if (isDurable) {
 			validateNumEnqueuedMessages(queue, 1);
 			Mockito.verify(retryableTaskService)
-					.submit(new RetryableRebindTask(flowReceiverContainer, messageContainer, retryableTaskService));
+					.submit(new RetryableAckRebindTask(flowReceiverContainer, messageContainer, retryableTaskService));
 			Mockito.verify(flowReceiverContainer, Mockito.times(2))
 					.acknowledgeRebind(messageContainer, true);
 			retryAssert(() -> assertEquals((Long) 2L, sempV2Api.monitor()

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
@@ -31,7 +31,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -67,7 +66,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
@@ -85,15 +87,13 @@ public class FlowReceiverContainerIT extends ITBase {
 	@Rule
 	public Timeout globalTimeout = new Timeout(5, TimeUnit.MINUTES);
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	@Parameterized.Parameter
 	public String parameterSetName; // Only used for parameter set naming
 
 	@Parameterized.Parameter(1)
 	public boolean isDurable;
 
+	private String vpnName;
 	private FlowReceiverContainer flowReceiverContainer;
 	private XMLMessageProducer producer;
 	private Queue queue;
@@ -110,6 +110,8 @@ public class FlowReceiverContainerIT extends ITBase {
 
 	@Before
 	public void setup() throws Exception {
+		vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+
 		if (isDurable) {
 			queue = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(20));
 			EndpointProperties endpointProperties = new EndpointProperties();
@@ -417,10 +419,10 @@ public class FlowReceiverContainerIT extends ITBase {
 			assertNull(flowReceiverContainer.getFlowReceiverReference());
 			assertThat(getTxFlows(1, null), hasSize(0));
 
-			thrown.expect(ExecutionException.class);
-			thrown.expectCause(instanceOf(JCSMPTransportException.class));
-			thrown.expectMessage("Consumer was closed while in receive");
-			receiveFuture.get(1, TimeUnit.MINUTES);
+			ExecutionException exception = assertThrows(ExecutionException.class,
+					() -> receiveFuture.get(1, TimeUnit.MINUTES));
+			assertThat(exception.getCause(), instanceOf(JCSMPTransportException.class));
+			assertThat(exception.getMessage(), containsString("Consumer was closed while in receive"));
 		} finally {
 			executorService.shutdownNow();
 		}
@@ -516,19 +518,15 @@ public class FlowReceiverContainerIT extends ITBase {
 
 	@Test
 	public void testRebindANonBoundFlow() throws Exception {
-		thrown.expect(IllegalStateException.class);
-		thrown.expectMessage("is not bound");
-		try {
-			flowReceiverContainer.rebind(UUID.randomUUID());
-		} catch (IllegalStateException e) {
-			if (isDurable) {
-				MonitorMsgVpnQueue queueInfo = getQueueInfo();
-				assertNotNull(queueInfo);
-				assertEquals((Long) 0L, queueInfo.getBindRequestCount());
-			} else {
-				assertNull(getQueueInfo());
-			}
-			throw e;
+		UnboundFlowReceiverContainerException exception = assertThrows(UnboundFlowReceiverContainerException.class,
+				() -> flowReceiverContainer.rebind(UUID.randomUUID()));
+		assertThat(exception.getMessage(), containsString("is not bound"));
+		if (isDurable) {
+			MonitorMsgVpnQueue queueInfo = getQueueInfo();
+			assertNotNull(queueInfo);
+			assertEquals((Long) 0L, queueInfo.getBindRequestCount());
+		} else {
+			assertNull(getQueueInfo());
 		}
 	}
 
@@ -675,6 +673,30 @@ public class FlowReceiverContainerIT extends ITBase {
 	}
 
 	@Test
+	public void testRebindAfterFlowDisconnect() throws Exception {
+		if (!isDurable) {
+			logger.info("Test does not apply for non-durable queues");
+			return;
+		}
+
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		flowReceiverContainer.bind();
+		MessageContainer messageContainer = flowReceiverContainer.receive((int) TimeUnit.MINUTES.toMillis(1));
+
+		logger.info(String.format("Disabling egress to queue %s", queue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
+				null);
+		retryAssert(() -> assertFalse(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
+
+		assertThrows(JCSMPException.class, () -> flowReceiverContainer.acknowledgeRebind(messageContainer));
+		assertEquals(0, flowReceiverContainer.getNumUnacknowledgedMessages());
+		assertNull(flowReceiverContainer.getFlowReceiverReference());
+	}
+
+	@Test
 	public void testRebindAfterFlowReconnect() throws Exception {
 		if (!isDurable) {
 			logger.info("Test does not apply for non-durable queues");
@@ -689,17 +711,23 @@ public class FlowReceiverContainerIT extends ITBase {
 		MessageContainer receivedMessage = flowReceiverContainer.receive();
 		assertNotNull(receivedMessage);
 
-		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
-
 		logger.info(String.format("Disabling egress to queue %s", queue.getName()));
 		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
 				null);
-		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+		retryAssert(() -> assertFalse(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
+
+		Thread.sleep(TimeUnit.SECONDS.toMillis(1));
 
 		logger.info(String.format("Enabling egress to queue %s", queue.getName()));
 		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true),
 				null);
-		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+		retryAssert(() -> assertTrue(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
 
 		assertEquals(1, flowReceiverContainer.getNumUnacknowledgedMessages());
 		logger.info(String.format("Initiating rebind with message container %s", receivedMessage.getId()));
@@ -710,13 +738,13 @@ public class FlowReceiverContainerIT extends ITBase {
 		Mockito.verify(flowReceiverContainer, Mockito.times(1)).unbind();
 		Mockito.verify(flowReceiverContainer, Mockito.times(2)).bind(); // +1 for init bind
 
-		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
-
-		List<MonitorMsgVpnQueueTxFlow> txFlows = getTxFlows(2, null);
-		assertThat(txFlows, hasSize(1));
-		assertEquals((Long) 0L, txFlows.get(0).getAckedMsgCount());
-		assertEquals((Long) 1L, txFlows.get(0).getUnackedMsgCount());
-		assertEquals((Long) 1L, txFlows.get(0).getRedeliveredMsgCount());
+		retryAssert(() -> {
+			List<MonitorMsgVpnQueueTxFlow> txFlows = getTxFlows(2, null);
+			assertThat(txFlows, hasSize(1));
+			assertEquals((Long) 0L, txFlows.get(0).getAckedMsgCount());
+			assertEquals((Long) 1L, txFlows.get(0).getUnackedMsgCount());
+			assertEquals((Long) 1L, txFlows.get(0).getRedeliveredMsgCount());
+		});
 	}
 
 	@Test
@@ -729,7 +757,6 @@ public class FlowReceiverContainerIT extends ITBase {
 		MessageContainer receivedMessage = flowReceiverContainer.receive();
 		assertNotNull(receivedMessage);
 
-		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
 		String clientName = (String) jcsmpSession.getProperty(JCSMPProperties.CLIENT_NAME);
 
 		logger.info(String.format("Remotely disconnecting session %s", jcsmpSession.getSessionName()));
@@ -803,10 +830,12 @@ public class FlowReceiverContainerIT extends ITBase {
 	}
 
 	@Test
-	public void testReceiveOnANonBoundFlow() throws Exception {
-		thrown.expect(IllegalStateException.class);
-		thrown.expectMessage("is not bound");
-		flowReceiverContainer.receive();
+	public void testReceiveOnANonBoundFlow() {
+		long startTime = System.currentTimeMillis();
+		UnboundFlowReceiverContainerException exception = assertThrows(UnboundFlowReceiverContainerException.class,
+				() -> flowReceiverContainer.receive());
+		assertThat(System.currentTimeMillis() - startTime, greaterThan(TimeUnit.SECONDS.toMillis(5)));
+		assertThat(exception.getMessage(), containsString("is not bound"));
 	}
 
 	@Test
@@ -886,6 +915,12 @@ public class FlowReceiverContainerIT extends ITBase {
 	}
 
 	@Test
+	public void testReceiveNoWait() throws Exception {
+		flowReceiverContainer.bind();
+		assertNull(flowReceiverContainer.receive(0));
+	}
+
+	@Test
 	public void testReceiveWithTimeout() throws Exception {
 		TextMessage message = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
 
@@ -900,9 +935,78 @@ public class FlowReceiverContainerIT extends ITBase {
 	}
 
 	@Test
-	public void testReceiveThrowTimeout() throws Exception {
+	public void testReceiveElapsedTimeout() throws Exception {
 		flowReceiverContainer.bind();
 		assertNull(flowReceiverContainer.receive(1));
+	}
+
+	@Test
+	public void testReceiveNegativeTimeout() throws Exception {
+		flowReceiverContainer.bind();
+		assertNull(flowReceiverContainer.receive(-1));
+	}
+
+	@Test
+	public void testReceiveZeroTimeout() throws Exception {
+		flowReceiverContainer.bind();
+		assertNull(flowReceiverContainer.receive(0));
+	}
+
+	@Test
+	public void testReceiveWithDelayedBind() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		try {
+			long startTime = System.currentTimeMillis();
+			Future<MessageContainer> future = executorService.submit(() -> flowReceiverContainer.receive());
+
+			Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+			assertFalse(future.isDone());
+			flowReceiverContainer.bind();
+
+			if (!isDurable) {
+				producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+			}
+
+			assertNotNull(future.get(1, TimeUnit.MINUTES));
+			assertThat(System.currentTimeMillis() - startTime, lessThan(5500L));
+			assertEquals(1, flowReceiverContainer.getNumUnacknowledgedMessages());
+		} finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	@Test
+	public void testReceiveWithTimeoutAndDelayedBind() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		try {
+			long timeout = TimeUnit.SECONDS.toMillis(10);
+			long bindDelay = TimeUnit.SECONDS.toMillis(5);
+
+			long startTime = System.currentTimeMillis();
+			Future<MessageContainer> future = executorService.submit(() -> flowReceiverContainer.receive((int) timeout));
+
+			Thread.sleep(bindDelay);
+			assertFalse(future.isDone());
+
+			flowReceiverContainer.bind();
+
+			if (isDurable) {
+				assertNotNull(future.get(1, TimeUnit.MINUTES));
+				assertThat(System.currentTimeMillis() - startTime, lessThan(timeout + 500));
+				assertEquals(1, flowReceiverContainer.getNumUnacknowledgedMessages());
+			} else {
+				assertNull(future.get(1, TimeUnit.MINUTES));
+				assertThat(System.currentTimeMillis() - startTime,
+						allOf(greaterThanOrEqualTo(timeout), lessThan(timeout + 500)));
+				assertEquals(0, flowReceiverContainer.getNumUnacknowledgedMessages());
+			}
+		} finally {
+			executorService.shutdownNow();
+		}
 	}
 
 	@Test
@@ -932,8 +1036,6 @@ public class FlowReceiverContainerIT extends ITBase {
 
 		flowReceiverContainer.bind();
 
-		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
-
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		try {
 			Future<MessageContainer> receiveFuture = executorService.submit(() -> flowReceiverContainer.receive());
@@ -945,7 +1047,10 @@ public class FlowReceiverContainerIT extends ITBase {
 			logger.info(String.format("Disabling egress to queue %s", queue.getName()));
 			sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
 					null);
-			Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+			retryAssert(() -> assertFalse(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queue.getName(), null)
+					.getData()
+					.isEgressEnabled()));
 
 			logger.info(String.format("Sending message to queue %s", queue.getName()));
 			producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
@@ -953,7 +1058,10 @@ public class FlowReceiverContainerIT extends ITBase {
 			logger.info(String.format("Enabling egress to queue %s", queue.getName()));
 			sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true),
 					null);
-			Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+			retryAssert(() -> assertTrue(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queue.getName(), null)
+					.getData()
+					.isEgressEnabled()));
 
 			assertNotNull(receiveFuture.get(1, TimeUnit.MINUTES));
 		} finally {
@@ -965,7 +1073,6 @@ public class FlowReceiverContainerIT extends ITBase {
 	public void testReceiveInterruptedBySessionReconnect() throws Exception {
 		flowReceiverContainer.bind();
 
-		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
 		String clientName = (String) jcsmpSession.getProperty(JCSMPProperties.CLIENT_NAME);
 
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -1017,6 +1124,28 @@ public class FlowReceiverContainerIT extends ITBase {
 	}
 
 	@Test
+	public void testWaitForBind() throws Exception {
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		try {
+			Future<Boolean> future = executorService.submit(() ->
+					flowReceiverContainer.waitForBind(TimeUnit.HOURS.toMillis(1)));
+			Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+			assertFalse(future.isDone());
+			flowReceiverContainer.bind();
+			assertTrue(future.get(1, TimeUnit.MINUTES));
+		} finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	@Test
+	public void testWaitForBindNegative() throws Exception {
+		long startTime = System.currentTimeMillis();
+		assertFalse(flowReceiverContainer.waitForBind(-100));
+		assertThat(System.currentTimeMillis() - startTime, lessThan(500L));
+	}
+
+	@Test
 	public void testAcknowledgeNull() throws Exception {
 		flowReceiverContainer.acknowledge(null);
 	}
@@ -1051,17 +1180,23 @@ public class FlowReceiverContainerIT extends ITBase {
 		MessageContainer receivedMessage = flowReceiverContainer.receive();
 		assertNotNull(receivedMessage);
 
-		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
-
 		logger.info(String.format("Disabling egress to queue %s", queue.getName()));
 		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
 				null);
-		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+		retryAssert(() -> assertFalse(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
+
+		Thread.sleep(TimeUnit.SECONDS.toMillis(1));
 
 		logger.info(String.format("Enabling egress to queue %s", queue.getName()));
 		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true),
 				null);
-		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+		retryAssert(() -> assertTrue(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
 
 		assertEquals(1, flowReceiverContainer.getNumUnacknowledgedMessages());
 		logger.info(String.format("Acknowledging message %s", receivedMessage.getMessage().getMessageId()));
@@ -1087,7 +1222,6 @@ public class FlowReceiverContainerIT extends ITBase {
 		MessageContainer receivedMessage = flowReceiverContainer.receive();
 		assertNotNull(receivedMessage);
 
-		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
 		String clientName = (String) jcsmpSession.getProperty(JCSMPProperties.CLIENT_NAME);
 
 		logger.info(String.format("Remotely disconnecting session %s", jcsmpSession.getSessionName()));
@@ -1119,13 +1253,9 @@ public class FlowReceiverContainerIT extends ITBase {
 				(Callable<?>) () -> {
 					try {
 						return flowReceiverContainer.rebind(flowReferenceId);
-					} catch (IllegalStateException e) {
-						if (e.getMessage().contains("is not bound")) {
-							logger.info("Received expected exception due to no bound flow", e);
-							return null;
-						} else {
-							throw e;
-						}
+					} catch (UnboundFlowReceiverContainerException e) {
+						logger.info("Received expected exception due to no bound flow", e);
+						return null;
 					}
 				},
 				(Callable<?>) () -> {
@@ -1148,13 +1278,9 @@ public class FlowReceiverContainerIT extends ITBase {
 						} else {
 							throw e;
 						}
-					} catch (IllegalStateException e) {
-						if (e.getMessage().contains("is not bound")) {
-							logger.info("Received expected exception due to no bound flow", e);
-							return null;
-						} else {
-							throw e;
-						}
+					} catch (UnboundFlowReceiverContainerException e) {
+						logger.info("Received expected exception due to no bound flow", e);
+						return null;
 					}
 
 					if (messageContainer == null) {
@@ -1209,8 +1335,7 @@ public class FlowReceiverContainerIT extends ITBase {
 
 	private MonitorMsgVpnQueue getQueueInfo() throws ApiException, JsonProcessingException {
 		try {
-			return sempV2Api.monitor().getMsgVpnQueue((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
-					queue.getName(), null).getData();
+			return sempV2Api.monitor().getMsgVpnQueue(vpnName, queue.getName(), null).getData();
 		} catch (ApiException e) {
 			return processApiException(e);
 		}
@@ -1220,8 +1345,8 @@ public class FlowReceiverContainerIT extends ITBase {
 			throws ApiException, JsonProcessingException {
 		try {
 			return sempV2Api.monitor()
-					.getMsgVpnQueueTxFlows((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
-					queue.getName(), count, cursor, null, null).getData();
+					.getMsgVpnQueueTxFlows(vpnName, queue.getName(), count, cursor, null, null)
+					.getData();
 		} catch (ApiException e) {
 			return processApiException(e);
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableAckRebindTaskIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableAckRebindTaskIT.java
@@ -1,0 +1,221 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.ITBase;
+import com.solace.test.integration.semp.v2.config.model.ConfigMsgVpnQueue;
+import com.solacesystems.jcsmp.Consumer;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.Queue;
+import com.solacesystems.jcsmp.TextMessage;
+import com.solacesystems.jcsmp.XMLMessageProducer;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(classes = SolaceJavaAutoConfiguration.class,
+		initializers = ConfigFileApplicationContextInitializer.class)
+public class RetryableAckRebindTaskIT extends ITBase {
+	private RetryableTaskService taskService;
+	private String vpnName;
+	private Queue queue;
+	private FlowReceiverContainer flowReceiverContainer;
+	private XMLMessageProducer producer;
+
+	private static final Log logger = LogFactory.getLog(RetryableAckRebindTaskIT.class);
+
+	@Before
+	public void setUp() throws Exception {
+		vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		taskService = Mockito.spy(new RetryableTaskService());
+		queue = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(20));
+		jcsmpSession.provision(queue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+		flowReceiverContainer = Mockito.spy(new FlowReceiverContainer(jcsmpSession, queue.getName(),
+				new EndpointProperties()));
+		flowReceiverContainer.bind();
+		producer = jcsmpSession.getMessageProducer(new JCSMPSessionProducerManager.CloudStreamEventHandler());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (flowReceiverContainer != null) {
+			Optional.ofNullable(flowReceiverContainer.getFlowReceiverReference())
+					.map(FlowReceiverContainer.FlowReceiverReference::get)
+					.ifPresent(Consumer::close);
+		}
+
+		if (jcsmpSession != null && !jcsmpSession.isClosed()) {
+			jcsmpSession.deprovision(queue, JCSMPSession.WAIT_FOR_CONFIRM);
+		}
+	}
+
+	@Test
+	public void testRun() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+		UUID flowId = Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId();
+
+		assertTrue(task.run(1));
+		Mockito.verify(flowReceiverContainer).acknowledgeRebind(messageContainer, true);
+		Mockito.verify(taskService, Mockito.never()).submit(Mockito.any());
+		assertTrue(messageContainer.isAcknowledged());
+		assertTrue(messageContainer.isStale());
+		assertTrue(flowReceiverContainer.isBound());
+		assertNotEquals(flowId, Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId());
+	}
+
+	@Test
+	public void testReturnNull() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		Mockito.doReturn(null).when(flowReceiverContainer)
+				.acknowledgeRebind(messageContainer, true);
+		assertFalse(task.run(1));
+		Mockito.verify(flowReceiverContainer).acknowledgeRebind(messageContainer, true);
+		Mockito.verify(taskService, Mockito.never()).submit(Mockito.any());
+		assertFalse(messageContainer.isAcknowledged());
+		assertFalse(messageContainer.isStale());
+	}
+
+	@Test
+	public void testReturnNullAndAcknowledged() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = Mockito.spy(flowReceiverContainer.receive(5000));
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		Mockito.when(messageContainer.isAcknowledged()).thenReturn(true);
+		Mockito.doReturn(null).when(flowReceiverContainer)
+				.acknowledgeRebind(messageContainer, true);
+
+		assertTrue(task.run(1));
+		Mockito.verify(flowReceiverContainer, Mockito.atLeastOnce()).acknowledgeRebind(messageContainer, true);
+		Mockito.verify(taskService).submit(new RetryableRebindTask(flowReceiverContainer,
+				messageContainer.getFlowReceiverReferenceId(), taskService));
+		assertFalse(taskService.hasTask(task));
+	}
+
+	@Test
+	public void testFail() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		Mockito.doThrow(new JCSMPException("test")).when(flowReceiverContainer)
+				.acknowledgeRebind(messageContainer, true);
+		assertFalse(task.run(1));
+		Mockito.verify(flowReceiverContainer).acknowledgeRebind(messageContainer, true);
+		Mockito.verify(taskService, Mockito.never()).submit(Mockito.any());
+		assertFalse(messageContainer.isAcknowledged());
+		assertFalse(messageContainer.isStale());
+	}
+
+	@Test
+	public void testStale() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = Mockito.spy(flowReceiverContainer.receive(5000));
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+		UUID flowId = Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId();
+
+		Mockito.when(messageContainer.isStale()).thenReturn(true);
+		assertTrue(task.run(1));
+		Mockito.verify(taskService, Mockito.never()).submit(Mockito.any());
+		assertEquals(flowId, Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId());
+		Mockito.verify(messageContainer).isStale();
+	}
+
+	@Test
+	public void testFailAndStale() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		logger.info(String.format("Shutting down egress for queue %s", queue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
+				null);
+		retryAssert(() -> assertFalse(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
+
+		assertTrue(task.run(1));
+		assertFalse(messageContainer.isAcknowledged());
+		assertTrue(messageContainer.isStale());
+		assertFalse(taskService.hasTask(task));
+		assertTrue(taskService.hasTask(new RetryableBindTask(flowReceiverContainer)));
+		assertFalse(flowReceiverContainer.isBound());
+
+		logger.info(String.format("Starting egress for queue %s", queue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true),
+				null);
+
+		retryAssert(() -> {
+			assertTrue(sempV2Api.monitor().getMsgVpnQueue(vpnName, queue.getName(), null).getData()
+					.isEgressEnabled());
+			assertFalse(taskService.hasTask(new RetryableBindTask(flowReceiverContainer)));
+			assertTrue(flowReceiverContainer.isBound());
+		}, 1, TimeUnit.MINUTES);
+
+//		assertNotNull(flowReceiverContainer.receive(5000)); //TODO Re-enable once SOL-45982 is fixed
+	}
+
+	@Test
+	public void testFailWhenUnbound() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = Mockito.spy(flowReceiverContainer.receive(5000));
+		RetryableAckRebindTask task = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		flowReceiverContainer.unbind();
+		Mockito.when(messageContainer.isStale()).thenReturn(false).thenCallRealMethod();
+
+		assertTrue(task.run(1));
+		Mockito.verify(taskService).submit(new RetryableBindTask(flowReceiverContainer));
+		assertFalse(messageContainer.isAcknowledged());
+		assertTrue(messageContainer.isStale());
+		assertFalse(taskService.hasTask(task));
+
+		retryAssert(() -> {
+			assertFalse(taskService.hasTask(new RetryableBindTask(flowReceiverContainer)));
+			assertTrue(flowReceiverContainer.isBound());
+		}, 1, TimeUnit.MINUTES);
+
+		assertNotNull(flowReceiverContainer.receive(5000));
+	}
+
+	@Test
+	public void testEquals() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableAckRebindTask task1 = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+		RetryableAckRebindTask task2 = new RetryableAckRebindTask(flowReceiverContainer, messageContainer, taskService);
+		assertEquals(task1, task2);
+		assertEquals(task1.hashCode(), task1.hashCode());
+		assertThat(new HashSet<>(Collections.singleton(task1)), contains(task2));
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableBindTaskIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableBindTaskIT.java
@@ -1,0 +1,91 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.ITBase;
+import com.solace.test.integration.semp.v2.config.model.ConfigMsgVpnQueue;
+import com.solacesystems.jcsmp.Consumer;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.Queue;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(classes = SolaceJavaAutoConfiguration.class,
+		initializers = ConfigFileApplicationContextInitializer.class)
+public class RetryableBindTaskIT extends ITBase {
+	private String vpnName;
+	private Queue queue;
+	private FlowReceiverContainer flowReceiverContainer;
+
+	private static final Log logger = LogFactory.getLog(RetryableBindTaskIT.class);
+
+	@Before
+	public void setUp() throws Exception {
+		vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		queue = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(20));
+		jcsmpSession.provision(queue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+		flowReceiverContainer = new FlowReceiverContainer(jcsmpSession, queue.getName(), new EndpointProperties());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (flowReceiverContainer != null) {
+			Optional.ofNullable(flowReceiverContainer.getFlowReceiverReference())
+					.map(FlowReceiverContainer.FlowReceiverReference::get)
+					.ifPresent(Consumer::close);
+		}
+
+		if (jcsmpSession != null && !jcsmpSession.isClosed()) {
+			jcsmpSession.deprovision(queue, JCSMPSession.WAIT_FOR_CONFIRM);
+		}
+	}
+
+	@Test
+	public void testRun() {
+		RetryableBindTask task = new RetryableBindTask(flowReceiverContainer);
+		assertFalse(flowReceiverContainer.isBound());
+		assertTrue(task.run(1));
+		assertTrue(flowReceiverContainer.isBound());
+	}
+
+	@Test
+	public void testRunFail() throws Exception {
+		logger.info(String.format("Shutting down egress for queue %s", queue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
+				null);
+		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+
+		RetryableBindTask task = new RetryableBindTask(flowReceiverContainer);
+		assertFalse(flowReceiverContainer.isBound());
+		assertFalse(task.run(1));
+		assertFalse(flowReceiverContainer.isBound());
+	}
+
+	@Test
+	public void testEquals() {
+		RetryableBindTask task1 = new RetryableBindTask(flowReceiverContainer);
+		RetryableBindTask task2 = new RetryableBindTask(flowReceiverContainer);
+		assertEquals(task1, task2);
+		assertEquals(task1.hashCode(), task1.hashCode());
+		assertThat(new HashSet<>(Collections.singleton(task1)), contains(task2));
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTaskIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableRebindTaskIT.java
@@ -1,0 +1,160 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.ITBase;
+import com.solace.test.integration.semp.v2.config.model.ConfigMsgVpnQueue;
+import com.solacesystems.jcsmp.Consumer;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.Queue;
+import com.solacesystems.jcsmp.TextMessage;
+import com.solacesystems.jcsmp.XMLMessageProducer;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(classes = SolaceJavaAutoConfiguration.class,
+		initializers = ConfigFileApplicationContextInitializer.class)
+public class RetryableRebindTaskIT extends ITBase {
+	private RetryableTaskService taskService;
+	private String vpnName;
+	private Queue queue;
+	private FlowReceiverContainer flowReceiverContainer;
+	private XMLMessageProducer producer;
+
+	private static final Log logger = LogFactory.getLog(RetryableBindTaskIT.class);
+
+	@Before
+	public void setUp() throws Exception {
+		vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		taskService = Mockito.spy(new RetryableTaskService());
+		queue = JCSMPFactory.onlyInstance().createQueue(RandomStringUtils.randomAlphanumeric(20));
+		jcsmpSession.provision(queue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+		flowReceiverContainer = Mockito.spy(new FlowReceiverContainer(jcsmpSession, queue.getName(),
+				new EndpointProperties()));
+		flowReceiverContainer.bind();
+		producer = jcsmpSession.getMessageProducer(new JCSMPSessionProducerManager.CloudStreamEventHandler());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (flowReceiverContainer != null) {
+			Optional.ofNullable(flowReceiverContainer.getFlowReceiverReference())
+					.map(FlowReceiverContainer.FlowReceiverReference::get)
+					.ifPresent(Consumer::close);
+		}
+
+		if (jcsmpSession != null && !jcsmpSession.isClosed()) {
+			jcsmpSession.deprovision(queue, JCSMPSession.WAIT_FOR_CONFIRM);
+		}
+	}
+
+	@Test
+	public void testRun() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableRebindTask task = new RetryableRebindTask(flowReceiverContainer, messageContainer, taskService);
+		UUID flowId = Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId();
+
+		assertTrue(task.run(1));
+		assertTrue(messageContainer.isAcknowledged());
+		assertTrue(messageContainer.isStale());
+		assertTrue(flowReceiverContainer.isBound());
+		assertNotEquals(flowId, Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId());
+	}
+
+	@Test
+	public void testFail() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableRebindTask task = new RetryableRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		Mockito.doThrow(new JCSMPException("test")).when(flowReceiverContainer).acknowledgeRebind(messageContainer);
+		assertFalse(task.run(1));
+		assertFalse(messageContainer.isAcknowledged());
+		assertFalse(messageContainer.isStale());
+	}
+
+	@Test
+	public void testFailWhenUnbound() {
+		flowReceiverContainer.unbind();
+	}
+
+	@Test
+	public void testStale() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = Mockito.spy(flowReceiverContainer.receive(5000));
+		RetryableRebindTask task = new RetryableRebindTask(flowReceiverContainer, messageContainer, taskService);
+		UUID flowId = Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId();
+
+		Mockito.when(messageContainer.isStale()).thenReturn(true);
+		assertTrue(task.run(1));
+		assertEquals(flowId, Objects.requireNonNull(flowReceiverContainer.getFlowReceiverReference()).getId());
+	}
+
+	@Test
+	public void testFailAndStale() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableRebindTask task = new RetryableRebindTask(flowReceiverContainer, messageContainer, taskService);
+
+		logger.info(String.format("Shutting down egress for queue %s", queue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false),
+				null);
+		retryAssert(() -> assertFalse(sempV2Api.monitor()
+				.getMsgVpnQueue(vpnName, queue.getName(), null)
+				.getData()
+				.isEgressEnabled()));
+
+		assertTrue(task.run(1));
+		assertFalse(messageContainer.isAcknowledged());
+		assertTrue(messageContainer.isStale());
+		assertFalse(taskService.hasTask(task));
+		assertTrue(taskService.hasTask(new RetryableBindTask(flowReceiverContainer)));
+		assertFalse(flowReceiverContainer.isBound());
+
+		logger.info(String.format("Starting egress for queue %s", queue.getName()));
+		sempV2Api.config().updateMsgVpnQueue(vpnName, queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true),
+				null);
+
+		retryAssert(() -> {
+			assertFalse(taskService.hasTask(new RetryableBindTask(flowReceiverContainer)));
+			assertTrue(flowReceiverContainer.isBound());
+		});
+
+//		assertNotNull(flowReceiverContainer.receive(5000)); //TODO Re-enable once SOL-45982 is fixed
+	}
+
+	@Test
+	public void testEquals() throws Exception {
+		producer.send(JCSMPFactory.onlyInstance().createMessage(TextMessage.class), queue);
+		MessageContainer messageContainer = flowReceiverContainer.receive(5000);
+		RetryableRebindTask task1 = new RetryableRebindTask(flowReceiverContainer, messageContainer, taskService);
+		RetryableRebindTask task2 = new RetryableRebindTask(flowReceiverContainer, messageContainer, taskService);
+		assertEquals(task1, task2);
+		assertEquals(task1.hashCode(), task1.hashCode());
+		assertThat(new HashSet<>(Collections.singleton(task1)), contains(task2));
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskServiceTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskServiceTest.java
@@ -1,0 +1,104 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solace.spring.cloud.stream.binder.util.RetryableTaskService.RetryableTask;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RetryableTaskServiceTest {
+	private RetryableTaskService taskService;
+	private static final Log logger = LogFactory.getLog(RetryableTaskServiceTest.class);
+
+	@Before
+	public void setUp() {
+		taskService = new RetryableTaskService();
+	}
+
+	@After
+	public void tearDown() {
+		taskService.close();
+	}
+
+	@Test
+	public void testSubmit() throws Exception {
+		CountDownLatch latch = new CountDownLatch(1);
+		taskService.submit(() -> {
+			latch.countDown();
+			return true;
+		});
+
+		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+	}
+
+	@Test
+	public void testRetry() throws Exception {
+		CountDownLatch latch = new CountDownLatch(3);
+		taskService.submit(() -> {
+			logger.info("Attempts remaining: " + latch.getCount());
+			latch.countDown();
+			return latch.getCount() <= 0;
+		});
+
+		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+	}
+
+	@Test
+	public void testRetryOrder() throws Exception {
+		final int numTasks = 3;
+		final int numAttempts = 3;
+		final int taskToEarlyTerminate = 1;
+
+		CountDownLatch startLatch = new CountDownLatch(1);
+		List<CountDownLatch> retryLatches = new ArrayList<>();
+
+		for (int i = 0; i < numTasks; i++) {
+			retryLatches.add(new CountDownLatch(taskToEarlyTerminate == i ? numAttempts - 1 : numAttempts));
+		}
+
+		ConcurrentLinkedQueue<Integer> receiveOrder = new ConcurrentLinkedQueue<>();
+		List<Integer> expectedReceiveOrder = new ArrayList<>();
+
+		for (int attempt = 1; attempt <= numAttempts; attempt++) {
+			for (int taskId = 0; taskId < numTasks; taskId++) {
+				if (taskToEarlyTerminate == taskId && attempt >= numAttempts) continue;
+				expectedReceiveOrder.add(taskId);
+			}
+		}
+
+		BiFunction<Integer, CountDownLatch, RetryableTask> taskGenerator = (id, retryLatch) -> () -> {
+			startLatch.await();
+			receiveOrder.add(id);
+			logger.info(String.format("Task %s: Attempt %s", id, retryLatch.getCount()));
+			retryLatch.countDown();
+			if (retryLatch.getCount() <= 0) {
+				logger.info(String.format("Task %s: Done", id));
+				return true;
+			} else {
+				return false;
+			}
+		};
+
+		for (int i = 0; i < numTasks; i++) {
+			taskService.submit(taskGenerator.apply(i, retryLatches.get(i)));
+		}
+
+		assertThat(receiveOrder).isEmpty();
+		startLatch.countDown();
+
+		for (CountDownLatch retryLatch : retryLatches) {
+			assertThat(retryLatch.await(1, TimeUnit.MINUTES)).isTrue();
+		}
+		assertThat(receiveOrder.toArray(new Integer[0])).isEqualTo(expectedReceiveOrder.toArray());
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskServiceTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/RetryableTaskServiceTest.java
@@ -8,13 +8,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class RetryableTaskServiceTest {
 	private RetryableTaskService taskService;
@@ -33,24 +37,46 @@ public class RetryableTaskServiceTest {
 	@Test
 	public void testSubmit() throws Exception {
 		CountDownLatch latch = new CountDownLatch(1);
-		taskService.submit(() -> {
+		RetryableTask task = attempt -> {
 			latch.countDown();
 			return true;
-		});
+		};
 
+		taskService.submit(task);
 		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+		Thread.sleep(500);
+		assertThat(taskService.hasTask(task)).isFalse();
+	}
+
+	@Test
+	public void testSubmitDuplicate() throws Exception {
+		CountDownLatch latch = new CountDownLatch(2);
+		RetryableTask task = attempt -> {
+			latch.countDown();
+			return true;
+		};
+
+		taskService.submit(task, 1, TimeUnit.MINUTES);
+		taskService.submit(task, 1, TimeUnit.MINUTES);
+		assertThat(latch.await(3, TimeUnit.SECONDS)).isFalse();
+		assertThat(latch.getCount()).isEqualTo(1);
+		Thread.sleep(500);
+		assertThat(taskService.hasTask(task)).isFalse();
 	}
 
 	@Test
 	public void testRetry() throws Exception {
 		CountDownLatch latch = new CountDownLatch(3);
-		taskService.submit(() -> {
+		RetryableTask task = attempt -> {
 			logger.info("Attempts remaining: " + latch.getCount());
 			latch.countDown();
 			return latch.getCount() <= 0;
-		});
+		};
 
+		taskService.submit(task);
 		assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+		Thread.sleep(500);
+		assertThat(taskService.hasTask(task)).isFalse();
 	}
 
 	@Test
@@ -76,10 +102,10 @@ public class RetryableTaskServiceTest {
 			}
 		}
 
-		BiFunction<Integer, CountDownLatch, RetryableTask> taskGenerator = (id, retryLatch) -> () -> {
+		BiFunction<Integer, CountDownLatch, RetryableTask> taskGenerator = (id, retryLatch) -> attempt -> {
 			startLatch.await();
 			receiveOrder.add(id);
-			logger.info(String.format("Task %s: Attempt %s", id, retryLatch.getCount()));
+			logger.info(String.format("Task %s: Attempt %s", id, attempt));
 			retryLatch.countDown();
 			if (retryLatch.getCount() <= 0) {
 				logger.info(String.format("Task %s: Done", id));
@@ -89,8 +115,11 @@ public class RetryableTaskServiceTest {
 			}
 		};
 
+		Set<RetryableTask> tasks = new HashSet<>();
 		for (int i = 0; i < numTasks; i++) {
-			taskService.submit(taskGenerator.apply(i, retryLatches.get(i)));
+			RetryableTask task = taskGenerator.apply(i, retryLatches.get(i));
+			tasks.add(task);
+			taskService.submit(task);
 		}
 
 		assertThat(receiveOrder).isEmpty();
@@ -100,5 +129,50 @@ public class RetryableTaskServiceTest {
 			assertThat(retryLatch.await(1, TimeUnit.MINUTES)).isTrue();
 		}
 		assertThat(receiveOrder.toArray(new Integer[0])).isEqualTo(expectedReceiveOrder.toArray());
+		for (RetryableTask task : tasks) {
+			assertThat(taskService.hasTask(task)).isFalse();
+		}
+	}
+
+	@Test
+	public void testTaskInterrupt() throws Exception {
+		RetryableTask task = attempt -> {
+			throw new InterruptedException("Test");
+		};
+
+		taskService.submit(task);
+		Thread.sleep(500);
+		assertThat(taskService.hasTask(task)).isFalse();
+	}
+
+	@Test
+	public void testShutdown() throws Exception {
+		CountDownLatch latch1 = new CountDownLatch(1);
+		RetryableTask task1 = attempt -> {
+			latch1.countDown();
+			Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+			return false;
+		};
+		RetryableTask task2 = attempt -> false;
+
+		taskService.submit(task1);
+		taskService.submit(task2);
+		assertThat(latch1.await(1, TimeUnit.MINUTES)).isTrue();
+		taskService.close();
+		Thread.sleep(500);
+		assertThat(taskService.hasTask(task1)).isFalse();
+		assertThat(taskService.hasTask(task2)).isFalse();
+	}
+
+	@Test
+	public void testSubmitAfterClose() {
+		taskService.close();
+		assertThrows(RejectedExecutionException.class, () -> taskService.submit(attempt -> true));
+	}
+
+	@Test
+	public void testSubmitNull() {
+		taskService.submit(null);
+		assertThrows(NullPointerException.class, () -> taskService.hasTask(null));
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicIT.java
@@ -41,7 +41,6 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.MimeTypeUtils;
 
 import java.util.HashMap;
@@ -453,16 +452,12 @@ public class SolaceBinderBasicIT extends SolaceBinderITBase {
 		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
 		moduleOutputChannel.send(message);
 
-		boolean gotMessage = false;
-		for (int i = 0; !gotMessage && i < 100; i++) {
-			gotMessage = moduleInputChannel.poll(message1 -> {
-				throw new RuntimeException("Throwing expected exception!");
-			});
-		}
-		assertThat(gotMessage).isTrue();
+		retryAssert(() -> assertThat(moduleInputChannel.poll(message1 -> {
+			throw new RuntimeException("Throwing expected exception!");
+		})).isTrue());
 
-		gotMessage = moduleInputChannel.poll(message1 -> logger.info(String.format("Received message %s", message1)));
-		assertThat(gotMessage).isTrue();
+		retryAssert(() -> assertThat(moduleInputChannel.poll(message1 ->
+				logger.info(String.format("Received message %s", message1)))).isTrue());
 
 		producerBinding.unbind();
 		consumerBinding.unbind();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderCustomErrorMessageHandlerIT.java
@@ -1,13 +1,16 @@
 package com.solace.spring.cloud.stream.binder;
 
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.messaging.SolaceHeaders;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
 import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredRunner;
 import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
 import com.solace.spring.cloud.stream.binder.util.SolaceErrorMessageHandler;
+import com.solacesystems.jcsmp.ConsumerFlowProperties;
 import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.FlowReceiver;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
@@ -23,21 +26,26 @@ import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.PollableSource;
+import org.springframework.cloud.stream.binder.RequeueCurrentMessageException;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
+import org.springframework.integration.acks.AckUtils;
+import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.MimeTypeUtils;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -102,18 +110,257 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		assertThat(errorLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		softly.assertAll();
 
-		// Give some time for the message to actually ack off the original queue
-		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(0);
+		});
 
-		assertThat(sempV2Api.monitor()
-				.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
-				.getData())
-				.hasSize(0);
-		assertThat(sempV2Api.monitor()
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverrideErrorMessageHandlerThrowException() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			throw new RuntimeException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.setMaxAttempts(1);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		moduleInputChannel.subscribe(msg -> {
+			logger.info(String.format("Received message %s", msg));
+			throw new RuntimeException("bad");
+		});
+
+		moduleOutputChannel.send(message);
+
+		FlowReceiver flowReceiver = null;
+		try {
+			final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+			errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(
+					binder.getConsumerErrorQueueName(consumerBinding)));
+			errorQueueFlowProperties.setStartState(true);
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(0);
+		});
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverrideErrorMessageHandlerThrowRequeueException() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			throw new RequeueCurrentMessageException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.setMaxAttempts(1);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		moduleInputChannel.subscribe(msg -> {
+			logger.info(String.format("Received message %s", msg));
+			Boolean redelivered = msg.getHeaders().get(SolaceHeaders.REDELIVERED, Boolean.class);
+			if (redelivered != null && redelivered) {
+				latch.countDown();
+			} else {
+				throw new RuntimeException("bad");
+			}
+		});
+
+		moduleOutputChannel.send(message);
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(1);
+		});
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverrideErrorMessageHandlerThrowExceptionAndStale() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		CountDownLatch continueLatch = new CountDownLatch(1);
+		CountDownLatch errorStartLatch = new CountDownLatch(1);
+		SoftAssertions softly = new SoftAssertions();
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			errorStartLatch.countDown();
+			try {
+				softly.assertThat(continueLatch.await(1, TimeUnit.MINUTES)).isTrue();
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+			throw new RuntimeException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.setMaxAttempts(1);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		consumerProperties.getExtension().setFlowPreRebindWaitTimeout(0);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message1 = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader("skip", true)
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+		Message<?> message2 = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		CompletableFuture<AcknowledgmentCallback> staleTriggeringAckFuture = new CompletableFuture<>();
+
+		moduleInputChannel.subscribe(msg -> {
+			logger.info(String.format("Received message %s", msg));
+			Boolean redelivered = msg.getHeaders().get(SolaceHeaders.REDELIVERED, Boolean.class);
+			if (redelivered == null || !redelivered) {
+				if (msg.getHeaders().containsKey("skip")) {
+					AcknowledgmentCallback ackCallback = StaticMessageHeaderAccessor.getAcknowledgmentCallback(msg);
+					softly.assertThat(ackCallback).isNotNull();
+					ackCallback.noAutoAck();
+					staleTriggeringAckFuture.complete(ackCallback);
+				} else {
+					throw new RuntimeException("bad");
+				}
+			}
+		});
+
+		moduleOutputChannel.send(message1);
+		moduleOutputChannel.send(message2);
+
+		AcknowledgmentCallback staleTriggeringAck = staleTriggeringAckFuture.get(1, TimeUnit.MINUTES);
+		assertThat(errorStartLatch.await(1, TimeUnit.MINUTES)).isTrue();
+		AckUtils.requeue(staleTriggeringAck); // Force real message to be stale
+
+		retryAssert(() -> assertThat(sempV2Api.monitor()
 				.getMsgVpnQueue(vpnName, queueName, null)
 				.getData()
-				.getRedeliveredMsgCount())
-				.isEqualTo(0);
+				.getBindSuccessCount())
+				.isEqualTo(3));
+
+		continueLatch.countDown();
+		softly.assertAll();
+
+		String errorQueueName = binder.getConsumerErrorQueueName(consumerBinding);
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(2);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, errorQueueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+		});
 
 		producerBinding.unbind();
 		consumerBinding.unbind();
@@ -168,18 +415,154 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		assertThat(errorLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		softly.assertAll();
 
-		// Give some time for the message to actually ack off the original queue
-		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(0);
+		});
 
-		assertThat(sempV2Api.monitor()
-				.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
-				.getData())
-				.hasSize(0);
-		assertThat(sempV2Api.monitor()
-				.getMsgVpnQueue(vpnName, queueName, null)
-				.getData()
-				.getRedeliveredMsgCount())
-				.isEqualTo(0);
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverrideRetryableErrorMessageHandlerThrowException() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			throw new RuntimeException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.setMaxAttempts(3);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		moduleInputChannel.subscribe(msg -> {
+			logger.info(String.format("Received message %s", msg));
+			throw new RuntimeException("bad");
+		});
+
+		moduleOutputChannel.send(message);
+
+		FlowReceiver flowReceiver = null;
+		try {
+			final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+			errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(
+					binder.getConsumerErrorQueueName(consumerBinding)));
+			errorQueueFlowProperties.setStartState(true);
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(0);
+		});
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverrideRetryableErrorMessageHandlerThrowRequeueException() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		DirectChannel moduleInputChannel = createBindableChannel("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			throw new RequeueCurrentMessageException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.setMaxAttempts(3);
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		moduleInputChannel.subscribe(msg -> {
+			logger.info(String.format("Received message %s", msg));
+			Boolean redelivered = msg.getHeaders().get(SolaceHeaders.REDELIVERED, Boolean.class);
+			if (redelivered != null && redelivered) {
+				latch.countDown();
+			} else {
+				throw new RuntimeException("bad");
+			}
+		});
+
+		moduleOutputChannel.send(message);
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(1);
+		});
 
 		producerBinding.unbind();
 		consumerBinding.unbind();
@@ -233,18 +616,161 @@ public class SolaceBinderCustomErrorMessageHandlerIT extends SolaceBinderITBase 
 		assertThat(errorLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		softly.assertAll();
 
-		// Give some time for the message to actually ack off the original queue
-		Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(0);
+		});
 
-		assertThat(sempV2Api.monitor()
-				.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
-				.getData())
-				.hasSize(0);
-		assertThat(sempV2Api.monitor()
-				.getMsgVpnQueue(vpnName, queueName, null)
-				.getData()
-				.getRedeliveredMsgCount())
-				.isEqualTo(0);
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverridePollableErrorMessageHandlerThrowException() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			throw new RuntimeException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		retryAssert(() -> assertThrows(MessageHandlingException.class, () -> moduleInputChannel.poll(msg -> {
+			logger.info(String.format("Received message %s", msg));
+			throw new RuntimeException("bad");
+		})));
+
+		FlowReceiver flowReceiver = null;
+		try {
+			final ConsumerFlowProperties errorQueueFlowProperties = new ConsumerFlowProperties();
+			errorQueueFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(
+					binder.getConsumerErrorQueueName(consumerBinding)));
+			errorQueueFlowProperties.setStartState(true);
+			flowReceiver = jcsmpSession.createFlow(null, errorQueueFlowProperties);
+			assertThat(flowReceiver.receive((int) TimeUnit.SECONDS.toMillis(10))).isNotNull();
+		} finally {
+			if (flowReceiver != null) {
+				flowReceiver.close();
+			}
+		}
+
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(0);
+		});
+
+		producerBinding.unbind();
+		consumerBinding.unbind();
+	}
+
+	@Test
+	public void testConsumerOverridePollableErrorMessageHandlerThrowRequeueException() throws Exception {
+		SolaceTestBinder binder = getBinder();
+
+		String destination0 = RandomStringUtils.randomAlphanumeric(10);
+		String group0 = RandomStringUtils.randomAlphanumeric(10);
+		String errorDestination0 = destination0 + getDestinationNameDelimiter() + group0 +
+				getDestinationNameDelimiter() + "errors";
+		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+		String queueName = destination0 + getDestinationNameDelimiter() + group0;
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", new BindingProperties());
+		PollableSource<MessageHandler> moduleInputChannel = createBindableMessageSource("input", new BindingProperties());
+
+		// Need to create channel before so that the override actually works
+		createChannel(errorDestination0, DirectChannel.class, msg -> {
+			logger.info("Got error message: " + msg);
+			throw new RequeueCurrentMessageException("test");
+		});
+
+		Binding<MessageChannel> producerBinding = binder.bindProducer(
+				destination0, moduleOutputChannel, createProducerProperties());
+
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setAutoBindErrorQueue(true);
+		Binding<PollableSource<MessageHandler>> consumerBinding = binder.bindPollableConsumer(
+				destination0, group0, moduleInputChannel, consumerProperties);
+
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+				.build();
+
+		binderBindUnbindLatency();
+
+		logger.info(String.format("Sending message to destination %s: %s", destination0, message));
+		moduleOutputChannel.send(message);
+
+		boolean gotMessage = false;
+		for (int i = 0; !gotMessage && i < 100; i++) {
+			gotMessage = moduleInputChannel.poll(msg -> {
+				logger.info(String.format("Received message %s", msg));
+				throw new RuntimeException("bad");
+			});
+		}
+
+		SoftAssertions softly = new SoftAssertions();
+		boolean gotSuccessMessage = false;
+		for (int i = 0; !gotSuccessMessage && i < 100; i++) {
+			gotSuccessMessage = moduleInputChannel.poll(msg -> {
+				logger.info(String.format("Received message %s", msg));
+				softly.assertThat(msg.getHeaders().get(SolaceHeaders.REDELIVERED, Boolean.class)).isTrue();
+			});
+		}
+		assertThat(gotSuccessMessage).isTrue();
+		softly.assertAll();
+
+		retryAssert(() -> {
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueueMsgs(vpnName, queueName, 1, null, null, null)
+					.getData())
+					.hasSize(0);
+			assertThat(sempV2Api.monitor()
+					.getMsgVpnQueue(vpnName, queueName, null)
+					.getData()
+					.getRedeliveredMsgCount())
+					.isEqualTo(1);
+		});
 
 		producerBinding.unbind();
 		consumerBinding.unbind();


### PR DESCRIPTION
fixes #36 
* When an error handler throws an exception, `REJECT` the message
* When an error handler throws a `RequeueCurrentMessageException`, `REQUEUE` the message
* Retry to publish to the error queue up to 3 times (configurable with `errorQueueMaxDeliveryAttempts`) then fallback to `REQUEUE`
* When `REQUEUE` fails, asynchronously retry for all of eternity.