### PR TITLE
Replace Links to Old Repo

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -130,7 +130,7 @@ spring:
                 reconnectRetries: -1
 ----
 
-Notice that the latter half of this configuration actually originates from the https://github.com/SolaceProducts/solace-java-spring-boot#updating-your-application-properties[JCSMP Spring Boot Auto-Configuration project].
+Notice that the latter half of this configuration actually originates from the https://github.com/SolaceProducts/solace-spring-boot/tree/master/solace-spring-boot-starters/solace-java-spring-boot-starter#updating-your-application-properties[JCSMP Spring Boot Auto-Configuration project].
 
 == Configuration Options
 
@@ -140,7 +140,7 @@ Configuration of the Solace Spring Cloud Stream Binder is done through https://d
 
 === Inherited Configuration Options
 
-As for auto-configuration-related options required for auto-connecting to Solace message brokers, refer to the https://github.com/SolaceProducts/solace-java-spring-boot#configure-the-application-to-use-your-solace-pubsub-service-credentials[JCSMP Spring Boot Auto-Configuration documentation].
+As for auto-configuration-related options required for auto-connecting to Solace message brokers, refer to the https://github.com/SolaceProducts/solace-spring-boot/tree/master/solace-spring-boot-starters/solace-java-spring-boot-starter#configure-the-application-to-use-your-solace-pubsub-service-credentials[JCSMP Spring Boot Auto-Configuration documentation].
 
 For general binder configuration options and properties, refer to the https://docs.spring.io/spring-cloud-stream/docs/{scst-version}/reference/html/spring-cloud-stream.html#_configuration_options[Spring Cloud Stream Reference Documentation].
 


### PR DESCRIPTION
Replace Links to Old Repo; point to `solace-spring-boot` repo