### PR TITLE
DATAGO-80545, DATAGO-79356: add batchWaitStrategy consumer config option

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -287,6 +287,17 @@ Only applicable when `batchMode` is `true`.
 +
 Default: `255`
 
+batchWaitStrategy::
+The waiting strategy for accumulating batches. +
+Only applicable when `batchMode` is `true`.
++
+Default: `respect_timeout`
++
+NOTE: The waiting strategy works alongside the `batchMaxSize` option.
++
+respect_timeout::: Adheres to the `batchTimeout` consumer config option.
+immediate::: Immediately collects the batch once no more messages are available on the endpoint.
+
 batchTimeout::
 The maximum wait time in milliseconds to receive a batch of messages. If this timeout is reached, then the messages that have already been received will be used to create the batch. A value of `0` means wait forever. +
 Only applicable when `batchMode` is `true`.
@@ -903,7 +914,7 @@ See https://docs.spring.io/spring-cloud-stream/docs/{scst-version}/reference/htm
 See <<Native Payload Types>> for more info regarding this binder's natively supported payload types.
 ====
 
-To create a batch of messages, the binder will consume messages from the PubSub+ broker until either a maximum batch size or timeout has been achieved. After which, the binder will compose the batch message and send it to the consumer handler for processing. Both these batching parameters can be configured using the `batchMaxSize` and `batchTimeout` consumer config options.
+To create a batch of messages, the binder will consume messages from the PubSub+ broker until either a maximum batch size or timeout has been achieved. After which, the binder will compose the batch message and send it to the consumer handler for processing. Both these batching parameters can be configured using the `batchMaxSize`, `batchWaitStrategy`, and `batchTimeout` consumer config options.
 
 === Batch Producers
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BatchCollector.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BatchCollector.java
@@ -80,7 +80,9 @@ public class BatchCollector {
 				}
 				case IMMEDIATE -> {
 					if (isLastMessageNull) {
-						LOGGER.trace("Last message was null, processing batch of {} messages...", batchedMessages.size());
+						LOGGER.trace(
+								"No more messages are available on the endpoint, processing batch of {} messages...",
+								batchedMessages.size());
 					} else {
 						return false;
 					}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BatchCollector.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BatchCollector.java
@@ -2,8 +2,9 @@ package com.solace.spring.cloud.stream.binder.inbound;
 
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.MessageContainer;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,10 +19,11 @@ import java.util.UUID;
 public class BatchCollector {
 	private final SolaceConsumerProperties consumerProperties;
 	private final List<MessageContainer> batchedMessages;
-	private long timeSentLastBatch = System.currentTimeMillis();
+	private long batchCollectionStartTimestamp = System.currentTimeMillis();
+	private boolean isLastMessageNull = false;
 	private UUID currentFlowReceiverReferenceId;
 
-	private static final Log logger = LogFactory.getLog(BatchCollector.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BatchCollector.class);
 
 	public BatchCollector(SolaceConsumerProperties consumerProperties) {
 		this.consumerProperties = consumerProperties;
@@ -32,19 +34,19 @@ public class BatchCollector {
 	 * Add message to batch
 	 * @param messageContainer message container
 	 */
-	public void addToBatch(MessageContainer messageContainer) {
+	public void addToBatch(@Nullable MessageContainer messageContainer) {
 		if (messageContainer == null) {
+			isLastMessageNull = true;
 			return;
 		}
 
+		isLastMessageNull = false;
 		batchedMessages.add(messageContainer);
 		UUID flowReceiverReferenceId = messageContainer.getFlowReceiverReferenceId();
 		if (currentFlowReceiverReferenceId != null && !currentFlowReceiverReferenceId.equals(flowReceiverReferenceId)) {
-			if (logger.isTraceEnabled()) {
-				logger.trace(String.format("Added a message to batch, but its flow receiver reference ID was %s, " +
-								"expected %s. Pruning stale messages from batch...",
-						flowReceiverReferenceId, currentFlowReceiverReferenceId));
-			}
+			LOGGER.trace("Added a message to batch, but its flow receiver reference ID was {}, expected {}. " +
+							"Pruning stale messages from batch...",
+					flowReceiverReferenceId, currentFlowReceiverReferenceId);
 			pruneStaleMessages();
 		}
 		currentFlowReceiverReferenceId = flowReceiverReferenceId;
@@ -55,26 +57,39 @@ public class BatchCollector {
 	 * @return true if available (batch may be empty).
 	 */
 	public boolean isBatchAvailable() {
+		// must be able to return an empty batch so that polled consumers don't block indefinitely
 		return isBatchAvailableInternal() && (!pruneStaleMessages() || isBatchAvailableInternal());
 	}
 
-	public boolean isBatchAvailableInternal() {
+	boolean isBatchAvailableInternal() {
 		if (batchedMessages.size() < consumerProperties.getBatchMaxSize()) {
-			long batchTimeDiff = System.currentTimeMillis() - timeSentLastBatch;
-			if (consumerProperties.getBatchTimeout() == 0 || batchTimeDiff < consumerProperties.getBatchTimeout()) {
-				if (logger.isTraceEnabled()) {
-					logger.trace(String.format("Collecting batch... Size: %s, Time since last batch: %s ms",
-							batchedMessages.size(), batchTimeDiff));
+			switch (consumerProperties.getBatchWaitStrategy()) {
+				case RESPECT_TIMEOUT -> {
+					long batchTimeDiff = System.currentTimeMillis() - batchCollectionStartTimestamp;
+					if (consumerProperties.getBatchTimeout() == 0 || batchTimeDiff < consumerProperties.getBatchTimeout()) {
+						if (!isLastMessageNull) {
+							LOGGER.trace("Collecting batch... Size: {}, Time elapsed: {} ms",
+									batchedMessages.size(), batchTimeDiff);
+						}
+						return false;
+					} else {
+						LOGGER.trace(
+								"Batch timeout reached <time elapsed: {} ms>, processing batch of {} messages...",
+								batchTimeDiff, batchedMessages.size());
+					}
 				}
-				return false;
-			} else if (logger.isTraceEnabled()) {
-				logger.trace(String.format(
-						"Batch timeout reached <time since last batch: %s ms>, processing batch of %s messages...",
-						batchTimeDiff, batchedMessages.size()));
+				case IMMEDIATE -> {
+					if (isLastMessageNull) {
+						LOGGER.trace("Last message was null, processing batch of {} messages...", batchedMessages.size());
+					} else {
+						return false;
+					}
+				}
+				default -> throw new UnsupportedOperationException("Unsupported batch wait strategy: " +
+						consumerProperties.getBatchWaitStrategy());
 			}
-		} else if (logger.isTraceEnabled()) {
-			logger.trace(String.format("Max batch size reached, processing batch of %s messages...",
-					batchedMessages.size()));
+		} else {
+			LOGGER.trace("Max batch size reached, processing batch of {} messages...", batchedMessages.size());
 		}
 		return true;
 	}
@@ -92,11 +107,11 @@ public class BatchCollector {
 	}
 
 	/**
-	 * Reset the timestamp of the last batch sent if the message batch is empty.
+	 * Reset batch collection start timestamp if the message batch is empty.
 	 */
-	public void resetLastSentTimeIfEmpty() {
+	public void resetBatchCollectionStartTimestampIfEmpty() {
 		if (batchedMessages.isEmpty()) {
-			resetLastSentTime();
+			resetBatchCollectionStartTimestamp();
 		}
 	}
 
@@ -104,7 +119,9 @@ public class BatchCollector {
 	 * Callback to invoke when batch of messages have been processed.
 	 */
 	public void confirmDelivery() {
-		resetLastSentTime();
+		LOGGER.trace("Confirmed delivery of batch of {} messages", batchedMessages.size());
+		resetBatchCollectionStartTimestamp();
+		isLastMessageNull = false;
 		batchedMessages.clear();
 	}
 
@@ -115,17 +132,13 @@ public class BatchCollector {
 	private boolean pruneStaleMessages() {
 		int prePrunedBatchSize = batchedMessages.size();
 		boolean pruned = batchedMessages.removeIf(MessageContainer::isStale);
-		if (logger.isTraceEnabled()) {
-			logger.trace(String.format("Finished pruning stale messages from undelivered batch. Size: %s -> %s",
-					prePrunedBatchSize, batchedMessages.size()));
-		}
+		LOGGER.trace("Finished pruning stale messages from undelivered batch. Size: {} -> {}", prePrunedBatchSize,
+				batchedMessages.size());
 		return pruned;
 	}
 
-	private void resetLastSentTime() {
-		timeSentLastBatch = System.currentTimeMillis();
-		if (logger.isTraceEnabled()) {
-			logger.trace("Timestamp of last batch sent was reset");
-		}
+	private void resetBatchCollectionStartTimestamp() {
+		batchCollectionStartTimestamp = System.currentTimeMillis();
+		LOGGER.trace("Batch collection start time was reset");
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -1,5 +1,6 @@
 package com.solace.spring.cloud.stream.binder.properties;
 
+import com.solace.spring.cloud.stream.binder.util.BatchWaitStrategy;
 import com.solace.spring.cloud.stream.binder.util.EndpointType;
 import com.solacesystems.jcsmp.EndpointProperties;
 import jakarta.validation.constraints.Min;
@@ -34,6 +35,11 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 */
 	@Min(0)
 	private int batchTimeout = 5000;
+
+	/**
+	 * The waiting strategy for accumulating batches.
+	 */
+	private BatchWaitStrategy batchWaitStrategy = BatchWaitStrategy.RESPECT_TIMEOUT;
 
 	/**
 	 * Maximum wait time for polled consumers to receive a message from their consumer group queue.
@@ -151,6 +157,14 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	public void setBatchTimeout(int batchTimeout) {
 		Assert.isTrue(batchTimeout >= 0, "batch timeout must be greater than or equal to 0");
 		this.batchTimeout = batchTimeout;
+	}
+
+	public BatchWaitStrategy getBatchWaitStrategy() {
+		return batchWaitStrategy;
+	}
+
+	public void setBatchWaitStrategy(BatchWaitStrategy batchWaitStrategy) {
+		this.batchWaitStrategy = batchWaitStrategy;
 	}
 
 	public int getPolledConsumerWaitTimeInMillis() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/BatchWaitStrategy.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/BatchWaitStrategy.java
@@ -1,0 +1,12 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+public enum BatchWaitStrategy {
+	/**
+	 * Adheres to the {@code batchTimeout} consumer config option.
+	 */
+	RESPECT_TIMEOUT,
+	/**
+	 * Immediately collects the batch once no more messages are available on the endpoint.
+	 */
+	IMMEDIATE
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListenerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListenerTest.java
@@ -7,6 +7,7 @@ import com.solacesystems.jcsmp.StaleSessionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -27,7 +28,7 @@ public class InboundXMLMessageListenerTest {
     public void testListenerIsStoppedOnStaleSessionException(@Mock FlowReceiverContainer flowReceiverContainer, CapturedOutput output)
             throws UnboundFlowReceiverContainerException, JCSMPException {
 
-        when(flowReceiverContainer.receive())
+        when(flowReceiverContainer.receive(Mockito.anyInt()))
                 .thenThrow(new StaleSessionException("Session has become stale", new JCSMPException("Specific JCSMP exception")));
 
         BasicInboundXMLMessageListener inboundXMLMessageListener = new BasicInboundXMLMessageListener(

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderHealthIndicatorIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderHealthIndicatorIT.java
@@ -8,7 +8,6 @@ import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
 import com.solace.test.integration.junit.jupiter.extension.PubSubPlusExtension;
 import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/spring/MessageLayout.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/spring/MessageLayout.java
@@ -1,0 +1,33 @@
+package com.solace.spring.cloud.stream.binder.test.spring;
+
+import com.solace.spring.cloud.stream.binder.util.BatchWaitStrategy;
+import org.springframework.lang.Nullable;
+
+public enum MessageLayout {
+	SINGLE(false),
+	BATCHED_TIMEOUT(true, BatchWaitStrategy.RESPECT_TIMEOUT),
+	BATCHED_IMMEDIATE(true, BatchWaitStrategy.IMMEDIATE);
+
+	private final boolean isBatched;
+	@Nullable private final BatchWaitStrategy waitStrategy;
+
+	MessageLayout(boolean isBatched) {
+		this(isBatched, null);
+	}
+
+	MessageLayout(boolean isBatched, @Nullable BatchWaitStrategy waitStrategy) {
+		this.isBatched = isBatched;
+		this.waitStrategy = waitStrategy;
+	}
+
+	public boolean isBatched() {
+		return isBatched;
+	}
+
+	public BatchWaitStrategy getWaitStrategy() {
+		if (waitStrategy == null || !isBatched) {
+			throw new UnsupportedOperationException("Message layout is not batched");
+		}
+		return waitStrategy;
+	}
+}


### PR DESCRIPTION
* Added the `batchWaitStrategy` consumer config option.
* Fixed `batchTimeout`'s reference timestamp to be when the first message is received instead of when the last message was sent.
  * Fix only applies to asynchronous consumers. The reference timestamp for polled consumers is still when `receive()` is invoked on the consumer.