### PR TITLE
Sol 46284 Queue Name Expression

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -394,7 +394,7 @@ WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in fav
 queueNameExpression::
 A SpEL expression for creating the consumer group’s queue name.
 +
-Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
+Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group?.trim() + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
 See: <<Generated Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -173,18 +173,24 @@ Naming prefix for all queues.
 +
 Default: `"scst"` +
 See: <<Generated Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 useFamiliarityInQueueName::
 When set to `true`, the familiarity modifier, `wk`/`an`, is included in the generated queue name.
 +
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 useDestinationEncodingInQueueName::
 When set to `true`, the destination encoding (`plain`), is included in the generated queue name.
 +
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 useGroupNameInQueueName::
 Whether to include the `group` name in the queue name for non-anonymous consumer groups.
@@ -193,6 +199,8 @@ Default: `true` +
 See: <<Generated Queue Name Syntax>>
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will consume from the same queue regardless of their configured `group` names.
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 queueAccessType::
 Access type for the consumer group queue.
@@ -264,6 +272,8 @@ A custom error queue name.
 +
 Default: `null` +
 See: <<Generated Error Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `errorQueueNameExpression`.
 
 useGroupNameInErrorQueueName::
 Whether to include the `group` name in the error queue name for non-anonymous consumer groups.
@@ -272,6 +282,8 @@ Default: `true` +
 See: <<Generated Error Queue Name Syntax>>
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will republish failed messages to the same error queue regardless of their configured `group` names.
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `errorQueueNameExpression`.
 
 errorQueueMaxDeliveryAttempts::
 Maximum number of attempts to send a failed message to the error queue. When all delivery attempts have been exhausted, the failed message will be requeued.
@@ -364,18 +376,24 @@ Naming prefix for all queues.
 +
 Default: `"scst"` +
 See: <<Generated Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 useFamiliarityInQueueName::
 When set to `true`, the familiarity modifier, `wk`/`an`, is included in the generated queue name.
 +
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 useDestinationEncodingInQueueName::
 When set to `true`, the destination encoding (`plain`), is included in the generated queue name.
 +
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
++
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
 
 queueAccessType::
 Access type for the required consumer group queue.

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -184,7 +184,7 @@ Naming prefix for all queues.
 Default: `"scst"` +
 See: <<Generated Queue Name Syntax>>
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `errorQueueNameExpression`. Prefixes can be specified directly in these SpEL expressions.
 
 useFamiliarityInQueueName::
 When set to `true`, the familiarity modifier, `wk`/`an`, is included in the generated queue name.
@@ -192,7 +192,7 @@ When set to `true`, the familiarity modifier, `wk`/`an`, is included in the gene
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `errorQueueNameExpression`. The familiarity modifier can be removed from queue names by removing it directly from these SpEL expressions.
 
 useDestinationEncodingInQueueName::
 When set to `true`, the destination encoding (`plain`), is included in the generated queue name.
@@ -200,7 +200,7 @@ When set to `true`, the destination encoding (`plain`), is included in the gener
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `errorQueueNameExpression`. The destination encoding can be removed from queue names by removing it directly from these SpEL expressions.
 
 useGroupNameInQueueName::
 Whether to include the `group` name in the queue name for non-anonymous consumer groups.
@@ -210,7 +210,7 @@ See: <<Generated Queue Name Syntax>>
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will consume from the same queue regardless of their configured `group` names.
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`. The group name can be removed from the consumer group's queue name by removing it directly from this SpEL expression.
 
 queueAccessType::
 Access type for the consumer group queue.
@@ -303,7 +303,7 @@ See: <<Generated Error Queue Name Syntax>>
 +
 IMPORTANT: If set to `false`, all consumers of the same `destination` which also have this set to `false` will republish failed messages to the same error queue regardless of their configured `group` names.
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `errorQueueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `errorQueueNameExpression`. The group name can be removed from the error queue name by removing it directly from this SpEL expression.
 
 errorQueueMaxDeliveryAttempts::
 Maximum number of attempts to send a failed message to the error queue. When all delivery attempts have been exhausted, the failed message will be requeued.
@@ -419,7 +419,7 @@ Naming prefix for all queues.
 Default: `"scst"` +
 See: <<Generated Queue Name Syntax>>
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `queueNameExpressionsForRequiredGroups`. Prefixes can be specified directly in these SpEL expressions.
 
 useFamiliarityInQueueName::
 When set to `true`, the familiarity modifier, `wk`/`an`, is included in the generated queue name.
@@ -427,7 +427,7 @@ When set to `true`, the familiarity modifier, `wk`/`an`, is included in the gene
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `queueNameExpressionsForRequiredGroups`. The familiarity modifier can be removed from queue names by removing it directly from these SpEL expressions.
 
 useDestinationEncodingInQueueName::
 When set to `true`, the destination encoding (`plain`), is included in the generated queue name.
@@ -435,7 +435,7 @@ When set to `true`, the destination encoding (`plain`), is included in the gener
 Default: `true` +
 See: <<Generated Queue Name Syntax>>
 +
-WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`.
+WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `queueNameExpressionsForRequiredGroups`. The destination encoding can be removed from queue names by removing it directly from these SpEL expressions.
 
 queueAccessType::
 Access type for the required consumer group queue.
@@ -724,8 +724,6 @@ The definitions of each segment of the error queue matches that from <<Generated
 
 group::
 The consumer `group` name. Can be enabled/disabled with the `useGroupNameInErrorQueueName` (deprecated) consumer config option.
-
-The error queue name can also be manually overridden with the `errorQueueNameOverride` (deprecated) consumer config option.
 
 == Consumer Concurrency
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -168,6 +168,14 @@ Default: `true`
 +
 WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `addDestinationAsSubscriptionToQueue`.
 
+queueNameExpression::
+A SpEL expression for creating the consumer group’s queue name.
++
+Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
+See: <<Generated Queue Name Syntax>>
++
+WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
+
 queueNamePrefix::
 Naming prefix for all queues.
 +
@@ -266,6 +274,14 @@ Whether to provision durable queues for error queues when `autoBindErrorQueue` i
 +
 Default: `true` +
 See: <<Generated Error Queue Name Syntax>>
+
+errorQueueNameExpression::
+A SpEL expression for creating the error queue’s name.
++
+Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";"` +
+See: <<Generated Error Queue Name Syntax>>
++
+WARNING: Modifying this can cause naming conflicts between the error queue names.
 
 errorQueueNameOverride::
 A custom error queue name.
@@ -370,6 +386,24 @@ Whether to add topic subscriptions to durable queues for non-anonymous consumer 
 Default: `true`
 +
 WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in favor of `addDestinationAsSubscriptionToQueue`.
