### PR TITLE
2.2.0 Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.solace.spring.cloud</groupId>
     <artifactId>solace-spring-cloud-build</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Cloud Build</name>
@@ -36,7 +36,7 @@
         <spring.boot.version>2.4.3</spring.boot.version>
 
         <solace.spring.cloud.connector.version>4.3.4-SNAPSHOT</solace.spring.cloud.connector.version>
-        <solace.spring.cloud.stream-starter.version>3.1.1-SNAPSHOT</solace.spring.cloud.stream-starter.version>
+        <solace.spring.cloud.stream-starter.version>3.2.0-SNAPSHOT</solace.spring.cloud.stream-starter.version>
 
         <solace.integration.test.support.version>0.2.0</solace.integration.test.support.version>
         <solace.integration.test.support.fetch_checkout.skip>false</solace.integration.test.support.fetch_checkout.skip>

--- a/solace-spring-cloud-bom/README.md
+++ b/solace-spring-cloud-bom/README.md
@@ -20,7 +20,7 @@ Consult the table below to determine which version of the BOM you need to use:
 |----------------------|-----------------------|-------------------|
 |Hoxton.SR1            |1.0.0                  | 2.2.x             |
 |Hoxton.SR6            |1.1.0                  | 2.3.x             |
-|2020.0.1              |2.0.0, 2.1.0           | 2.4.x             |
+|2020.0.1              |2.0.0, 2.1.0, 2.2.0    | 2.4.x             |
 
 ## Including the BOM
 
@@ -33,7 +33,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.cloud</groupId>
             <artifactId>solace-spring-cloud-bom</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -61,7 +61,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:2.1.0"
+        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:2.2.0"
     }
 }
 
@@ -73,7 +73,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:2.1.0"))
+    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:2.2.0"))
     implementation("com.solace.spring.cloud:spring-cloud-starter-stream-solace")
 }
 ```

--- a/solace-spring-cloud-bom/pom.xml
+++ b/solace-spring-cloud-bom/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-build</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>solace-spring-cloud-bom</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>Solace Spring Cloud BOM</name>
     <description>BOM for Solace Spring Cloud</description>

--- a/solace-spring-cloud-connector/README.md
+++ b/solace-spring-cloud-connector/README.md
@@ -76,7 +76,7 @@ Include version 4.0.0 or later to use Spring Boot release 2.x
 
 ```
 // Solace Cloud
-compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.3")
+compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.4")
 ```
 
 ### Using it with Maven
@@ -86,7 +86,7 @@ compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.3")
 <dependency>
   <groupId>com.solace.cloud.cloudfoundry</groupId>
   <artifactId>solace-spring-cloud-connector</artifactId>
-  <version>4.3.3</version>
+  <version>4.3.4</version>
 </dependency>
 ```
 

--- a/solace-spring-cloud-connector/pom.xml
+++ b/solace-spring-cloud-connector/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>com.solace.spring.cloud</groupId>
 		<artifactId>solace-spring-cloud-parent</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 		<relativePath>../solace-spring-cloud-parent/pom.xml</relativePath>
 	</parent>
 

--- a/solace-spring-cloud-parent/pom.xml
+++ b/solace-spring-cloud-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-build</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/solace-spring-cloud-parent/pom.xml
+++ b/solace-spring-cloud-parent/pom.xml
@@ -23,8 +23,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <solace.jcsmp.version>10.10.0</solace.jcsmp.version>
-        <solace.jms.version>10.10.0</solace.jms.version>
+        <solace.jcsmp.version>10.12.0</solace.jcsmp.version>
+        <solace.jms.version>10.12.0</solace.jms.version>
     </properties>
 
     <dependencyManagement>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -495,6 +495,11 @@ This is the `JMSType` header field if publishing/consuming to/from JMS.
 | Read
 | Indicates if the message has been delivered by the broker to the API before.
 
+| solace_replicationGroupMessageId
+| ReplicationGroupMessageId
+| Read
+| Specifies a Replication Group Message ID as a replay start location.
+
 | solace_replyTo
 | Destination
 | Read/Write

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -1,5 +1,5 @@
 = Spring Cloud Stream Binder for Solace PubSub+
-:revnumber: 3.1.0
+:revnumber: 3.2.0
 :toc: preamble
 :icons: font
 :scst-version: 3.1.1

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/pom.xml
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-parent</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-cloud-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-cloud-starter-stream-solace</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-parent</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-cloud-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-cloud-stream-binder-solace-core</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Spring Cloud Stream Binder Core</name>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaderMeta.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
 import com.solacesystems.jcsmp.Destination;
+import com.solacesystems.jcsmp.ReplicationGroupMessageId;
 import com.solacesystems.jcsmp.XMLMessage;
 
 import java.util.Map;
