### PR TITLE
Change JUnit parallelism to fixed with an upper limit

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/resources/junit-platform.properties
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/resources/junit-platform.properties
@@ -3,5 +3,13 @@ junit.jupiter.extensions.autodetection.enabled=true
 # Parallel test execution is disabled by default for easy debugging in IDEs.
 # It is overridden to be enabled by the Maven Surefire/Failsafe plugins.
 junit.jupiter.execution.parallel.enabled=false
+
+# Configured based on Github-hosted runners for public repositories.
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+junit.jupiter.execution.parallel.config.strategy=fixed
+# Parallelism should ideally equal to the num of processors on the machine
+junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=20
+
 junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/resources/junit-platform.properties
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/resources/junit-platform.properties
@@ -3,5 +3,13 @@ junit.jupiter.extensions.autodetection.enabled=true
 # Parallel test execution is disabled by default for easy debugging in IDEs.
 # It is overridden to be enabled by the Maven Surefire/Failsafe plugins.
 junit.jupiter.execution.parallel.enabled=false
+
+# Configured based on Github-hosted runners for public repositories.
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+junit.jupiter.execution.parallel.config.strategy=fixed
+# Parallelism should ideally equal to the num of processors on the machine
+junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=20
+
 junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=same_thread


### PR DESCRIPTION
Fix running out of broker resources due to too many tests running in parallel.