### PR TITLE
Upgrading to solace-spring-boot-bom:1.1.1, solace-services-info:0.4.3, and log4j:2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-bom</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <groupId>com.solace.spring.cloud</groupId>
@@ -29,7 +29,7 @@
         <!-- This is the version of Solace Spring Boot we have targeted for this build -->
         <!-- This also dictates the expected version of Spring Boot -->
         <!-- Must match ${project.parent.version} -->
-        <solace.spring.boot.bom.version>1.1.0</solace.spring.boot.bom.version>
+        <solace.spring.boot.bom.version>1.1.1</solace.spring.boot.bom.version>
 
         <!-- Override spring-boot version from solace-spring-boot to latest patch version -->
         <!-- Remove this if the next version of solace-spring-boot works fine -->

--- a/solace-spring-cloud-bom/README.md
+++ b/solace-spring-cloud-bom/README.md
@@ -16,11 +16,11 @@ Note that since Spring Cloud depends on Spring Boot, the Solace Spring Boot BOM 
 
 Consult the table below to determine which version of the BOM you need to use:
 
-| Spring Cloud         |Solace Spring Cloud BOM|Spring Boot        |
-|----------------------|-----------------------|-------------------|
-|Hoxton.SR1            |1.0.0                  | 2.2.x             |
-|Hoxton.SR6            |1.1.0                  | 2.3.x             |
-|2020.0.1              |2.0.0, 2.1.0, 2.2.0    | 2.4.x             |
+| Spring Cloud         |Solace Spring Cloud BOM    |Spring Boot        |
+|----------------------|---------------------------|-------------------|
+|Hoxton.SR1            |1.0.0                      | 2.2.x             |
+|Hoxton.SR6            |1.1.0                      | 2.3.x             |
+|2020.0.1              |2.0.0, 2.1.0, 2.2.0, 2.2.1 | 2.4.x             |
 
 ## Including the BOM
 
@@ -33,7 +33,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.cloud</groupId>
             <artifactId>solace-spring-cloud-bom</artifactId>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -61,7 +61,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:2.2.0"
+        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:2.2.1"
     }
 }
 
@@ -73,7 +73,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:2.2.0"))
+    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:2.2.1"))
     implementation("com.solace.spring.cloud:spring-cloud-starter-stream-solace")
 }
 ```

--- a/solace-spring-cloud-connector/README.md
+++ b/solace-spring-cloud-connector/README.md
@@ -76,7 +76,7 @@ Include version 4.0.0 or later to use Spring Boot release 2.x
 
 ```
 // Solace Cloud
-compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.4")
+compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.5")
 ```
 
 ### Using it with Maven
@@ -86,7 +86,7 @@ compile("com.solace.cloud.cloudfoundry:solace-spring-cloud-connector:4.3.4")
 <dependency>
   <groupId>com.solace.cloud.cloudfoundry</groupId>
   <artifactId>solace-spring-cloud-connector</artifactId>
-  <version>4.3.4</version>
+  <version>4.3.5</version>
 </dependency>
 ```
 

--- a/solace-spring-cloud-connector/pom.xml
+++ b/solace-spring-cloud-connector/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>com.solace.cloud.core</groupId>
 			<artifactId>solace-services-info</artifactId>
-			<version>0.4.1</version>
+			<version>0.4.2</version>
 		</dependency>
 
 		<dependency>

--- a/solace-spring-cloud-connector/pom.xml
+++ b/solace-spring-cloud-connector/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>com.solace.cloud.core</groupId>
 			<artifactId>solace-services-info</artifactId>
-			<version>0.4.2</version>
+			<version>0.4.3</version>
 		</dependency>
 
 		<dependency>

--- a/solace-spring-cloud-parent/pom.xml
+++ b/solace-spring-cloud-parent/pom.xml
@@ -29,6 +29,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+			Workaround for CVE-2021-45046
+			Remove after upgrading to Spring Boot >= 2.6.2
+			 -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.16.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <!-- Import Solace Spring Boot dependency management -->
                 <groupId>com.solace.spring.boot</groupId>

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -1,5 +1,5 @@
 = Spring Cloud Stream Binder for Solace PubSub+
-:revnumber: 3.2.0
+:revnumber: 3.2.1
 :toc: preamble
 :icons: font
 :scst-version: 3.1.1

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
@@ -81,14 +81,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
@@ -81,14 +81,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
@@ -80,14 +80,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
@@ -80,14 +80,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixes risks for CVE-2021-45046