### PR TITLE
DATAGO-73954: migrate producer bindings to use JCSMP producer flows

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
@@ -4,6 +4,9 @@ import com.solace.spring.cloud.stream.binder.properties.SolaceCommonProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.ProducerFlowProperties;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
@@ -40,6 +43,24 @@ public class SolaceProvisioningUtil {
 		endpointProperties.setQuota(properties.getErrorQueueQuota());
 		endpointProperties.setRespectsMsgTTL(properties.getErrorQueueRespectsMsgTtl());
 		return endpointProperties;
+	}
+
+	public static ProducerFlowProperties getProducerFlowProperties(JCSMPSession jcsmpSession) {
+		ProducerFlowProperties producerFlowProperties = new ProducerFlowProperties();
+
+		// SOL-118898:
+		// PUB_ACK_WINDOW_SIZE & ACK_EVENT_MODE aren't automatically used as default values for
+		// ProducerFlowProperties.
+		Integer pubAckWindowSize = (Integer) jcsmpSession.getProperty(JCSMPProperties.PUB_ACK_WINDOW_SIZE);
+		if (pubAckWindowSize != null) {
+			producerFlowProperties.setWindowSize(pubAckWindowSize);
+		}
+		String ackEventMode = (String) jcsmpSession.getProperty(JCSMPProperties.ACK_EVENT_MODE);
+		if (ackEventMode != null) {
+			producerFlowProperties.setAckEventMode(ackEventMode);
+		}
+
+		return producerFlowProperties;
 	}
 
 	public static boolean isAnonQueue(String groupName) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
@@ -4,14 +4,15 @@ import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.XMLMessageProducer;
-import java.util.Optional;
-import java.util.UUID;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public class JCSMPSessionProducerManager extends SharedResourceManager<XMLMessageProducer> {
 	private final JCSMPSession session;


### PR DESCRIPTION
Migrate the producer binding to use dedicated producer flows, which are more performant than the session's global default producer.

Due to SOL-118898, the `PUB_ACK_WINDOW_SIZE` and `ACK_EVENT_MODE` properties had to be manually mapped from the JCSMP session to the producer flow properties.