### PR TITLE
add support for PubSub+ partitioned queues

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -35,8 +35,6 @@ In Solace, the above setup is called topic-to-queue mapping. So a typical messag
 +
 NOTE: Round-robin distribution only occurs if the consumer group's queue is configured for non-exclusive access. If the queue has exclusive access, then only one consumer will receive messages.
 
-NOTE: Partitioning is not yet supported by this version of the binder.
-
 IMPORTANT: Since consumer bindings always consumes from queues it is required that Assured Delivery is enabled on the Solace PubSub+ Message VPN being used (Assured Delivery is automatically enabled if using Solace Cloud). Additionally, the client username's client profile must be allowed to send and receive guaranteed messages.
 
 For the sake of brevity, it will be assumed that you have a basic understanding of the Spring Cloud Stream project. If not, then please refer to https://docs.spring.io/spring-cloud-stream/docs/{scst-version}/reference/html/[Spring's documentation]. This document will solely focus on discussing components unique to Solace.
@@ -639,6 +637,12 @@ The consolidated list of message headers for a batch of messages where the heade
 |
 | Present and true to indicate when the PubSub+ message payload was null.
 
+| solace_scst_partitionKey
+| String
+| Write
+|
+| The partition key for PubSub+ partitioned queues.
+
 | solace_scst_serializedPayload
 | Boolean
 | Internal Binder Use Only
@@ -843,6 +847,34 @@ See <<Native Payload Types>> for more info regarding this binder's natively supp
 ====
 
 To create a batch of messages, the binder will consume messages from the PubSub+ broker until either a maximum batch size or timeout has been achieved. After which, the binder will compose the batch message and send it to the consumer handler for processing. Both these batching parameters can be configured using the `batchMaxSize` and `batchTimeout` consumer config options.
+
+== Partitioning
+
+[NOTE]
+====
+The Solace PubSub+ broker supports partitioning natively.
+
+The partitioning abstraction as described in the https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#partitioning[Spring Cloud Stream documentation] is not supported.
+====
+
+To publish messages that are intended for partitioned queues, you must provide a partition key by setting the `solace_scst_partitionKey` message header (accessible through the `SolaceBinderHeaders.PARTITION_KEY` constant).
+
+For example:
+
+[source,java]
+----
+public class MyMessageBuilder {
+    public Message<String> buildMeAMessage() {
+        return MessageBuilder.withPayload("payload")
+            .setHeader(SolaceBinderHeaders.PARTITION_KEY, "partition-key")
+            .build();
+    }
+}
+----
+
+As for consuming messages from partitioned queues, this is handled transparently by the PubSub+ broker. That is to say, consuming messages from a partitioned queue is no different from consuming messages from any other queue.
+
+See https://docs.solace.com/Messaging/Guaranteed-Msg/Queues.htm#partitioned-queues[Partitioned Queues] for more.
 
 == Manual Message Acknowledgment
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaderMeta.java
@@ -1,14 +1,15 @@
 package com.solace.spring.cloud.stream.binder.messaging;
 
+import com.solace.spring.cloud.stream.binder.util.CorrelationData;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.solace.spring.cloud.stream.binder.util.CorrelationData;
-
 public class SolaceBinderHeaderMeta<T> implements HeaderMeta<T> {
 	public static final Map<String, SolaceBinderHeaderMeta<?>> META = Stream.of(new Object[][] {
+			{SolaceBinderHeaders.PARTITION_KEY, new SolaceBinderHeaderMeta<>(String.class, false, true, Scope.WIRE)},
 			{SolaceBinderHeaders.MESSAGE_VERSION, new SolaceBinderHeaderMeta<>(Integer.class, true, false, Scope.WIRE)},
 			{SolaceBinderHeaders.SERIALIZED_PAYLOAD, new SolaceBinderHeaderMeta<>(Boolean.class, false, false, Scope.WIRE)},
 			{SolaceBinderHeaders.SERIALIZED_HEADERS, new SolaceBinderHeaderMeta<>(String.class, false, false, Scope.WIRE)},

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/messaging/SolaceBinderHeaders.java
@@ -25,6 +25,14 @@ public final class SolaceBinderHeaders {
 	static final String PREFIX = SolaceHeaders.PREFIX + "scst_";
 
 	/**
+	 * <p><b>Acceptable Value Type:</b> {@link String}</p>
+	 * <p><b>Access:</b> Write</p>
+	 * <br>
+	 * <p>The partition key for PubSub+ partitioned queues.</p>
+	 */
+	public static final String PARTITION_KEY = PREFIX + "partitionKey";
+
+	/**
 	 * <p><b>Acceptable Value Type:</b> {@link Integer}</p>
 	 * <p><b>Access:</b> Read</p>
 	 * <p><b>Default Value: </b>{@code 1}</p>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -169,6 +169,9 @@ public class JmsCompatibilityIT {
 				for (Map.Entry<String, SolaceBinderHeaderMeta<?>> headerMeta : SolaceBinderHeaderMeta.META.entrySet()) {
 					if (!HeaderMeta.Scope.WIRE.equals(headerMeta.getValue().getScope())) continue;
 					String headerName = headerMeta.getKey();
+					if (headerName.equals(SolaceBinderHeaders.PARTITION_KEY)) {
+						headerName = XMLMessage.MessageUserPropertyConstants.QUEUE_PARTITION_KEY;
+					}
 					// Everything should be receivable as a String in JMS
 					softly.assertThat(msg.getStringProperty(headerName))
 							.withFailMessage("Expecting JMS property %s to not be null", headerName)


### PR DESCRIPTION
* Added `solace_scst_partitionKey`
* Clarify docs that Solace PubSub+ broker natively supports partitioning, and that we do not support the binder partitioning abstraction.