@@ -22,6 +23,7 @@ public class SolaceHeaderMeta<T> implements HeaderMeta<T> {
 			{SolaceHeaders.PRIORITY, new SolaceHeaderMeta<>(Integer.class, XMLMessage::getPriority, XMLMessage::setPriority)},
 			{SolaceHeaders.RECEIVE_TIMESTAMP, new SolaceHeaderMeta<>(Long.class, XMLMessage::getReceiveTimestamp, null)},
 			{SolaceHeaders.REDELIVERED, new SolaceHeaderMeta<>(Boolean.class, XMLMessage::getRedelivered, null)},
+			{SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID, new SolaceHeaderMeta<>(ReplicationGroupMessageId.class, XMLMessage::getReplicationGroupMessageId, null)},
 			{SolaceHeaders.REPLY_TO, new SolaceHeaderMeta<>(Destination.class, XMLMessage::getReplyTo, XMLMessage::setReplyTo)},
 			{SolaceHeaders.SENDER_ID, new SolaceHeaderMeta<>(String.class, XMLMessage::getSenderId, XMLMessage::setSenderId)},
 			{SolaceHeaders.SENDER_TIMESTAMP, new SolaceHeaderMeta<>(Long.class, XMLMessage::getSenderTimestamp, XMLMessage::setSenderTimestamp)},

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeaders.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
 import com.solacesystems.jcsmp.Destination;
+import com.solacesystems.jcsmp.ReplicationGroupMessageId;
 import org.springframework.messaging.Message;
 
 /**
@@ -91,6 +92,15 @@ public final class SolaceHeaders {
 	 * <p>Priority value in the range of 0–255, or -1 if it is not set.</p>
 	 */
 	public static final String PRIORITY = PREFIX + "priority";
+
+	/**
+	 * <p><b>Acceptable Value Type:</b> {@link ReplicationGroupMessageId}</p>
+	 * <p><b>Access:</b> Read</p>
+	 * <br>
+	 * <p>The replication group message ID (Specifies a Replication Group Message ID as a replay start location.).</p>
+	 */
+
+	public static final String REPLICATION_GROUP_MESSAGE_ID = PREFIX + "replicationGroupMessageId";
 
 	/**
 	 * <p><b>Acceptable Value Type:</b> {@link Long}</p>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -15,6 +15,7 @@ import com.solacesystems.jcsmp.BytesMessage;
 import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.MapMessage;
+import com.solacesystems.jcsmp.ReplicationGroupMessageId;
 import com.solacesystems.jcsmp.SDTException;
 import com.solacesystems.jcsmp.SDTMap;
 import com.solacesystems.jcsmp.SDTStream;
@@ -322,6 +323,9 @@ public class XMLMessageMapperTest {
 
 		for (Map.Entry<String, ? extends HeaderMeta<?>> header : nonWriteableHeaders) {
 			switch (header.getKey()) {
+				case SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID:
+					assertNull(xmlMessage.getReplicationGroupMessageId());
+					break;
 				case SolaceHeaders.DESTINATION:
 					assertNull(xmlMessage.getDestination());
 					break;
@@ -861,6 +865,9 @@ public class XMLMessageMapperTest {
 				case SolaceHeaders.REDELIVERED:
 					Mockito.when(xmlMessage.getRedelivered()).thenReturn(!defaultXmlMessage.getRedelivered());
 					break;
+				case SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID:
+					Mockito.when(xmlMessage.getReplicationGroupMessageId()).thenReturn(Mockito.mock(ReplicationGroupMessageId.class));
+					break;
 				case SolaceHeaders.REPLY_TO:
 					Mockito.when(xmlMessage.getReplyTo())
 							.thenReturn(JCSMPFactory.onlyInstance().createQueue(header.getKey()));
@@ -931,6 +938,9 @@ public class XMLMessageMapperTest {
 					break;
 				case SolaceHeaders.REDELIVERED:
 					assertEquals(xmlMessage.getRedelivered(), actualValue);
+					break;
+				case SolaceHeaders.REPLICATION_GROUP_MESSAGE_ID:
+					assertEquals(xmlMessage.getReplicationGroupMessageId(), actualValue);
 					break;
 				case SolaceHeaders.REPLY_TO:
 					assertEquals(xmlMessage.getReplyTo(), actualValue);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-parent</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-cloud-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-cloud-stream-binder-solace</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Spring Cloud Stream Binder</name>


### PR DESCRIPTION
# Global
* Minor version bump to `2.2.0`
* Upgrade to sol-jcsmp `10.12.0`
* Upgrade to sol-jms `10.12.0`

# Solace Spring Cloud Stream Binder
* Minor version bump to `3.2.0`
* Add `solace_replicationGroupMessageId` message header