+
+queueNameExpression::
+A SpEL expression for creating the consumer group’s queue name.
++
+Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
+See: <<Generated Queue Name Syntax>>
++
+WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
+
+queueNameExpressionsForRequiredGroups::
+A mapping of required consumer groups to queue name SpEL expressions.
++
+By default, queueNameExpression will be used to generate a required group’s queue name if it isn’t specified within this configuration option.
++
+Default: `Empty Map<String, String>` +
+See: <<Generated Queue Name Syntax>>
++
+WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
 
 queueNamePrefix::
 Naming prefix for all queues.
@@ -631,20 +665,42 @@ By default, generated consumer group queue names have the following form:
 ----
 <prefix>/<familiarity-modifier>/<group>/<destination-encoding>/<encoded-destination>
 ----
+The `queueNameExpression` property's default Spring Expression conforms to the above format, however, users can provide any valid Spring Expression in order to generate custom queue names. Valid expressions evaluate against the following context:
+[cols="1m,1", options="header"]
+|===
+| Level
+| Description
 
-prefix::
+| destination
+| The binding’s destination name.
+
+| group
+| The binding’s consumer group name.
+
+| isAnonymous
+| Indicates whether the consumer is an anonymous consumer group
+
+| properties.solace
+| The configured Solace binding properties.
+
+| properties.spring
+| The configured Spring binding properties.
+|===
+WARNING: The expression evaluation context is subject to change and should not be used other than to customize queue names.
+
+prefix (deprecated)::
 A static prefix as indicated by the `queueNamePrefix` configuration option.
 
-familiarity-modifier::
+familiarity-modifier (deprecated)::
 Indicates the durability of the consumer group (`wk` for well-known or `an` for anonymous). Can be enabled/disabled with the `useFamiliarityInQueueName` config option.
 
-group::
+group (deprecated)::
 The consumer `group` name. Can be enabled/disabled for consumers with the `useGroupNameInQueueName` consumer config option.
 
-destination-encoding::
+destination-encoding (deprecated)::
 Indicates the encoding scheme used to encode the destination in the queue name (currently only `plain` is supported). Can be enabled/disabled with the `useDestinationEncodingInQueueName` config option.
 
-encoded-destination::
+encoded-destination (deprecated)::
 The encoded `destination` as per `<destination-encoding>`.
 
 === Generated Error Queue Name Syntax
@@ -655,9 +711,11 @@ By default, generated error queue names have the following form:
 <prefix>/error/<familiarity-modifier>/<group>/<destination-encoding>/<encoded-destination>
 ----
 
+The `errorQueueNameExpression` property's default Spring Expression conforms to the above format. Users can provide any valid Spring Expression in order to generate custom error queue names using the same evaluation context as described in <<Generated Queue Name Syntax>>.
+
 The definitions of each segment of the error queue matches that from <<Generated Queue Name Syntax>>, with the following exceptions:
 
-group::
+group (deprecated)::
 The consumer `group` name. Can be enabled/disabled with the `useGroupNameInErrorQueueName` consumer config option.
 
 The error queue name can also be manually overridden with the `errorQueueNameOverride` consumer config option.

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -718,12 +718,12 @@ By default, generated error queue names have the following form:
 <prefix>/error/<familiarity-modifier>/<group>/<destination-encoding>/<encoded-destination>
 ----
 
-The `errorQueueNameExpression` property's default SpEL expression conforms to the above format. Users can provide any valid SpEL expression in order to generate custom error queue names using the same evaluation context as described in <<Generated Queue Name Syntax>>.
-
 The definitions of each segment of the error queue matches that from <<Generated Queue Name Syntax>>, with the following exceptions:
 
 group::
 The consumer `group` name. Can be enabled/disabled with the `useGroupNameInErrorQueueName` (deprecated) consumer config option.
+
+The `errorQueueNameExpression` property's default SpEL expression conforms to the above format. Users can provide any valid SpEL expression in order to generate custom error queue names using the same evaluation context as described in <<Generated Queue Name Syntax>>.
 
 == Consumer Concurrency
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -175,6 +175,8 @@ Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties
 See: <<Generated Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
++
+WARNING: While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>, directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 
 queueNamePrefix::
 Naming prefix for all queues.
@@ -282,6 +284,8 @@ Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties
 See: <<Generated Error Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the error queue names.
++
+WARNING: While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>, directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 
 errorQueueNameOverride::
 A custom error queue name.
@@ -394,6 +398,8 @@ Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties
 See: <<Generated Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
++
+WARNING: While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>, directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 
 queueNameExpressionsForRequiredGroups::
 A mapping of required consumer groups to queue name SpEL expressions.
@@ -404,6 +410,8 @@ Default: `Empty Map<String, String>` +
 See: <<Generated Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
++
+WARNING: While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>, directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 
 queueNamePrefix::
 Naming prefix for all queues.
@@ -665,7 +673,22 @@ By default, generated consumer group queue names have the following form:
 ----
 <prefix>/<familiarity-modifier>/<group>/<destination-encoding>/<encoded-destination>
 ----
-The `queueNameExpression` property's default Spring Expression conforms to the above format, however, users can provide any valid Spring Expression in order to generate custom queue names. Valid expressions evaluate against the following context:
+prefix::
+A static prefix as indicated by the `queueNamePrefix` (deprecated) configuration option.
+
+familiarity-modifier::
+Indicates the durability of the consumer group (`wk` for well-known or `an` for anonymous). Can be enabled/disabled with the `useFamiliarityInQueueName` (deprecated) config option.
+
+group::
+The consumer `group` name. Can be enabled/disabled for consumers with the `useGroupNameInQueueName` (deprecated) consumer config option.
+
+destination-encoding::
+Indicates the encoding scheme used to encode the destination in the queue name (currently only `plain` is supported). Can be enabled/disabled with the `useDestinationEncodingInQueueName` (deprecated) config option.
+
+encoded-destination::
+The encoded `destination` as per `<destination-encoding>`.
+
+The `queueNameExpression` property's default SpEL expression conforms to the above format, however, users can provide any valid SpEL expression in order to generate custom queue names. Valid expressions evaluate against the following context:
 [cols="1m,1", options="header"]
 |===
 | Context Variable
@@ -686,22 +709,6 @@ The `queueNameExpression` property's default Spring Expression conforms to the a
 | properties.spring
 | The configured Spring binding properties.
 |===
-WARNING: The expression evaluation context is subject to change and should not be used other than to customize queue names.
-
-prefix (deprecated)::
-A static prefix as indicated by the `queueNamePrefix` configuration option.
-
-familiarity-modifier (deprecated)::
-Indicates the durability of the consumer group (`wk` for well-known or `an` for anonymous). Can be enabled/disabled with the `useFamiliarityInQueueName` config option.
-
-group (deprecated)::
-The consumer `group` name. Can be enabled/disabled for consumers with the `useGroupNameInQueueName` consumer config option.
-
-destination-encoding (deprecated)::
-Indicates the encoding scheme used to encode the destination in the queue name (currently only `plain` is supported). Can be enabled/disabled with the `useDestinationEncodingInQueueName` config option.
-
-encoded-destination (deprecated)::
-The encoded `destination` as per `<destination-encoding>`.
 
 === Generated Error Queue Name Syntax
 
