### PR TITLE
DATAGO-67277: Add ability to exclude headers on consumers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.solace.spring.cloud</groupId>
     <artifactId>solace-spring-cloud-build</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Cloud Build</name>
@@ -32,7 +32,7 @@
         <!-- Remove this if the next version of solace-spring-boot works fine -->
         <spring.boot.version>3.1.5</spring.boot.version>
 
-        <solace.spring.cloud.stream-starter.version>4.1.0-SNAPSHOT</solace.spring.cloud.stream-starter.version>
+        <solace.spring.cloud.stream-starter.version>4.2.0-SNAPSHOT</solace.spring.cloud.stream-starter.version>
 
         <solace.integration.test.support.version>1.0.2</solace.integration.test.support.version>
         <solace.integration.test.support.fetch_checkout.skip>false</solace.integration.test.support.fetch_checkout.skip>

--- a/solace-spring-cloud-bom/README.md
+++ b/solace-spring-cloud-bom/README.md
@@ -26,6 +26,7 @@ Consult the table below to determine which version of the BOM you need to use:
 | 2021.0.6     | 2.5.0                      | 2.7.x       |
 | 2022.0.2     | 3.0.0                      | 3.0.x       |
 | 2022.0.4     | 3.1.0                      | 3.1.x       |
+| 2022.0.4     | 3.2.0                      | 3.1.x       |
 
 ## Including the BOM
 
@@ -38,7 +39,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.cloud</groupId>
             <artifactId>solace-spring-cloud-bom</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -66,7 +67,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:3.1.0"
+        mavenBom "com.solace.spring.cloud:solace-spring-cloud-bom:3.2.0"
     }
 }
 
