### PR TITLE
added support for new ReplicationGroupMessageId

### DIFF
--- a/solace-spring-cloud-parent/pom.xml
+++ b/solace-spring-cloud-parent/pom.xml
@@ -23,8 +23,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <solace.jcsmp.version>10.10.0</solace.jcsmp.version>
-        <solace.jms.version>10.10.0</solace.jms.version>
+        <solace.jcsmp.version>10.12.0</solace.jcsmp.version>
+        <solace.jms.version>10.12.0</solace.jms.version>
     </properties>
 
     <dependencyManagement>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -495,6 +495,11 @@ This is the `JMSType` header field if publishing/consuming to/from JMS.
 | Read
 | Indicates if the message has been delivered by the broker to the API before.
 
+| solace_replicationGroupMessageId
+| ReplicationGroupMessageId
+| Read
+| Specifies a Replication Group Message ID as a replay start location.
+
 | solace_replyTo
 | Destination
 | Read/Write

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
 import com.solacesystems.jcsmp.Destination;
+import com.solacesystems.jcsmp.ReplicationGroupMessageId;
 import com.solacesystems.jcsmp.XMLMessage;
 
 import java.util.Map;
@@ -22,6 +23,7 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 			{SolaceHeaders.PRIORITY, new SolaceHeaderMeta<>(Integer.class, XMLMessage::getPriority, XMLMessage::setPriority)},
 			{SolaceHeaders.RECEIVE_TIMESTAMP, new SolaceHeaderMeta<>(Long.class, XMLMessage::getReceiveTimestamp, null)},
 			{SolaceHeaders.REDELIVERED, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::getRedelivered, null)},
+			{SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID, new SolaceHeaderMeta<>(ReplicationGroupMessageId.class, XMLMessage::getReplicationGroupMessageId, null)},
 			{SolaceHeaders.REPLY_TO, new SolaceHeaderMeta<>(Destination.class, XMLMessage::getReplyTo, XMLMessage::setReplyTo)},
 			{SolaceHeaders.SENDER_ID, new SolaceHeaderMeta<>(String.class, XMLMessage::getSenderId, XMLMessage::setSenderId)},
 			{SolaceHeaders.SENDER_TIMESTAMP, new SolaceHeaderMeta<>(Long.class, XMLMessage::getSenderTimestamp, XMLMessage::setSenderTimestamp)},

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
@@ -18,7 +18,7 @@ public final class SolaceHeaders {
 	static final String PREFIX = "solace_";
 
 	/**
-	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
+	 * <p><b>Acceptable Value Type:</b> {@link ReplicationGroupMessageId}</p>
 	 * <p><b>Access:</b> Read/Write</p>
 	 * <br>
 	 * <p>The message ID (a string for an application-specific message identifier).</p>
@@ -91,6 +91,15 @@ public final class SolaceHeaders {
 	 * <p>Priority value in the range of 0–255, or -1 if it is not set.</p>
 	 */
 	public static final String PRIORITY = PREFIX + "priority";
+
+	/**
+	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
+	 * <p><b>Access:</b> Read</p>
+	 * <br>
+	 * <p>The replication group message ID (Specifies a Replication Group Message ID as a replay start location.).</p>
+	 */
+
+	public static final String REPLICATION_GROUP_MESSAGE_ID = PREFIX + "replicationGroupMessageId";
 
 	/**
 	 * <p><b>Acceptable Value Type:</b> {@link Long}</p>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
 import com.solacesystems.jcsmp.Destination;
+import com.solacesystems.jcsmp.ReplicationGroupMessageId;
 import org.springframework.messaging.Message;
 
 /**

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
@@ -18,7 +18,7 @@ public final class SolaceHeaders {
 	static final String PREFIX = "solace_";
 
 	/**
-	 * <p><b>Acceptable Value Type:</b> {@link ReplicationGroupMessageId}</p>
+	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
 	 * <p><b>Access:</b> Read/Write</p>
 	 * <br>
 	 * <p>The message ID (a string for an application-specific message identifier).</p>
@@ -93,7 +93,7 @@ public final class SolaceHeaders {
 	public static final String PRIORITY = PREFIX + "priority";
 
 	/**
-	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
+	 * <p><b>Acceptable Value Type:</b> {@link ReplicationGroupMessageId}</p>
 	 * <p><b>Access:</b> Read</p>
 	 * <br>
 	 * <p>The replication group message ID (Specifies a Replication Group Message ID as a replay start location.).</p>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -15,6 +15,7 @@ import com.solacesystems.jcsmp.BytesMessage;
 import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.MapMessage;
+import com.solacesystems.jcsmp.ReplicationGroupMessageId;
 import com.solacesystems.jcsmp.SDTException;
 import com.solacesystems.jcsmp.SDTMap;
 import com.solacesystems.jcsmp.SDTStream;
@@ -322,6 +323,9 @@ public class XMLMessageMapperTest {
 
 		for (Map.Entry<String, ? extends HeaderMeta<?>> header : nonWriteableHeaders) {
 			switch (header.getKey()) {
+				case SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID:
+					assertNull(xmlMessage.getReplicationGroupMessageId());
+					break;
 				case SolaceHeaders.DESTINATION:
 					assertNull(xmlMessage.getDestination());
 					break;
@@ -861,6 +865,9 @@ public class XMLMessageMapperTest {
 				case SolaceHeaders.REDELIVERED:
 					Mockito.when(xmlMessage.getRedelivered()).thenReturn(!defaultXmlMessage.getRedelivered());
 					break;
+				case SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID:
+					Mockito.when(xmlMessage.getReplicationGroupMessageId()).thenReturn(Mockito.mock(ReplicationGroupMessageId.class));
+					break;
 				case SolaceHeaders.REPLY_TO:
 					Mockito.when(xmlMessage.getReplyTo())
 							.thenReturn(JCSMPFactory.onlyInstance().createQueue(header.getKey()));
@@ -931,6 +938,9 @@ public class XMLMessageMapperTest {
 					break;
 				case SolaceHeaders.REDELIVERED:
 					assertEquals(xmlMessage.getRedelivered(), actualValue);
+					break;
+				case SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID:
+					assertEquals(xmlMessage.getReplicationGroupMessageId(), actualValue);
 					break;
 				case SolaceHeaders.REPLY_TO:
 					assertEquals(xmlMessage.getReplyTo(), actualValue);


### PR DESCRIPTION
Added support for `ReplicationGroupMessageId` as a Solace header message property.

This was recently added in the broker to support replay from a message but was left out of the Spring Cloud Stream binders.