@@ -711,14 +718,14 @@ By default, generated error queue names have the following form:
 <prefix>/error/<familiarity-modifier>/<group>/<destination-encoding>/<encoded-destination>
 ----
 
-The `errorQueueNameExpression` property's default Spring Expression conforms to the above format. Users can provide any valid Spring Expression in order to generate custom error queue names using the same evaluation context as described in <<Generated Queue Name Syntax>>.
+The `errorQueueNameExpression` property's default SpEL expression conforms to the above format. Users can provide any valid SpEL expression in order to generate custom error queue names using the same evaluation context as described in <<Generated Queue Name Syntax>>.
 
 The definitions of each segment of the error queue matches that from <<Generated Queue Name Syntax>>, with the following exceptions:
 
-group (deprecated)::
-The consumer `group` name. Can be enabled/disabled with the `useGroupNameInErrorQueueName` consumer config option.
+group::
+The consumer `group` name. Can be enabled/disabled with the `useGroupNameInErrorQueueName` (deprecated) consumer config option.
 
-The error queue name can also be manually overridden with the `errorQueueNameOverride` consumer config option.
+The error queue name can also be manually overridden with the `errorQueueNameOverride` (deprecated) consumer config option.
 
 == Consumer Concurrency
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -171,7 +171,7 @@ WARNING: **Deprecated:** Since version 3.3.0, this property is deprecated in fav
 queueNameExpression::
 A SpEL expression for creating the consumer group’s queue name.
 +
-Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
+Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group?.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group?.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
 See: <<Generated Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the queue names of consumer groups.
@@ -278,7 +278,7 @@ See: <<Generated Error Queue Name Syntax>>
 errorQueueNameExpression::
 A SpEL expression for creating the error queue’s name.
 +
-Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";"` +
+Default: `"(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group?.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group?.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')"` +
 See: <<Generated Error Queue Name Syntax>>
 +
 WARNING: Modifying this can cause naming conflicts between the error queue names.
@@ -668,7 +668,7 @@ By default, generated consumer group queue names have the following form:
 The `queueNameExpression` property's default Spring Expression conforms to the above format, however, users can provide any valid Spring Expression in order to generate custom queue names. Valid expressions evaluate against the following context:
 [cols="1m,1", options="header"]
 |===
-| Level
+| Context Variable
 | Description
 
 | destination

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
@@ -26,14 +26,17 @@ public class SolaceCommonProperties {
 	/**
 	 * Naming prefix for all queues.
 	 */
+	@Deprecated
 	private String queueNamePrefix = "scst";
 	/**
 	 * When set to true, the familiarity modifier, wk/an, is included in the generated queue name.
 	 */
+	@Deprecated
 	private boolean useFamiliarityInQueueName = true;
 	/**
 	 * When set to true, the destination encoding (plain), is included in the generated queue name.
 	 */
+	@Deprecated
 	private boolean useDestinationEncodingInQueueName = true;
 
 	/**

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
@@ -15,7 +15,7 @@ public class SolaceCommonProperties {
 	 * This should only be set to false if you have externally pre-added the required topic subscriptions (the destination topic should be added at minimum)
 	 * on the consumer group’s queue on the message broker. This property also applies to topics added by the queueAdditionalSubscriptions property.
 	 */
-  @Deprecated
+	@Deprecated
 	private boolean provisionSubscriptionsToDurableQueue = true;
 	/**
 	 * Whether to add the Destination as a subscription to queue during provisioning.

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceCommonProperties.java
@@ -94,6 +94,7 @@ public class SolaceCommonProperties {
 		this.addDestinationAsSubscriptionToQueue = addDestinationAsSubscriptionToQueue;
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Since version 3.3.0, this property is deprecated in favor of queueNameExpression and errorQueueNameExpression. Prefixes can be specified directly in these SpEL expressions.")
 	public String getQueueNamePrefix() {
 		return queueNamePrefix;
 	}
@@ -102,6 +103,7 @@ public class SolaceCommonProperties {
 		this.queueNamePrefix = queueNamePrefix;
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `errorQueueNameExpression`. The familiarity modifier can be removed from queue names by removing it directly from these SpEL expressions.")
 	public boolean isUseFamiliarityInQueueName() {
 		return useFamiliarityInQueueName;
 	}
@@ -110,6 +112,7 @@ public class SolaceCommonProperties {
 		this.useFamiliarityInQueueName = useFamiliarityInQueueName;
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Since version 3.3.0, this property is deprecated in favor of `queueNameExpression` and `errorQueueNameExpression`. The destination encoding can be removed from queue names by removing it directly from these SpEL expressions.")
 	public boolean isUseDestinationEncodingInQueueName() {
 		return useDestinationEncodingInQueueName;
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -29,6 +29,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	/**
 	 * Whether to include the group name in the queue name for non-anonymous consumer groups.
 	 */
+	@Deprecated
 	private boolean useGroupNameInQueueName = true;
 
 	/**
@@ -56,10 +57,12 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	/**
 	 * A custom error queue name.
 	 */
+	@Deprecated
 	private String errorQueueNameOverride = null;
 	/**
 	 * Whether to include the group name in the error queue name for non-anonymous consumer groups.
 	 */
+	@Deprecated
 	private boolean useGroupNameInErrorQueueName = true;
 	/**
 	 * Maximum number of attempts to send a failed message to the error queue.

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -36,7 +36,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 * A SpEL expression for creating the consumer group’s queue name.
 	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
 	 */
-	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group?.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group?.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 
 	// Error Queue Properties ---------
 	/**
@@ -53,7 +53,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 * A SpEL expression for creating the error queue’s name.
 	 * Modifying this can cause naming conflicts between the error queue names.
 	 */
-	private String errorQueueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+	private String errorQueueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group?.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group?.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 	/**
 	 * A custom error queue name.
 	 */

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -35,6 +35,8 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	/**
 	 * A SpEL expression for creating the consumer group’s queue name.
 	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
+	 * While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>,
+	 * directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 	 */
 	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group?.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group?.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 
@@ -52,6 +54,8 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	/**
 	 * A SpEL expression for creating the error queue’s name.
 	 * Modifying this can cause naming conflicts between the error queue names.
+	 * While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>,
+	 * directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 	 */
 	private String errorQueueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group?.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group?.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 	/**

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -2,6 +2,7 @@ package com.solace.spring.cloud.stream.binder.properties;
 
 import com.solacesystems.jcsmp.EndpointProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 import java.util.concurrent.TimeUnit;
 
@@ -135,6 +136,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 		this.queueAdditionalSubscriptions = queueAdditionalSubscriptions;
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Since version 3.3.0, this property is deprecated in favor of `queueNameExpression`. The group name can be removed from the consumer group's queue name by removing it directly from this SpEL expression.")
 	public boolean isUseGroupNameInQueueName() {
 		return useGroupNameInQueueName;
 	}
@@ -175,6 +177,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 		this.errorQueueNameExpression = errorQueueNameExpression;
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Since version 3.3.0, this property is deprecated in favor of `errorQueueNameExpression`.")
 	public String getErrorQueueNameOverride() {
 		return errorQueueNameOverride;
 	}
@@ -183,6 +186,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 		this.errorQueueNameOverride = errorQueueNameOverride;
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Since version 3.3.0, this property is deprecated in favor of `errorQueueNameExpression`. The group name can be removed from the error queue name by removing it directly from this SpEL expression.")
 	public boolean isUseGroupNameInErrorQueueName() {
 		return useGroupNameInErrorQueueName;
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -31,6 +31,12 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 */
 	private boolean useGroupNameInQueueName = true;
 
+	/**
+	 * A SpEL expression for creating the consumer group’s queue name.
+	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
+	 */
+	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group + '/' : (properties.solace.useGroupNameInQueueName ? group + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+
 	// Error Queue Properties ---------
 	/**
 	 * Whether to automatically create a durable error queue to which messages will be republished when message processing failures are encountered.
@@ -42,6 +48,11 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 * This should only be set to false if you have externally pre-provisioned the required queue on the message broker.
 	 */
 	private boolean provisionErrorQueue = true;
+	/**
+	 * A SpEL expression for creating the error queue’s name.
+	 * Modifying this can cause naming conflicts between the error queue names.
+	 */
+	private String errorQueueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group + '/' : (properties.solace.useGroupNameInErrorQueueName ? group + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 	/**
 	 * A custom error queue name.
 	 */
@@ -125,6 +136,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 		this.useGroupNameInQueueName = useGroupNameInQueueName;
 	}
 
+	public String getQueueNameExpression() {
+		return queueNameExpression;
+	}
+
+	public void setQueueNameExpression(String queueNameExpression) {
+		this.queueNameExpression = queueNameExpression;
+	}
+
 	public boolean isAutoBindErrorQueue() {
 		return autoBindErrorQueue;
 	}
@@ -139,6 +158,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setProvisionErrorQueue(boolean provisionErrorQueue) {
 		this.provisionErrorQueue = provisionErrorQueue;
+	}
+
+	public String getErrorQueueNameExpression() {
+		return errorQueueNameExpression;
+	}
+
+	public void setErrorQueueNameExpression(String errorQueueNameExpression) {
+		this.errorQueueNameExpression = errorQueueNameExpression;
 	}
 
 	public String getErrorQueueNameOverride() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -35,7 +35,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 * A SpEL expression for creating the consumer group’s queue name.
 	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
 	 */
-	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group + '/' : (properties.solace.useGroupNameInQueueName ? group + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 
 	// Error Queue Properties ---------
 	/**
@@ -52,7 +52,7 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 * A SpEL expression for creating the error queue’s name.
 	 * Modifying this can cause naming conflicts between the error queue names.
 	 */
-	private String errorQueueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group + '/' : (properties.solace.useGroupNameInErrorQueueName ? group + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+	private String errorQueueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + 'error/' + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + (isAnonymous ? group.trim() + '/' : (properties.solace.useGroupNameInErrorQueueName ? group.trim() + '/' : '')) + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 	/**
 	 * A custom error queue name.
 	 */

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -19,7 +19,7 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	 * While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>,
 	 * directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 	 */
-	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group?.trim() + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 
 	/**
 	 * A mapping of required consumer groups to queue name SpEL expressions.

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -20,7 +20,6 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 
 	/**
-	 * TODO: Use this property
 	 * A mapping of required consumer groups to queue name SpEL expressions.
 	 * By default, queueNameExpression will be used to generate a required group’s queue name if it isn’t specified within this configuration option.
 	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
@@ -47,6 +46,14 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 
 	public void setQueueNameExpression(String queueNameExpression) {
 		this.queueNameExpression = queueNameExpression;
+	}
+
+	public Map<String, String> getQueueNameExpressionsForRequiredGroups() {
+		return queueNameExpressionsForRequiredGroups;
+	}
+
+	public void setQueueNameExpressionsForRequiredGroups(Map<String, String> queueNameExpressionsForRequiredGroups) {
+		this.queueNameExpressionsForRequiredGroups = queueNameExpressionsForRequiredGroups;
 	}
 
 	public Map<String, String[]> getQueueAdditionalSubscriptions() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -12,6 +12,20 @@ import static com.solace.spring.cloud.stream.binder.properties.SolaceExtendedBin
 @SuppressWarnings("ConfigurationProperties")
 @ConfigurationProperties(DEFAULTS_PREFIX + ".producer")
 public class SolaceProducerProperties extends SolaceCommonProperties {
+
+	/**
+	 * A SpEL expression for creating the consumer group’s queue name.
+	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
+	 */
+	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
+
+	/**
+	 * TODO: Use this property
+	 * A mapping of required consumer groups to queue name SpEL expressions.
+	 * By default, queueNameExpression will be used to generate a required group’s queue name if it isn’t specified within this configuration option.
+	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
+	 */
+	private Map<String, String> queueNameExpressionsForRequiredGroups = new HashMap<>();
 	/**
 	 * A mapping of required consumer groups to arrays of additional topic subscriptions to be applied on each consumer group’s queue.
 	 * These subscriptions may also contain wildcards.
@@ -26,6 +40,14 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	 * When set to true, irreversibly convert non-serializable headers to strings. An exception is thrown otherwise.
 	 */
 	private boolean nonserializableHeaderConvertToString = false;
+
+	public String getQueueNameExpression() {
+		return queueNameExpression;
+	}
+
+	public void setQueueNameExpression(String queueNameExpression) {
+		this.queueNameExpression = queueNameExpression;
+	}
 
 	public Map<String, String[]> getQueueAdditionalSubscriptions() {
 		return queueAdditionalSubscriptions;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -16,6 +16,8 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	/**
 	 * A SpEL expression for creating the consumer group’s queue name.
 	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
+	 * While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>,
+	 * directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 	 */
 	private String queueNameExpression = "(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '/' : '') + (properties.solace.useFamiliarityInQueueName ? (isAnonymous ? 'an' : 'wk') + '/' : '') + group + '/' + (properties.solace.useDestinationEncodingInQueueName ? 'plain' + '/' : '') + destination.trim().replaceAll('[*>]', '_')";
 
@@ -23,6 +25,8 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	 * A mapping of required consumer groups to queue name SpEL expressions.
 	 * By default, queueNameExpression will be used to generate a required group’s queue name if it isn’t specified within this configuration option.
 	 * Modifying this can cause naming conflicts between the queue names of consumer groups.
+	 * While the default SpEL expression will consistently return a value adhering to <<Generated Queue Name Syntax>>,
+	 * directly using the SpEL expression string is not supported. The default value for this config option is subject to change without notice.
 	 */
 	private Map<String, String> queueNameExpressionsForRequiredGroups = new HashMap<>();
 	/**

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/ExpressionContextRoot.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/ExpressionContextRoot.java
@@ -1,0 +1,73 @@
+package com.solace.spring.cloud.stream.binder.provisioning;
+
+import com.solace.spring.cloud.stream.binder.properties.SolaceCommonProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+
+/**
+ * The context used to evaluate a queue name expression (SpEL)
+ */
+public class ExpressionContextRoot {
+
+    private final String group;
+    private final String destination;
+    private final boolean isAnonymous;
+    private final Properties<?> properties;
+
+    public ExpressionContextRoot(String physicalGroupName, String destination, boolean isAnonymous, ExtendedConsumerProperties<SolaceConsumerProperties> extendedProperties) {
+        this.group = physicalGroupName;
+        this.destination = destination;
+        this.isAnonymous = isAnonymous;
+        this.properties = new Properties<>(extendedProperties);
+    }
+
+    public ExpressionContextRoot(String groupName, String destination, ExtendedProducerProperties<SolaceProducerProperties> extendedProperties) {
+        this.group = groupName;
+        this.destination = destination;
+        this.isAnonymous = false;
+        this.properties = new Properties<>(extendedProperties);
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public boolean isAnonymous() {
+        return isAnonymous;
+    }
+
+    public Properties<?> getProperties() {
+        return properties;
+    }
+
+    private static class Properties<T> {
+
+        private final SolaceCommonProperties solace;
+        private final T spring;
+
+        public Properties(T extendedProperties) {
+            if (extendedProperties instanceof ExtendedConsumerProperties) {
+                this.solace = (SolaceCommonProperties) ((ExtendedConsumerProperties<?>) extendedProperties).getExtension();
+            } else if (extendedProperties instanceof ExtendedProducerProperties) {
+                this.solace = (SolaceCommonProperties) ((ExtendedProducerProperties<?>) extendedProperties).getExtension();
+            } else {
+                throw new IllegalArgumentException("Unsupported argument type");
+            }
+            this.spring = extendedProperties;
+        }
+
+        public SolaceCommonProperties getSolace() {
+            return solace;
+        }
+
+        public T getSpring() {
+            return spring;
+        }
+    }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
@@ -6,6 +6,7 @@ import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties
 import com.solacesystems.jcsmp.EndpointProperties;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.provisioning.ProvisioningException;
 import org.springframework.expression.*;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -76,10 +77,14 @@ public class SolaceProvisioningUtil {
 	}
 
 	private static String resolveQueueNameExpression(String expression, ExpressionContextRoot root) {
-		EvaluationContext evaluationContext = new StandardEvaluationContext(root);
-		ExpressionParser parser = new SpelExpressionParser();
-		Expression queueNameExp = parser.parseExpression(expression);
-		return (String) queueNameExp.getValue(evaluationContext);
+		try {
+			EvaluationContext evaluationContext = new StandardEvaluationContext(root);
+			ExpressionParser parser = new SpelExpressionParser();
+			Expression queueNameExp = parser.parseExpression(expression);
+			return (String) queueNameExp.getValue(evaluationContext);
+		} catch (ExpressionException e) {
+			throw new ProvisioningException(String.format("Failed to evaluate Spring expression: %s", expression), e);
+		}
 	}
 
 	public static class QueueNames {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
@@ -80,9 +80,18 @@ public class SolaceProvisioningUtil {
 			EvaluationContext evaluationContext = new StandardEvaluationContext(root);
 			ExpressionParser parser = new SpelExpressionParser();
 			Expression queueNameExp = parser.parseExpression(expression);
-			return (String) queueNameExp.getValue(evaluationContext);
+			String resolvedQueueName = (String) queueNameExp.getValue(evaluationContext);
+			validateQueueName(resolvedQueueName, expression);
+			return resolvedQueueName != null ? resolvedQueueName.trim() : null;
 		} catch (ExpressionException e) {
 			throw new ProvisioningException(String.format("Failed to evaluate Spring expression: %s", expression), e);
+		}
+	}
+
+	private static void validateQueueName(String name, String expression) {
+		if (!StringUtils.hasText(name)) {
+			throw new ProvisioningException(String.format("Invalid SpEL expression %s as it resolves to a String that does not contain actual text.",
+					expression));
 		}
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
@@ -55,7 +55,8 @@ public class SolaceProvisioningUtil {
 	}
 
 	public static String getQueueName(String topicName, String groupName, ExtendedProducerProperties<SolaceProducerProperties> properties) {
-		return resolveQueueNameExpression(properties.getExtension().getQueueNameExpression(), new ExpressionContextRoot(groupName, topicName, properties));
+		String queueNameExpression = properties.getExtension().getQueueNameExpressionsForRequiredGroups().getOrDefault(groupName, properties.getExtension().getQueueNameExpression());
+		return resolveQueueNameExpression(queueNameExpression, new ExpressionContextRoot(groupName, topicName, properties));
 	}
 
 	public static QueueNames getQueueNames(String topicName, String groupName,

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
@@ -65,16 +65,14 @@ public class SolaceProvisioningUtil {
 		ExpressionContextRoot root = new ExpressionContextRoot(physicalGroupName, topicName, isAnonymous, consumerProperties);
 
 		String resolvedQueueName = resolveQueueNameExpression(consumerProperties.getExtension().getQueueNameExpression(), root);
-		String resolvedErrorQueueName = resolveQueueNameExpression(consumerProperties.getExtension().getErrorQueueNameExpression(), root);
-
-		QueueNames queueNames = new QueueNames(resolvedQueueName, resolvedErrorQueueName, physicalGroupName);
-
+		String resolvedErrorQueueName;
 		if (StringUtils.hasText(consumerProperties.getExtension().getErrorQueueNameOverride())) {
-			return new QueueNames(queueNames.getConsumerGroupQueueName(),
-					consumerProperties.getExtension().getErrorQueueNameOverride(), queueNames.getPhysicalGroupName());
+			resolvedErrorQueueName = consumerProperties.getExtension().getErrorQueueNameOverride();
 		} else {
-			return queueNames;
+			resolvedErrorQueueName = resolveQueueNameExpression(consumerProperties.getExtension().getErrorQueueNameExpression(), root);
 		}
+
+		return new QueueNames(resolvedQueueName, resolvedErrorQueueName, physicalGroupName);
 	}
 
 	private static String resolveQueueNameExpression(String expression, ExpressionContextRoot root) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -145,6 +145,7 @@ public class SolaceQueueProvisioner
 			if (isDurable) {
 				queue = JCSMPFactory.onlyInstance().createQueue(name);
 				if (doDurableProvisioning) {
+					validateQueueName(name);
 					jcsmpSession.provision(queue, endpointProperties, JCSMPSession.FLAG_IGNORE_ALREADY_EXISTS);
 				} else {
 					logger.info(String.format(
@@ -152,6 +153,7 @@ public class SolaceQueueProvisioner
 							durableQueueType, name));
 				}
 			} else {
+				validateQueueName(name);
 				// EndpointProperties will be applied during consumer creation
 				queue = jcsmpSession.createTemporaryQueue(name);
 			}
@@ -182,6 +184,12 @@ public class SolaceQueueProvisioner
 		}
 
 		return queue;
+	}
+
+	private void validateQueueName(String name) {
+		if (!StringUtils.hasText(name)) {
+			throw new ProvisioningException(String.format("The name of the queue to provision is invalid. At least one character is required. Current value is '%s'", name));
+		}
 	}
 
 	private Queue provisionErrorQueue(String errorQueueName, SolaceConsumerProperties properties) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -57,7 +57,7 @@ public class SolaceQueueProvisioner
 		Map<String,String[]> requiredGroupsExtraSubs = properties.getExtension().getQueueAdditionalSubscriptions();
 
 		for (String groupName : requiredGroups) {
-			String queueName = SolaceProvisioningUtil.getQueueName(name, groupName, properties.getExtension());
+			String queueName = SolaceProvisioningUtil.getQueueName(name, groupName, properties);
 			logger.info(String.format("Creating durable queue %s for required consumer group %s", queueName, groupName));
 			EndpointProperties endpointProperties = SolaceProvisioningUtil.getEndpointProperties(properties.getExtension());
 			boolean doDurableQueueProvisioning = properties.getExtension().isProvisionDurableQueue();
@@ -96,8 +96,7 @@ public class SolaceQueueProvisioner
 
 		boolean isAnonQueue = SolaceProvisioningUtil.isAnonQueue(group);
 		boolean isDurableQueue = SolaceProvisioningUtil.isDurableQueue(group);
-		SolaceProvisioningUtil.QueueNames queueNames = SolaceProvisioningUtil.getQueueNames(name, group,
-				properties.getExtension(), isAnonQueue);
+		SolaceProvisioningUtil.QueueNames queueNames = SolaceProvisioningUtil.getQueueNames(name, group, properties, isAnonQueue);
 		String groupQueueName = queueNames.getConsumerGroupQueueName();
 
 		EndpointProperties endpointProperties = SolaceProvisioningUtil.getEndpointProperties(properties.getExtension());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -144,7 +144,6 @@ public class SolaceQueueProvisioner
 			if (isDurable) {
 				queue = JCSMPFactory.onlyInstance().createQueue(name);
 				if (doDurableProvisioning) {
-					validateQueueName(name);
 					jcsmpSession.provision(queue, endpointProperties, JCSMPSession.FLAG_IGNORE_ALREADY_EXISTS);
 				} else {
 					logger.info(String.format(
@@ -152,7 +151,6 @@ public class SolaceQueueProvisioner
 							durableQueueType, name));
 				}
 			} else {
-				validateQueueName(name);
 				// EndpointProperties will be applied during consumer creation
 				queue = jcsmpSession.createTemporaryQueue(name);
 			}
@@ -183,12 +181,6 @@ public class SolaceQueueProvisioner
 		}
 
 		return queue;
-	}
-
-	private void validateQueueName(String name) {
-		if (!StringUtils.hasText(name)) {
-			throw new ProvisioningException(String.format("The name of the queue to provision is invalid. At least one character is required. Current value is '%s'", name));
-		}
 	}
 
 	private Queue provisionErrorQueue(String errorQueueName, SolaceConsumerProperties properties) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -24,7 +24,6 @@ import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -57,7 +56,7 @@ public class SolaceQueueProvisioner
 		Map<String,String[]> requiredGroupsExtraSubs = properties.getExtension().getQueueAdditionalSubscriptions();
 
 		for (String groupName : requiredGroups) {
-			String queueName = SolaceProvisioningUtil.getQueueName(name, groupName, properties);
+			String queueName = SolaceProvisioningUtil.getQueueName(topicName, groupName, properties);
 			logger.info(String.format("Creating durable queue %s for required consumer group %s", queueName, groupName));
 			EndpointProperties endpointProperties = SolaceProvisioningUtil.getEndpointProperties(properties.getExtension());
 			boolean doDurableQueueProvisioning = properties.getExtension().isProvisionDurableQueue();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceQueueProvisioner.java
@@ -156,7 +156,7 @@ public class SolaceQueueProvisioner
 				// EndpointProperties will be applied during consumer creation
 				queue = jcsmpSession.createTemporaryQueue(name);
 			}
-		} catch (JCSMPException e) {
+		} catch (Exception e) {
 			String action = isDurable ? "provision durable" : "create temporary";
 			String msg = String.format("Failed to %s queue %s", action, name);
 			logger.warn(msg, e);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilQueueNameTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilQueueNameTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -94,7 +95,7 @@ public class SolaceProvisioningUtilQueueNameTest {
                 useGroupNameInErrorQueue, useFamiliarity, useDestinationEncoding);
         boolean isAnonymous = groupName == null;
 
-        String actual = SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+        String actual = SolaceProvisioningUtil.getQueueNames(destination, groupName, new ExtendedConsumerProperties<>(consumerProperties), isAnonymous)
                 .getConsumerGroupQueueName();
         LOGGER.info("Testing Queue Name: {}", actual);
 
@@ -148,7 +149,7 @@ public class SolaceProvisioningUtilQueueNameTest {
                 useGroupNameInErrorQueue, useFamiliarity, useDestinationEncoding);
         boolean isAnonymous = groupName == null;
 
-        String actual = SolaceProvisioningUtil.getQueueNames(destination, groupName, consumerProperties, isAnonymous)
+        String actual = SolaceProvisioningUtil.getQueueNames(destination, groupName, new ExtendedConsumerProperties<>(consumerProperties), isAnonymous)
                 .getErrorQueueName();
 
         LOGGER.info("Testing Error Queue Name: {}", actual);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilQueueNameTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilQueueNameTest.java
@@ -265,12 +265,12 @@ public class SolaceProvisioningUtilQueueNameTest {
     public void testQueueNameExpressionWithStaticValue() {
         SolaceConsumerProperties consumerProperties = createConsumerProperties(null, true, true, true, true);
         //The escaped single quote '' resolves to a single quote in the actual queue name
-        consumerProperties.setQueueNameExpression("'My/Static.QueueName-_''>*!@#$%^&()+='");
+        consumerProperties.setQueueNameExpression("'My/Static.QueueName-_''>*!@#$%^&()+=#{test}:[]{}|\\\"-~'");
 
         String actual = SolaceProvisioningUtil
                 .getQueueNames("unused/destination", "unusedGroup", new ExtendedConsumerProperties<>(consumerProperties), true)
                 .getConsumerGroupQueueName();
-        assertEquals("My/Static.QueueName-_'>*!@#$%^&()+=", actual);
+        assertEquals("My/Static.QueueName-_'>*!@#$%^&()+=#{test}:[]{}|\\\"-~", actual);
     }
 
     @Test

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilQueueNameTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilQueueNameTest.java
@@ -226,7 +226,8 @@ public class SolaceProvisioningUtilQueueNameTest {
         String destination = "  destination/with/spaces      ";
         String group = "    aGroupWithSpaces    ";
 
-        SolaceProvisioningUtil.QueueNames queueNames = SolaceProvisioningUtil.getQueueNames(destination, group, consumerProperties, group == null);
+        SolaceProvisioningUtil.QueueNames queueNames = SolaceProvisioningUtil.getQueueNames(destination, group, consumerProperties,
+                SolaceProvisioningUtil.isAnonQueue(group));
 
         assertEquals("aQueueNamePrefixWithSpaces/wk/aGroupWithSpaces/plain/destination/with/spaces", queueNames.getConsumerGroupQueueName());
         assertEquals("aQueueNamePrefixWithSpaces/error/wk/aGroupWithSpaces/plain/destination/with/spaces", queueNames.getErrorQueueName());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtilTest.java
@@ -3,25 +3,26 @@ package com.solace.spring.cloud.stream.binder.provisioning;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.provisioning.SolaceProvisioningUtil.QueueNames;
 import org.junit.jupiter.api.Test;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SolaceProvisioningUtilTest {
 	@Test
 	public void testConsumerErrorQueueNameOverride() {
-		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
-		consumerProperties.setErrorQueueNameOverride("some-custom-named-error-queue-name");
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = new ExtendedConsumerProperties<>(new SolaceConsumerProperties());
+		consumerProperties.getExtension().setErrorQueueNameOverride("some-custom-named-error-queue-name");
 		QueueNames queueNames = SolaceProvisioningUtil.getQueueNames("topic", "group",
 				consumerProperties, false);
-		assertEquals(consumerProperties.getErrorQueueNameOverride(), queueNames.getErrorQueueName());
+		assertEquals(consumerProperties.getExtension().getErrorQueueNameOverride(), queueNames.getErrorQueueName());
 	}
 
 	@Test
 	public void testAnonConsumerErrorQueueNameOverride() {
-		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
-		consumerProperties.setErrorQueueNameOverride("some-custom-named-error-queue-name");
+		ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = new ExtendedConsumerProperties<>(new SolaceConsumerProperties());
+		consumerProperties.getExtension().setErrorQueueNameOverride("some-custom-named-error-queue-name");
 		QueueNames queueNames = SolaceProvisioningUtil.getQueueNames("topic", null,
 				consumerProperties, true);
-		assertEquals(consumerProperties.getErrorQueueNameOverride(), queueNames.getErrorQueueName());
+		assertEquals(consumerProperties.getExtension().getErrorQueueNameOverride(), queueNames.getErrorQueueName());
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicIT.java
@@ -717,7 +717,7 @@ public class SolaceBinderBasicIT extends SpringCloudStreamContext {
 		EndpointProperties endpointProperties = new EndpointProperties();
 		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
 		Queue queue = JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-				.getQueueName(destination0, group0, createProducerProperties(testInfo).getExtension()));
+				.getQueueName(destination0, group0, createProducerProperties(testInfo)));
 
 		logger.info(String.format("Pre-provisioning queue %s with AccessType %s to conflict with defaultAccessType %s",
 				queue.getName(), endpointProperties.getAccessType(), defaultAccessType));
@@ -753,7 +753,7 @@ public class SolaceBinderBasicIT extends SpringCloudStreamContext {
 		EndpointProperties endpointProperties = new EndpointProperties();
 		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
 		Queue queue = JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-				.getQueueNames(destination0, group0, createConsumerProperties().getExtension(), false)
+				.getQueueNames(destination0, group0, createConsumerProperties(), false)
 				.getConsumerGroupQueueName());
 
 		logger.info(String.format("Pre-provisioning queue %s with AccessType %s to conflict with defaultAccessType %s",
@@ -788,7 +788,7 @@ public class SolaceBinderBasicIT extends SpringCloudStreamContext {
 		EndpointProperties endpointProperties = new EndpointProperties();
 		endpointProperties.setAccessType((defaultAccessType + 1) % 2);
 		Queue errorQueue = JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-				.getQueueNames(destination0, group0, createConsumerProperties().getExtension(), false)
+				.getQueueNames(destination0, group0, createConsumerProperties(), false)
 				.getErrorQueueName());
 
 		logger.info(String.format("Pre-provisioning error queue %s with AccessType %s to conflict with defaultAccessType %s",

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
@@ -105,7 +105,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 		consumerProperties.getExtension().setProvisionDurableQueue(false);
 
 		Queue queue = JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-				.getQueueNames(destination0, group0, consumerProperties.getExtension(), false)
+				.getQueueNames(destination0, group0, consumerProperties, false)
 				.getConsumerGroupQueueName());
 		EndpointProperties endpointProperties = new EndpointProperties();
 		endpointProperties.setPermission(EndpointProperties.PERMISSION_MODIFY_TOPIC);
@@ -163,7 +163,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 		consumerProperties.getExtension().setProvisionSubscriptionsToDurableQueue(false);
 
 		Queue queue = JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-				.getQueueName(destination0, group0, producerProperties.getExtension()));
+				.getQueueName(destination0, group0, producerProperties));
 		EndpointProperties endpointProperties = new EndpointProperties();
 		endpointProperties.setPermission(EndpointProperties.PERMISSION_MODIFY_TOPIC);
 
@@ -215,7 +215,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 		consumerProperties.getExtension().setProvisionDurableQueue(false);
 
 		Queue queue = JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-				.getQueueNames(destination0, group0, consumerProperties.getExtension(), false)
+				.getQueueNames(destination0, group0, consumerProperties, false)
 				.getConsumerGroupQueueName());
 		EndpointProperties endpointProperties = new EndpointProperties();
 		endpointProperties.setPermission(EndpointProperties.PERMISSION_MODIFY_TOPIC);
@@ -390,7 +390,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 		consumerProperties.getExtension().setAutoBindErrorQueue(true);
 
 		String errorQueueName = SolaceProvisioningUtil
-				.getQueueNames(destination0, group0, consumerProperties.getExtension(), false)
+				.getQueueNames(destination0, group0, consumerProperties, false)
 				.getErrorQueueName();
 		Queue errorQueue = JCSMPFactory.onlyInstance().createQueue(errorQueueName);
 
@@ -971,7 +971,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 		consumerProperties.getExtension().setProvisionDurableQueue(false);
 
 		String queue0 = SolaceProvisioningUtil
-				.getQueueNames(destination0, group0, consumerProperties.getExtension(), false)
+				.getQueueNames(destination0, group0, consumerProperties, false)
 				.getConsumerGroupQueueName();
 
 		String vpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
@@ -1117,7 +1117,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 			ConsumerFlowProperties consumerFlowProperties = new ConsumerFlowProperties();
 			consumerFlowProperties.setStartState(true);
 			consumerFlowProperties.setEndpoint(JCSMPFactory.onlyInstance().createQueue(SolaceProvisioningUtil
-					.getQueueName(topic0, group0, producerProperties.getExtension())));
+					.getQueueName(topic0, group0, producerProperties)));
 			flowReceiver = jcsmpSession.createFlow(new XMLMessageListener() {
 				@Override
 				public void onReceive(BytesXMLMessage bytesXMLMessage) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderProvisioningLifecycleIT.java
@@ -1847,7 +1847,7 @@ public class SolaceBinderProvisioningLifecycleIT {
 			fail("Expected provisioning to fail due to empty queue name");
 		} catch (Exception e) {
 			assertThat(e).isInstanceOf(ProvisioningException.class);
-			assertThat(e.getMessage()).containsIgnoringCase("The name of the queue to provision is invalid. At least one character is required. Current value is '   '");
+			assertThat(e.getMessage()).isEqualTo("Invalid SpEL expression '   ' as it resolves to a String that does not contain actual text.");
 		}
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderSubscriptionsIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderSubscriptionsIT.java
@@ -107,7 +107,7 @@ public class SolaceBinderSubscriptionsIT {
 
         Binding<MessageChannel> producerBinding = binder.bindProducer(DESTINATION, moduleOutputChannel, producerProperties);
 
-        String queueName = SolaceProvisioningUtil.getQueueName(DESTINATION, group0, producerProperties.getExtension());
+        String queueName = SolaceProvisioningUtil.getQueueName(DESTINATION, group0, producerProperties);
         assertActualSubscriptionsAreCorrect(context, sempV2Api, queueName, addDestinationAsSubscriptionToQueue,
                 provisionSubscriptionsToDurableQueue);
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
@@ -146,7 +146,14 @@ public class SolaceTestBinder
 		for (String queueName : queues) {
 			try {
 				logger.info(String.format("De-provisioning queue %s", queueName));
-				Queue queue = JCSMPFactory.onlyInstance().createQueue(queueName);
+				Queue queue;
+				try {
+					queue = JCSMPFactory.onlyInstance().createQueue(queueName);
+				} catch (Exception e) {
+					//This is possible as we eagerly add queues to cleanup in preBindCaptureConsumerResources()
+					logger.info(String.format("Skipping de-provisioning as queue name is invalid; queue was never provisioned", queueName));
+					continue;
+				}
 				jcsmpSession.deprovision(queue, JCSMPSession.FLAG_IGNORE_DOES_NOT_EXIST);
 			} catch (JCSMPException e) {
 				throw new RuntimeException(e);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
@@ -58,7 +58,7 @@ public class SolaceTestBinder
 	@Override
 	public Binding<MessageChannel> bindConsumer(String name, String group, MessageChannel moduleInputChannel,
 												ExtendedConsumerProperties<SolaceConsumerProperties> properties) {
-		preBindCaptureConsumerResources(name, group, properties.getExtension());
+		preBindCaptureConsumerResources(name, group, properties);
 		Binding<MessageChannel> binding = super.bindConsumer(name, group, moduleInputChannel, properties);
 		captureConsumerResources(binding, group, properties.getExtension());
 		return binding;
@@ -68,7 +68,7 @@ public class SolaceTestBinder
 	public Binding<PollableSource<MessageHandler>> bindPollableConsumer(String name, String group,
 																		PollableSource<MessageHandler> inboundBindTarget,
 																		ExtendedConsumerProperties<SolaceConsumerProperties> properties) {
-		preBindCaptureConsumerResources(name, group, properties.getExtension());
+		preBindCaptureConsumerResources(name, group, properties);
 		Binding<PollableSource<MessageHandler>> binding = super.bindPollableConsumer(name, group, inboundBindTarget, properties);
 		captureConsumerResources(binding, group, properties.getExtension());
 		return binding;
@@ -79,7 +79,7 @@ public class SolaceTestBinder
 												ExtendedProducerProperties<SolaceProducerProperties> properties) {
 		if (properties.getRequiredGroups() != null) {
 			Arrays.stream(properties.getRequiredGroups())
-					.forEach(g -> preBindCaptureProducerResources(name, g, properties.getExtension()));
+					.forEach(g -> preBindCaptureProducerResources(name, g, properties));
 		}
 
 		return super.bindProducer(name, moduleOutputChannel, properties);
@@ -93,15 +93,14 @@ public class SolaceTestBinder
 		return bindingNameToErrorQueueName.get(binding.getBindingName());
 	}
 
-	private void preBindCaptureConsumerResources(String name, String group, SolaceConsumerProperties consumerProperties) {
+	private void preBindCaptureConsumerResources(String name, String group, ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties) {
 		if (SolaceProvisioningUtil.isAnonQueue(group)) return; // we don't know any anon resource names before binding
 
-		SolaceProvisioningUtil.QueueNames queueNames = SolaceProvisioningUtil.getQueueNames(name, group,
-				consumerProperties, false);
+		SolaceProvisioningUtil.QueueNames queueNames = SolaceProvisioningUtil.getQueueNames(name, group, consumerProperties, false);
 
 		// values set here may be overwritten after binding
 		queues.add(queueNames.getConsumerGroupQueueName());
-		if (consumerProperties.isAutoBindErrorQueue()) {
+		if (consumerProperties.getExtension().isAutoBindErrorQueue()) {
 			queues.add(queueNames.getErrorQueueName());
 		}
 	}
@@ -121,7 +120,7 @@ public class SolaceTestBinder
 		}
 	}
 
-	private void preBindCaptureProducerResources(String name, String group, SolaceProducerProperties producerProperties) {
+	private void preBindCaptureProducerResources(String name, String group, ExtendedProducerProperties<SolaceProducerProperties> producerProperties) {
 		String queueName = SolaceProvisioningUtil.getQueueName(name, group, producerProperties);
 		queues.add(queueName);
 	}


### PR DESCRIPTION
* add config options to change the queue name format:
  * Add `queueNameExpression` and `errorQueueNameExpression` consumer config options
  * Add `queueNameExpression` and `queueNameExpressionsForRequiredGroups` producer config options
  * Deprecate `queueNamePrefix`, `useGroupNameInQueueName`, `useFamiliarityInQueueName`, `useDestinationEncodingInQueueName`, `errorQueueNameOverride`, and `useGroupNameInErrorQueueName` binding config options
  * Fixes #88 