@@ -78,7 +79,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:3.1.0"))
+    implementation(platform("com.solace.spring.cloud:solace-spring-cloud-bom:3.2.0"))
     implementation("com.solace.spring.cloud:spring-cloud-starter-stream-solace")
 }
 ```

--- a/solace-spring-cloud-bom/pom.xml
+++ b/solace-spring-cloud-bom/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-build</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>solace-spring-cloud-bom</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <name>Solace Spring Cloud BOM</name>
     <description>BOM for Solace Spring Cloud</description>

--- a/solace-spring-cloud-parent/pom.xml
+++ b/solace-spring-cloud-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-build</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -1,5 +1,5 @@
 = Spring Cloud Stream Binder for Solace PubSub+
-:revnumber: 4.1.0
+:revnumber: 4.2.0
 :toc: preamble
 :toclevels: 3
 :icons: font

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -346,6 +346,11 @@ The number of milliseconds before republished messages are discarded or moved to
 +
 Default: `null`
 
+headerExclusions::
+The list of headers to exclude when converting consumed Solace message to Spring message.
++
+Default: Empty `List&lt;String&gt;`
+
 ==== Solace Producer Properties
 
 The following properties are available for Solace producers only and must be prefixed with `spring.cloud.stream.solace.bindings.&lt;bindingName&gt;.producer.` where `bindingName` looks something like `functionName-out-0` as defined in https://docs.spring.io/spring-cloud-stream/docs/{scst-version}/reference/html/spring-cloud-stream.html#_functional_binding_names[Functional Binding Names].

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/pom.xml
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-cloud-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-cloud-starter-stream-solace</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-cloud-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-cloud-stream-binder-solace-core</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Spring Cloud Stream Binder Core</name>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -241,13 +241,13 @@ abstract class InboundXMLMessageListener implements Runnable {
 
 	Message<?> createOneMessage(BytesXMLMessage bytesXMLMessage, AcknowledgmentCallback acknowledgmentCallback) {
 		setAttributesIfNecessary(bytesXMLMessage, acknowledgmentCallback);
-		return xmlMessageMapper.map(bytesXMLMessage, acknowledgmentCallback);
+		return xmlMessageMapper.map(bytesXMLMessage, acknowledgmentCallback, consumerProperties.getExtension());
 	}
 
 	Message<?> createBatchMessage(List<BytesXMLMessage> bytesXMLMessages,
 								  AcknowledgmentCallback acknowledgmentCallback) {
 		setAttributesIfNecessary(bytesXMLMessages, acknowledgmentCallback);
-		return xmlMessageMapper.mapBatchMessage(bytesXMLMessages, acknowledgmentCallback);
+		return xmlMessageMapper.mapBatchMessage(bytesXMLMessages, acknowledgmentCallback, consumerProperties.getExtension());
 	}
 
 	void sendOneToConsumer(final Message<?> message, final BytesXMLMessage bytesXMLMessage)

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
@@ -167,7 +167,7 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 	private Message<?> processMessage(MessageContainer messageContainer) {
 		AcknowledgmentCallback acknowledgmentCallback = ackCallbackFactory.createCallback(messageContainer);
 		try {
-			return xmlMessageMapper.map(messageContainer.getMessage(), acknowledgmentCallback, true);
+			return xmlMessageMapper.map(messageContainer.getMessage(), acknowledgmentCallback, true, consumerProperties.getExtension());
 		} catch (Exception e) {
 			//TODO If one day the errorChannel or attributesHolder can be retrieved, use those instead
 			logger.warn(e, String.format("XMLMessage %s cannot be consumed. It will be rejected",
@@ -188,7 +188,7 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 			return xmlMessageMapper.mapBatchMessage(batchedMessages.get()
 					.stream()
 					.map(MessageContainer::getMessage)
-					.collect(Collectors.toList()), acknowledgmentCallback, true);
+					.collect(Collectors.toList()), acknowledgmentCallback, true, consumerProperties.getExtension());
 		} catch (Exception e) {
 			logger.warn(e, "Message batch cannot be consumed. It will be rejected");
 			AckUtils.reject(acknowledgmentCallback);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -1,6 +1,8 @@
 package com.solace.spring.cloud.stream.binder.properties;
 
 import com.solacesystems.jcsmp.EndpointProperties;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.Assert;
 
@@ -133,6 +135,10 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	private Long errorMsgTtl = null;
 	// ------------------------
 
+	/**
+	 * The list of headers to exclude when converting consumed Solace message to Spring message.
+	 */
+	private List<String> headerExclusions = new ArrayList<>();
 
 	public int getBatchMaxSize() {
 		return batchMaxSize;
@@ -316,5 +322,13 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setErrorMsgTtl(Long errorMsgTtl) {
 		this.errorMsgTtl = errorMsgTtl;
+	}
+
+	public List<String> getHeaderExclusions() {
+		return headerExclusions;
+	}
+
+	public void setHeaderExclusions(List<String> headerExclusions) {
+		this.headerExclusions = headerExclusions;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -164,18 +164,18 @@ public class XMLMessageMapper {
 	}
 
 	public Message<List<?>> mapBatchMessage(List<? extends XMLMessage> xmlMessages,
-											AcknowledgmentCallback acknowledgmentCallback)
+											AcknowledgmentCallback acknowledgmentCallback, SolaceConsumerProperties solaceConsumerProperties)
 			throws SolaceMessageConversionException {
-		return mapBatchMessage(xmlMessages, acknowledgmentCallback, false);
+		return mapBatchMessage(xmlMessages, acknowledgmentCallback, false, solaceConsumerProperties);
 	}
 
 	public Message<List<?>> mapBatchMessage(List<? extends XMLMessage> xmlMessages,
 											AcknowledgmentCallback acknowledgmentCallback,
-											boolean setRawMessageHeader) throws SolaceMessageConversionException {
+											boolean setRawMessageHeader, SolaceConsumerProperties solaceConsumerProperties) throws SolaceMessageConversionException {
 		List<Map<String, Object>> batchedHeaders = new ArrayList<>();
 		List<Object> batchedPayloads = new ArrayList<>();
 		for (XMLMessage xmlMessage : xmlMessages) {
-			Message<?> message = mapInternal(xmlMessage).build();
+			Message<?> message = mapInternal(xmlMessage, solaceConsumerProperties).build();
 			batchedHeaders.add(message.getHeaders());
 			batchedPayloads.add(message.getPayload());
 		}
@@ -186,20 +186,21 @@ public class XMLMessageMapper {
 				.build();
 	}
 
-	public Message<?> map(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback)
+	public Message<?> map(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback, SolaceConsumerProperties solaceConsumerProperties)
 			throws SolaceMessageConversionException {
-		return map(xmlMessage, acknowledgmentCallback, false);
+		return map(xmlMessage, acknowledgmentCallback, false, solaceConsumerProperties);
 	}
 
 	public Message<?> map(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback,
-						  boolean setRawMessageHeader) throws SolaceMessageConversionException {
-		return injectRootMessageHeaders(mapInternal(xmlMessage), acknowledgmentCallback, setRawMessageHeader ?
+						  boolean setRawMessageHeader, SolaceConsumerProperties solaceConsumerProperties) throws SolaceMessageConversionException {
+		return injectRootMessageHeaders(mapInternal(xmlMessage, solaceConsumerProperties), acknowledgmentCallback, setRawMessageHeader ?
 				xmlMessage : null).build();
 	}
 
-	private AbstractIntegrationMessageBuilder<?> mapInternal(XMLMessage xmlMessage)
+	private AbstractIntegrationMessageBuilder<?> mapInternal(XMLMessage xmlMessage, SolaceConsumerProperties solaceConsumerProperties)
 			throws SolaceMessageConversionException {
 		SDTMap metadata = xmlMessage.getProperties();
+		List<String> excludedHeaders = solaceConsumerProperties.getHeaderExclusions();
 
 		Object payload;
 		if (xmlMessage instanceof BytesMessage) {
@@ -247,7 +248,7 @@ public class XMLMessageMapper {
 
 		AbstractIntegrationMessageBuilder<?> builder = MESSAGE_BUILDER_FACTORY
 				.withPayload(payload)
-				.copyHeaders(map(metadata))
+				.copyHeaders(map(metadata, excludedHeaders))
 				.setHeaderIfAbsent(MessageHeaders.CONTENT_TYPE, xmlMessage.getHTTPContentType());
 
 		if (isNullPayload) {
@@ -259,6 +260,9 @@ public class XMLMessageMapper {
 
 		for (Map.Entry<String, SolaceHeaderMeta<?>> header : SolaceHeaderMeta.META.entrySet()) {
 			if (!header.getValue().isReadable()) {
+				continue;
+			}
+			if (excludedHeaders != null && excludedHeaders.contains(header.getKey())) {
 				continue;
 			}
 			if (ignoredHeaderProperties.contains(header.getKey())) {
@@ -320,15 +324,19 @@ public class XMLMessageMapper {
 		return metadata;
 	}
 
-	MessageHeaders map(SDTMap metadata) {
+	MessageHeaders map(SDTMap metadata, Collection<String> excludedHeaders) {
 		if (metadata == null) {
 			return new MessageHeaders(Collections.emptyMap());
 		}
 
+		final Collection<String> exclusionList =
+				excludedHeaders != null ? excludedHeaders : Collections.emptyList();
+
 		Map<String,Object> headers = new HashMap<>();
 
 		// Deserialize headers
-		if (metadata.containsKey(SolaceBinderHeaders.SERIALIZED_HEADERS)) {
+		if (!exclusionList.contains(SolaceBinderHeaders.SERIALIZED_HEADERS) &&
+				metadata.containsKey(SolaceBinderHeaders.SERIALIZED_HEADERS)) {
 			Encoder encoder = null;
 			if (metadata.containsKey(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING)) {
 				String encoding = rethrowableCall(metadata::getString, SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING);
@@ -345,7 +353,9 @@ public class XMLMessageMapper {
 					rethrowableCall(metadata::getString, SolaceBinderHeaders.SERIALIZED_HEADERS));
 
 			for (String headerName : serializedHeaders) {
-				if (metadata.containsKey(headerName)) {
+				if (exclusionList.contains(headerName)) {
+					continue;
+				} else if (metadata.containsKey(headerName)) {
 					byte[] serializedValue = encoder != null ?
 							encoder.decode(rethrowableCall(metadata::getString, headerName)) :
 							rethrowableCall(metadata::getBytes, headerName);
@@ -359,6 +369,7 @@ public class XMLMessageMapper {
 		}
 
 		metadata.keySet().stream()
+				.filter(h -> !exclusionList.contains(h))
 				.filter(h -> !headers.containsKey(h))
 				.filter(h -> !SolaceBinderHeaderMeta.META.containsKey(h))
 				.filter(h -> !SolaceHeaderMeta.META.containsKey(h))
@@ -370,7 +381,8 @@ public class XMLMessageMapper {
 					headers.put(h, value);
 				});
 
-		if (metadata.containsKey(SolaceBinderHeaders.MESSAGE_VERSION)) {
+		if (!exclusionList.contains(SolaceBinderHeaders.MESSAGE_VERSION) &&
+				metadata.containsKey(SolaceBinderHeaders.MESSAGE_VERSION)) {
 			int messageVersion = rethrowableCall(metadata::getInteger, SolaceBinderHeaders.MESSAGE_VERSION);
 			headers.put(SolaceBinderHeaders.MESSAGE_VERSION, messageVersion);
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerPropertiesTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerPropertiesTest.java
@@ -1,10 +1,12 @@
 package com.solace.spring.cloud.stream.binder.properties;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SolaceConsumerPropertiesTest {
 	@ParameterizedTest
@@ -80,5 +82,10 @@ public class SolaceConsumerPropertiesTest {
 	public void testFailSetFlowRebindBackOffMultiplier(double multiplier) {
 		assertThrows(IllegalArgumentException.class, () -> new SolaceConsumerProperties()
 				.setFlowRebindBackOffMultiplier(multiplier));
+	}
+
+	@Test
+	void testDefaultHeaderExclusionsListIsEmpty() {
+		assertTrue(new SolaceConsumerProperties().getHeaderExclusions().isEmpty());
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -6,6 +6,7 @@ import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
 import com.solace.spring.cloud.stream.binder.messaging.HeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.test.util.SerializableFoo;
 import com.solace.test.integration.junit.jupiter.extension.PubSubPlusExtension;
 import com.solacesystems.jcsmp.BytesMessage;
@@ -339,6 +340,7 @@ public class JmsCompatibilityIT {
 			messages.add(mapMessage);
 		}
 
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		XMLMessageConsumer messageConsumer = null;
 		try {
 			Set<Class<? extends XMLMessage>> processedMessageTypes = new HashSet<>();
@@ -349,7 +351,7 @@ public class JmsCompatibilityIT {
 				public void onReceive(BytesXMLMessage bytesXMLMessage) {
 					logger.info("Got message " + bytesXMLMessage);
 					try {
-						Message<?> msg = xmlMessageMapper.map(bytesXMLMessage, null);
+						Message<?> msg = xmlMessageMapper.map(bytesXMLMessage, null, consumerProperties);
 						if (msg.getPayload() instanceof byte[]) {
 							softly.assertThat(msg.getPayload()).isEqualTo("test".getBytes());
 							processedMessageTypes.add(BytesMessage.class);
@@ -428,6 +430,7 @@ public class JmsCompatibilityIT {
 		ObjectMessage message = jmsSession.createObjectMessage(payload);
 		message.setBooleanProperty(SolaceBinderHeaders.SERIALIZED_PAYLOAD, true);
 
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		XMLMessageConsumer messageConsumer = null;
 		try {
 			AtomicReference<Exception> exceptionAtomicReference = new AtomicReference<>();
@@ -437,7 +440,7 @@ public class JmsCompatibilityIT {
 				public void onReceive(BytesXMLMessage bytesXMLMessage) {
 					logger.info("Got message " + bytesXMLMessage);
 					try {
-						softly.assertThat(xmlMessageMapper.map(bytesXMLMessage, null).getPayload())
+						softly.assertThat(xmlMessageMapper.map(bytesXMLMessage, null, consumerProperties).getPayload())
 								.isEqualTo(payload);
 					} catch (Exception e) {
 						exceptionAtomicReference.set(e);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -25,6 +25,7 @@ import com.solacesystems.jcsmp.StreamMessage;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLContentMessage;
 import com.solacesystems.jcsmp.XMLMessage;
+import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.logging.Log;
@@ -726,8 +727,9 @@ public class XMLMessageMapperTest {
 		xmlMessage.setProperties(metadata);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
-		Message<?> springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
-		Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		Message<?> springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
+		Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false, consumerProperties);
 
 		validateSpringPayload(springMessage.getPayload(), expectedPayload);
 		validateSpringHeaders(springMessage.getHeaders(), xmlMessage);
@@ -756,8 +758,9 @@ public class XMLMessageMapperTest {
 				.collect(Collectors.toList());
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
-		Message<List<?>> springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
-		Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		Message<List<?>> springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
+		Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false, consumerProperties);
 
 		validateSpringBatchPayload(springMessage.getPayload(), expectedPayloads);
 		validateSpringBatchHeaders(springMessage.getHeaders(), xmlMessages);
@@ -780,7 +783,8 @@ public class XMLMessageMapperTest {
 		xmlMessage.setProperties(metadata);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
-		Message<?> springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, true);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		Message<?> springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, true, consumerProperties);
 
 		validateSpringPayload(springMessage.getPayload(), expectedPayload);
 		validateSpringHeaders(springMessage.getHeaders(), xmlMessage);
@@ -809,7 +813,8 @@ public class XMLMessageMapperTest {
 				.collect(Collectors.toList());
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
-		Message<List<?>> springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, true);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		Message<List<?>> springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, true, consumerProperties);
 
 		validateSpringBatchPayload(springMessage.getPayload(), expectedPayloads);
 		validateSpringBatchHeaders(springMessage.getHeaders(), xmlMessages);
@@ -839,19 +844,20 @@ public class XMLMessageMapperTest {
 		xmlMessage.setHTTPContentType(MimeTypeUtils.TEXT_HTML_VALUE);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<MT> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false, consumerProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false, consumerProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -959,20 +965,21 @@ public class XMLMessageMapperTest {
 		metadata.putString(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false, consumerProperties);
 
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 							.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false, consumerProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1104,21 +1111,22 @@ public class XMLMessageMapperTest {
 		metadata.putString(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false, consumerProperties);
 
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false, consumerProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1167,21 +1175,22 @@ public class XMLMessageMapperTest {
 		metadata.putString(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchMessage(xmlMessages, acknowledgmentCallback, false, consumerProperties);
 
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
-			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
+			Mockito.verify(xmlMessageMapper).map(xmlMessage, acknowledgmentCallback, false, consumerProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1221,16 +1230,17 @@ public class XMLMessageMapperTest {
 		Mockito.when(xmlMessage.getDeliveryCount()).thenReturn(deliveryCount);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		MapAssert<String, Object> headersAssert;
 		if (batchMode) {
 			headersAssert = Assertions.assertThat(Objects.requireNonNull(xmlMessageMapper
-									.mapBatchMessage(Collections.singletonList(xmlMessage), acknowledgmentCallback)
+									.mapBatchMessage(Collections.singletonList(xmlMessage), acknowledgmentCallback, consumerProperties)
 									.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class))
 					.get(0))
 					.asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class));
 		} else {
-			headersAssert = Assertions.assertThat(xmlMessageMapper.map(xmlMessage, acknowledgmentCallback)
+			headersAssert = Assertions.assertThat(xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties)
 					.getHeaders());
 		}
 		headersAssert.extractingByKey(SolaceHeaders.DELIVERY_COUNT).isEqualTo(deliveryCount);
@@ -1252,18 +1262,19 @@ public class XMLMessageMapperTest {
 		xmlMessage.setProperties(metadata);
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1282,18 +1293,19 @@ public class XMLMessageMapperTest {
 	public void testMapXMLMessageToSpringMessage_WithNullPayload(boolean batchMode) {
 		BytesMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(BytesMessage.class);
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<BytesMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1315,13 +1327,14 @@ public class XMLMessageMapperTest {
 		metadata.putBoolean(SolaceBinderHeaders.SERIALIZED_PAYLOAD, true);
 		xmlMessage.setProperties(metadata);
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 
 		Message<?> springMessage;
 		if (batchMode) {
 			springMessage = xmlMessageMapper.mapBatchMessage(Collections.singletonList(xmlMessage),
-					acknowledgmentCallback);
+					acknowledgmentCallback, consumerProperties);
 		} else {
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
 		}
 
 		if (batchMode) {
@@ -1420,7 +1433,7 @@ public class XMLMessageMapperTest {
 		List<String> serializedHeaders = Arrays.asList(key, key);
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 
-		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, List.of());
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
@@ -1434,10 +1447,110 @@ public class XMLMessageMapperTest {
 		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
 		sdtMap.putObject(key, null);
 
-		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, List.of());
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertNull(messageHeaders.get(key));
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_WithNullExcludedHeader() throws Exception {
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		for (int i = 0; i < 10; i++) {
+			sdtMap.putObject("headerKey" + i, UUID.randomUUID().toString());
+		}
+
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, null);
+
+		for (int i = 0; i < 10; i++) {
+			String key = "headerKey" + i;
+			assertEquals(sdtMap.get(key), messageHeaders.get(key));
+		}
+	}
+
+	@ParameterizedTest(name = "[{index}] batchMode={0}")
+	@ValueSource(booleans = {false, true})
+	public void testMapXMLMessageToSpringMessage_WithExcludedHeader(boolean batchMode)
+			throws SDTException {
+		List<String> excludedHeaders = List.of("headerKey1", "headerKey2", "headerKey5",
+				"solace_expiration", "solace_discardIndication", "solace_redelivered",
+				"solace_dmqEligible", "solace_priority");
+		BytesMessage xmlMessage = Mockito.spy(JCSMPFactory.onlyInstance().createMessage(BytesMessage.class));
+		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setHeaderExclusions(excludedHeaders);
+
+		SDTMap metadata = JCSMPFactory.onlyInstance().createMap();
+		Mockito.when(xmlMessage.getProperties()).thenReturn(metadata);
+		for (int i = 0; i < 10; i++) {
+			metadata.putObject("headerKey" + i, UUID.randomUUID().toString());
+		}
+
+		Message<?> springMessage;
+		MessageHeaders springMessageHeaders;
+		if (batchMode) {
+			List<BytesMessage> xmlMessages = Collections.singletonList(xmlMessage);
+			springMessage = xmlMessageMapper.mapBatchMessage(xmlMessages, acknowledgmentCallback, consumerProperties);
+			@SuppressWarnings("unchecked")
+			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
+					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
+			springMessageHeaders = new MessageHeaders(messageHeaders);
+		} else {
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
+			springMessageHeaders = springMessage.getHeaders();
+		}
+
+		for (int i = 0; i < 10; i++) {
+			String key = "headerKey" + i;
+			if (excludedHeaders.contains(key)) {
+				assertFalse(springMessageHeaders.containsKey(key));
+			} else {
+				assertEquals(metadata.get(key), springMessageHeaders.get(key));
+			}
+		}
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_WithExcludedHeader() throws Exception {
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		for (int i = 0; i < 10; i++) {
+			sdtMap.putObject("headerKey" + i, UUID.randomUUID().toString());
+		}
+
+		List<String> excludedHeaders = List.of("headerKey1", "headerKey2", "headerKey5");
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, excludedHeaders);
+
+		for (int i = 0; i < 10; i++) {
+			String key = "headerKey" + i;
+			if (excludedHeaders.contains(key)) {
+				assertFalse(messageHeaders.containsKey(key));
+			} else {
+				assertEquals(sdtMap.get(key), messageHeaders.get(key));
+			}
+		}
+	}
+
+	@Test
+	public void testMapSDTMapToMessageHeaders_WithExcludedHeader_canExcludeBinderHeaders() throws Exception {
+		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
+		sdtMap.putObject(SolaceBinderHeaders.MESSAGE_VERSION, 10);
+		sdtMap.putObject(SolaceBinderHeaders.SERIALIZED_HEADERS, "header1, header2");
+		sdtMap.putObject("retainedHeader", "test");
+
+		List<String> excludedHeaders = List.of(SolaceBinderHeaders.MESSAGE_VERSION, SolaceBinderHeaders.SERIALIZED_HEADERS);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, excludedHeaders);
+
+		sdtMap.keySet().forEach(key -> {
+			if (excludedHeaders.contains(key)) {
+				assertFalse(messageHeaders.containsKey(key));
+			} else {
+				try {
+					assertEquals(sdtMap.get(key), messageHeaders.get(key));
+				} catch (SDTException e) {
+					fail(e);
+				}
+			}
+		});
 	}
 
 	@Test
@@ -1450,7 +1563,7 @@ public class XMLMessageMapperTest {
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "base64");
 
-		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, List.of());
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
@@ -1465,7 +1578,7 @@ public class XMLMessageMapperTest {
 		Set<String> serializedHeaders = Collections.singleton(key);
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 
-		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, List.of());
 
 		assertThat(messageHeaders.keySet(), not(hasItem(key)));
 		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
@@ -1480,7 +1593,7 @@ public class XMLMessageMapperTest {
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "base64");
 
-		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, List.of());
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertNull(messageHeaders.get(key));
@@ -1498,7 +1611,7 @@ public class XMLMessageMapperTest {
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "abc");
 
 		SolaceMessageConversionException exception = assertThrows(SolaceMessageConversionException.class,
-				() -> xmlMessageMapper.map(sdtMap));
+				() -> xmlMessageMapper.map(sdtMap, List.of()));
 		assertThat(exception.getMessage(), containsString("encoding is not supported"));
 	}
 
@@ -1510,7 +1623,7 @@ public class XMLMessageMapperTest {
 			sdtMap.putBytes(header, value);
 		}
 
-		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap);
+		MessageHeaders messageHeaders = xmlMessageMapper.map(sdtMap, List.of());
 
 		for (String header : JMS_INVALID_HEADER_NAMES) {
 			assertThat(messageHeaders.keySet(), hasItem(header));
@@ -1536,6 +1649,7 @@ public class XMLMessageMapperTest {
 		expectedXmlMessage.setProperties(metadata);
 		expectedXmlMessage.setHTTPContentType(MimeTypeUtils.TEXT_PLAIN_VALUE);
 
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		Message<?> springMessage = expectedSpringMessage;
 		XMLMessage xmlMessage;
 		int i = 0;
@@ -1546,7 +1660,7 @@ public class XMLMessageMapperTest {
 
 			logger.info(String.format("Iteration %s - XMLMessage to Message<?>:\n%s", i, xmlMessage));
 			AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
-			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback);
+			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
 			validateSpringHeaders(springMessage.getHeaders(), expectedXmlMessage);
 
 			// Update the expected default spring headers

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.cloud</groupId>
         <artifactId>solace-spring-cloud-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-cloud-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-cloud-stream-binder-solace</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Spring Cloud Stream Binder</name>


### PR DESCRIPTION
Introduced new consumer configuration properties to exclude headers on inbound messages.