### PR TITLE
fix max client error for FlowReceiverContainer.testConcurrentAll()

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
@@ -78,6 +78,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1769,7 +1770,11 @@ public class FlowReceiverContainerIT {
 		UUID flowReferenceId = flowReceiverContainer.bind();
 
 		Callable<?>[] actions = new Callable[]{
-				(Callable<?>) flowReceiverContainer::bind,
+				(Callable<?>) () -> {
+					AtomicReference<UUID> newFlowReferenceId = new AtomicReference<>();
+					retryAssert(() -> newFlowReferenceId.set(assertDoesNotThrow(flowReceiverContainer::bind)));
+					return newFlowReferenceId.get();
+				},
 				(Callable<?>) () -> {flowReceiverContainer.unbind(); return null;},
 				(Callable<?>) () -> {
 					try {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
@@ -1761,6 +1761,7 @@ public class FlowReceiverContainerIT {
 
 	@ParameterizedTest
 	@ValueSource(booleans = {false, true})
+	@Timeout(value = 10, unit = TimeUnit.MINUTES)
 	@Execution(ExecutionMode.SAME_THREAD)
 	public void testConcurrentAll(boolean isDurable, JCSMPSession jcsmpSession, Queue durableQueue) throws Exception {
 		Queue queue = isDurable ? durableQueue : jcsmpSession.createTemporaryQueue();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
@@ -12,6 +12,8 @@ import com.solace.test.integration.semp.v2.config.model.ConfigMsgVpnQueue;
 import com.solace.test.integration.semp.v2.monitor.ApiException;
 import com.solace.test.integration.semp.v2.monitor.model.MonitorMsgVpnQueue;
 import com.solace.test.integration.semp.v2.monitor.model.MonitorMsgVpnQueueTxFlow;
+import com.solace.test.integration.semp.v2.monitor.model.MonitorMsgVpnQueueTxFlowsResponse;
+import com.solace.test.integration.semp.v2.monitor.model.MonitorSempMeta;
 import com.solace.test.integration.semp.v2.monitor.model.MonitorSempMetaOnlyResponse;
 import com.solacesystems.jcsmp.ClosedFacilityException;
 import com.solacesystems.jcsmp.Consumer;
@@ -27,8 +29,7 @@ import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 import com.solacesystems.jcsmp.impl.flow.FlowHandle;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -97,7 +100,7 @@ public class FlowReceiverContainerIT {
 	private final AtomicReference<FlowReceiverContainer> flowReceiverContainerReference = new AtomicReference<>();
 	private XMLMessageProducer producer;
 
-	private static final Log logger = LogFactory.getLog(FlowReceiverContainerIT.class);
+	private static final Logger logger = LoggerFactory.getLogger(FlowReceiverContainerIT.class);
 
 	@BeforeEach
 	public void setup(JCSMPSession jcsmpSession) throws Exception {
@@ -110,7 +113,7 @@ public class FlowReceiverContainerIT {
 
 			@Override
 			public void handleErrorEx(Object o, JCSMPException e, long l) {
-				logger.error(e);
+				logger.error("Failed to send message", e);
 			}
 		});
 	}
@@ -1763,7 +1766,10 @@ public class FlowReceiverContainerIT {
 	@ValueSource(booleans = {false, true})
 	@Timeout(value = 10, unit = TimeUnit.MINUTES)
 	@Execution(ExecutionMode.SAME_THREAD)
-	public void testConcurrentAll(boolean isDurable, JCSMPSession jcsmpSession, Queue durableQueue) throws Exception {
+	public void testConcurrentAll(boolean isDurable,
+								  JCSMPSession jcsmpSession,
+								  Queue durableQueue,
+								  SempV2Api sempV2Api) throws Exception {
 		Queue queue = isDurable ? durableQueue : jcsmpSession.createTemporaryQueue();
 		FlowReceiverContainer flowReceiverContainer = createFlowReceiverContainer(jcsmpSession, queue);
 
@@ -1827,7 +1833,7 @@ public class FlowReceiverContainerIT {
 				}
 		};
 
-		CyclicBarrier barrier = new CyclicBarrier(actions.length * 50);
+		CyclicBarrier barrier = new CyclicBarrier(actions.length * 10);
 		ScheduledExecutorService executorService = Executors.newScheduledThreadPool(barrier.getParties());
 		AtomicInteger counter = new AtomicInteger();
 		try {
@@ -1853,7 +1859,37 @@ public class FlowReceiverContainerIT {
 					.collect(Collectors.toSet());
 
 			for (ScheduledFuture<?> future : futures) {
-				future.get(5, TimeUnit.MINUTES);
+				Assertions.assertThatCode(() -> future.get(5, TimeUnit.MINUTES))
+						.as(() -> {
+							String msgVpnName = (String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME);
+							Optional<MonitorMsgVpnQueueTxFlowsResponse> msgVpnQueueTxFlowsResponse;
+							try {
+								msgVpnQueueTxFlowsResponse = Optional.of(sempV2Api.monitor().getMsgVpnQueueTxFlows(
+										msgVpnName,
+										queue.getName(),
+										Integer.MAX_VALUE,
+										null, null, null));
+							} catch (ApiException e) {
+								logger.error("Failed to get tx flows for queue {}", queue.getName(), e);
+								msgVpnQueueTxFlowsResponse = Optional.empty();
+							}
+							return String.format("Check flow operation result for queue %s\n" +
+											"Flow receiver is using flow ID %s\n" +
+											"Queue has flows (%s) %s",
+									queue.getName(),
+									Optional.ofNullable(flowReceiverContainer.getFlowReceiverReference())
+											.map(FlowReceiverReference::get)
+											.map(r -> ((FlowHandle) r).getFlowId())
+											.orElse(null),
+									msgVpnQueueTxFlowsResponse.map(MonitorMsgVpnQueueTxFlowsResponse::getMeta)
+											.map(MonitorSempMeta::getCount)
+											.map(c -> Long.toString(c))
+											.orElse("'Error getting flows'"),
+									msgVpnQueueTxFlowsResponse.map(MonitorMsgVpnQueueTxFlowsResponse::getData)
+											.map(Object::toString)
+											.orElse("'Error getting flows'"));
+						})
+						.doesNotThrowAnyException();
 			}
 		} finally {
 			executorService.shutdownNow();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/FlowReceiverContainerIT.java
@@ -1762,7 +1762,6 @@ public class FlowReceiverContainerIT {
 	@ParameterizedTest
 	@ValueSource(booleans = {false, true})
 	@Execution(ExecutionMode.SAME_THREAD)
-//	@Repeat(10) // should run a few times to make sure its stable
 	public void testConcurrentAll(boolean isDurable, JCSMPSession jcsmpSession, Queue durableQueue) throws Exception {
 		Queue queue = isDurable ? durableQueue : jcsmpSession.createTemporaryQueue();
 		FlowReceiverContainer flowReceiverContainer = createFlowReceiverContainer(jcsmpSession, queue);
@@ -1772,7 +1771,8 @@ public class FlowReceiverContainerIT {
 		Callable<?>[] actions = new Callable[]{
 				(Callable<?>) () -> {
 					AtomicReference<UUID> newFlowReferenceId = new AtomicReference<>();
-					retryAssert(() -> newFlowReferenceId.set(assertDoesNotThrow(flowReceiverContainer::bind)));
+					retryAssert(() -> newFlowReferenceId.set(assertDoesNotThrow(flowReceiverContainer::bind)),
+							1, TimeUnit.MINUTES);
 					return newFlowReferenceId.get();
 				},
 				(Callable<?>) () -> {flowReceiverContainer.unbind(); return null;},
@@ -1852,7 +1852,7 @@ public class FlowReceiverContainerIT {
 					.collect(Collectors.toSet());
 
 			for (ScheduledFuture<?> future : futures) {
-				future.get(1, TimeUnit.MINUTES);
+				future.get(5, TimeUnit.MINUTES);
 			}
 		} finally {
 			executorService.shutdownNow();


### PR DESCRIPTION
* fix test throwing error about max clients exceeded for temporary queues
* Decrease number of threads in that test