### PR TITLE
DATAGO-73953: use slf4j instead of apache commons logging

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/base/SolaceHealthIndicator.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/base/SolaceHealthIndicator.java
@@ -1,8 +1,8 @@
 package com.solace.spring.cloud.stream.binder.health.base;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
@@ -16,12 +16,10 @@ public class SolaceHealthIndicator implements HealthIndicator {
 	private static final String INFO = "info";
 	private static final String RESPONSE_CODE = "responseCode";
 	private volatile Health health;
-	private static final Log logger = LogFactory.getLog(SolaceHealthIndicator.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceHealthIndicator.class);
 
 	private static void logDebugStatus(String status) {
-		if (logger.isDebugEnabled()) {
-			logger.debug(String.format("Solace connection/flow status is %s", status));
-		}
+		LOGGER.debug("Solace connection/flow status is {}", status);
 	}
 	protected void healthUp() {
 			health = Health.up().build();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/handlers/SolaceSessionEventHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/handlers/SolaceSessionEventHandler.java
@@ -5,13 +5,13 @@ import com.solacesystems.jcsmp.DefaultSolaceOAuth2SessionEventHandler;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.SessionEventArgs;
 import com.solacesystems.jcsmp.SolaceSessionOAuth2TokenProvider;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
 
 public class SolaceSessionEventHandler extends DefaultSolaceOAuth2SessionEventHandler {
 	private final SessionHealthIndicator sessionHealthIndicator;
-	private static final Log logger = LogFactory.getLog(SolaceSessionEventHandler.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceSessionEventHandler.class);
 
 	public SolaceSessionEventHandler(JCSMPProperties jcsmpProperties,
 			@Nullable SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider,
@@ -22,9 +22,7 @@ public class SolaceSessionEventHandler extends DefaultSolaceOAuth2SessionEventHa
 
 	@Override
 	public void handleEvent(SessionEventArgs eventArgs) {
-		if (logger.isDebugEnabled()) {
-			logger.debug(String.format("Received Solace JCSMP Session event [%s]", eventArgs));
-		}
+		LOGGER.debug("Received Solace JCSMP Session event [{}]", eventArgs);
 		super.handleEvent(eventArgs);
 		switch (eventArgs.getEvent()) {
 			case RECONNECTED -> this.sessionHealthIndicator.up();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/indicators/SessionHealthIndicator.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/indicators/SessionHealthIndicator.java
@@ -3,8 +3,8 @@ package com.solace.spring.cloud.stream.binder.health.indicators;
 import com.solace.spring.cloud.stream.binder.health.base.SolaceHealthIndicator;
 import com.solace.spring.cloud.stream.binder.properties.SolaceSessionHealthProperties;
 import com.solacesystems.jcsmp.SessionEventArgs;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
 
 import java.util.Optional;
@@ -15,7 +15,7 @@ public class SessionHealthIndicator extends SolaceHealthIndicator {
 	private final AtomicInteger reconnectCount = new AtomicInteger(0);
 	private final SolaceSessionHealthProperties solaceHealthSessionProperties;
 	private final ReentrantLock writeLock = new ReentrantLock();
-	private static final Log logger = LogFactory.getLog(SessionHealthIndicator.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SessionHealthIndicator.class);
 
 	public SessionHealthIndicator(SolaceSessionHealthProperties solaceHealthSessionProperties) {
 		this.solaceHealthSessionProperties = solaceHealthSessionProperties;
@@ -24,9 +24,7 @@ public class SessionHealthIndicator extends SolaceHealthIndicator {
 	public void up() {
 		writeLock.lock();
 		try {
-			if (logger.isTraceEnabled()) {
-				logger.trace("Reset reconnect count");
-			}
+			LOGGER.trace("Reset reconnect count");
 			this.reconnectCount.set(0);
 			super.healthUp();
 		} finally {
@@ -42,10 +40,8 @@ public class SessionHealthIndicator extends SolaceHealthIndicator {
 					.filter(maxReconnectAttempts -> maxReconnectAttempts > 0)
 					.filter(maxReconnectAttempts -> reconnectAttempt > maxReconnectAttempts)
 					.isPresent()) {
-				if (logger.isDebugEnabled()) {
-					logger.debug(String.format("Solace connection reconnect attempt %s > %s, changing state to down",
-							reconnectAttempt, solaceHealthSessionProperties.getReconnectAttemptsUntilDown()));
-				}
+				LOGGER.debug("Solace connection reconnect attempt {} > {}, changing state to down",
+						reconnectAttempt, solaceHealthSessionProperties.getReconnectAttemptsUntilDown());
 				this.down(eventArgs, false);
 				return;
 			}
@@ -64,9 +60,7 @@ public class SessionHealthIndicator extends SolaceHealthIndicator {
 		writeLock.lock();
 		try {
 			if (resetReconnectCount) {
-				if (logger.isTraceEnabled()) {
-					logger.trace("Reset reconnect count");
-				}
+				LOGGER.trace("Reset reconnect count");
 				this.reconnectCount.set(0);
 			}
 			super.healthDown(eventArgs);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BasicInboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/BasicInboundXMLMessageListener.java
@@ -6,8 +6,8 @@ import com.solace.spring.cloud.stream.binder.meter.SolaceMeterAccessor;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
 import com.solace.spring.cloud.stream.binder.util.SolaceAcknowledgmentException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.core.AttributeAccessor;
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 public class BasicInboundXMLMessageListener extends InboundXMLMessageListener {
 	private final BiFunction<Message<?>, RuntimeException, Boolean> errorHandlerFunction;
 
-	private static final Log logger = LogFactory.getLog(BasicInboundXMLMessageListener.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BasicInboundXMLMessageListener.class);
 
 	BasicInboundXMLMessageListener(FlowReceiverContainer flowReceiverContainer,
 								   ConsumerDestination consumerDestination,
@@ -63,9 +63,9 @@ public class BasicInboundXMLMessageListener extends InboundXMLMessageListener {
 			if (processedByErrorHandler) {
 				AckUtils.autoAck(acknowledgmentCallback);
 			} else {
-				logger.warn(String.format("Failed to map %s to a Spring Message and no error channel " +
+				LOGGER.warn("Failed to map {} to a Spring Message and no error channel " +
 						"was configured. Message will be rejected.", isBatched ? "a batch of XMLMessages" :
-						"an XMLMessage"), e);
+						"an XMLMessage", e);
 				if (!SolaceAckUtil.republishToErrorQueue(acknowledgmentCallback)) {
 					AckUtils.requeue(acknowledgmentCallback);
 				}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorChannelSendingCorrelationKey.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorChannelSendingCorrelationKey.java
@@ -2,8 +2,8 @@ package com.solace.spring.cloud.stream.binder.util;
 
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solacesystems.jcsmp.XMLMessage;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
@@ -20,7 +20,7 @@ public class ErrorChannelSendingCorrelationKey {
 	private List<XMLMessage> rawMessages;
 	private CorrelationData confirmCorrelation;
 
-	private static final Log logger = LogFactory.getLog(ErrorChannelSendingCorrelationKey.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ErrorChannelSendingCorrelationKey.class);
 
 	public ErrorChannelSendingCorrelationKey(Message<?> inputMessage, MessageChannel errorChannel,
 											 ErrorMessageStrategy errorMessageStrategy) {
@@ -64,8 +64,7 @@ public class ErrorChannelSendingCorrelationKey {
 						inputMessage.getHeaders().containsKey(SolaceBinderHeaders.BATCHED_HEADERS) ?
 								rawMessages : rawMessages.get(0));
 			}
-			logger.debug(String.format("Sending message %s to error channel %s", inputMessage.getHeaders().getId(),
-					errorChannel));
+			LOGGER.debug("Sending message {} to error channel {}", inputMessage.getHeaders().getId(), errorChannel);
 			errorChannel.send(errorMessageStrategy.buildErrorMessage(exception, attributes));
 		}
 		return exception;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueInfrastructure.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueInfrastructure.java
@@ -6,8 +6,8 @@ import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.XMLMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessagingException;
 
 public class ErrorQueueInfrastructure {
@@ -17,7 +17,7 @@ public class ErrorQueueInfrastructure {
 	private final SolaceConsumerProperties consumerProperties;
 	private final XMLMessageMapper xmlMessageMapper = new XMLMessageMapper();
 
-	private static final Log logger = LogFactory.getLog(ErrorQueueInfrastructure.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ErrorQueueInfrastructure.class);
 
 	public ErrorQueueInfrastructure(JCSMPSessionProducerManager producerManager, String producerKey,
 									String errorQueueName, SolaceConsumerProperties consumerProperties) {
@@ -35,10 +35,11 @@ public class ErrorQueueInfrastructure {
 		try {
 			producer = producerManager.get(producerKey);
 		} catch (Exception e) {
-			String msg = String.format("Failed to get producer to send message %s to queue %s",
-					xmlMessage.getMessageId(), errorQueueName);
-			logger.warn(msg, e);
-			throw new MessagingException(msg, e);
+			MessagingException wrappedException = new MessagingException(
+					String.format("Failed to get producer to send message %s to queue %s", xmlMessage.getMessageId(),
+							errorQueueName), e);
+			LOGGER.warn(wrappedException.getMessage(), e);
+			throw wrappedException;
 		}
 
 		producer.send(xmlMessage, queue);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKey.java
@@ -1,7 +1,7 @@
 package com.solace.spring.cloud.stream.binder.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ErrorQueueRepublishCorrelationKey {
 	private final ErrorQueueInfrastructure errorQueueInfrastructure;
@@ -9,7 +9,7 @@ public class ErrorQueueRepublishCorrelationKey {
 	private final FlowReceiverContainer flowReceiverContainer;
 	private long errorQueueDeliveryAttempt = 0;
 
-	private static final Log logger = LogFactory.getLog(ErrorQueueRepublishCorrelationKey.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ErrorQueueRepublishCorrelationKey.class);
 
 	public ErrorQueueRepublishCorrelationKey(ErrorQueueInfrastructure errorQueueInfrastructure,
 											 MessageContainer messageContainer,
@@ -36,26 +36,26 @@ public class ErrorQueueRepublishCorrelationKey {
 				break;
 			} else {
 				errorQueueDeliveryAttempt++;
-				logger.info(String.format("Republishing XMLMessage %s to error queue %s - attempt %s of %s",
-						messageContainer.getMessage().getMessageId(), errorQueueInfrastructure.getErrorQueueName(),
-						errorQueueDeliveryAttempt, errorQueueInfrastructure.getMaxDeliveryAttempts()));
+				LOGGER.info("Republishing XMLMessage {} to error queue {} - attempt {} of {}",
+						messageContainer.getMessage().getMessageId(),
+						errorQueueInfrastructure.getErrorQueueName(),
+						errorQueueDeliveryAttempt,
+						errorQueueInfrastructure.getMaxDeliveryAttempts());
 				try {
 					errorQueueInfrastructure.send(messageContainer, this);
 					break;
 				} catch (Exception e) {
-					logger.warn(String.format("Could not send XMLMessage %s to error queue %s",
-							messageContainer.getMessage().getMessageId(),
-							errorQueueInfrastructure.getErrorQueueName()));
+					LOGGER.warn("Could not send XMLMessage {} to error queue {}",
+							messageContainer.getMessage().getMessageId(), errorQueueInfrastructure.getErrorQueueName());
 				}
 			}
 		}
 	}
 
 	private void fallback() {
-			logger.info(String.format(
-					"Exceeded max error queue delivery attempts. XMLMessage %s will be re-queued onto queue %s",
-					messageContainer.getMessage().getMessageId(), flowReceiverContainer.getEndpointName()));
-			flowReceiverContainer.requeue(messageContainer);
+		LOGGER.info("Exceeded max error queue delivery attempts. XMLMessage {} will be re-queued onto queue {}",
+				messageContainer.getMessage().getMessageId(), flowReceiverContainer.getEndpointName());
+		flowReceiverContainer.requeue(messageContainer);
 	}
 
 	public String getSourceMessageId() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SharedResourceManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SharedResourceManager.java
@@ -1,7 +1,7 @@
 package com.solace.spring.cloud.stream.binder.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -12,7 +12,7 @@ abstract class SharedResourceManager<T> {
 	private Set<String> registeredIds = new HashSet<>();
 	private final Object lock = new Object();
 
-	private static final Log logger = LogFactory.getLog(SharedResourceManager.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SharedResourceManager.class);
 
 	SharedResourceManager(String type) {
 		this.type = type;
@@ -31,10 +31,10 @@ abstract class SharedResourceManager<T> {
 	public T get(String key) throws Exception {
 		synchronized (lock) {
 			if (registeredIds.isEmpty()) {
-				logger.info(String.format("No %s exists, a new one will be created", type));
+				LOGGER.info("No {} exists, a new one will be created", type);
 				sharedResource = create();
-			} else if (logger.isTraceEnabled()) {
-				logger.trace(String.format("A message %s already exists, reusing it", type));
+			} else {
+				LOGGER.trace("A message {} already exists, reusing it", type);
 			}
 
 			registeredIds.add(key);
@@ -53,11 +53,11 @@ abstract class SharedResourceManager<T> {
 			if (!registeredIds.contains(key)) return;
 
 			if (registeredIds.size() <= 1) {
-				logger.info(String.format("%s is the last user, closing %s...", key, type));
+				LOGGER.info("{} is the last user, closing {}...", key, type);
 				close();
 				sharedResource = null;
 			} else {
-				logger.info(String.format("%s is not the last user, persisting %s...", key, type));
+				LOGGER.info("{} is not the last user, persisting {}...", key, type);
 			}
 			registeredIds.remove(key);
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceFlowEventHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceFlowEventHandler.java
@@ -3,12 +3,12 @@ package com.solace.spring.cloud.stream.binder.util;
 import com.solacesystems.jcsmp.FlowEvent;
 import com.solacesystems.jcsmp.FlowEventArgs;
 import com.solacesystems.jcsmp.FlowEventHandler;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SolaceFlowEventHandler implements FlowEventHandler {
 
-	private static final Log logger = LogFactory.getLog(SolaceFlowEventHandler.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceFlowEventHandler.class);
 	private final XMLMessageMapper xmlMessageMapper;
 	private final String flowReceiverContainerId;
 
@@ -19,15 +19,11 @@ public class SolaceFlowEventHandler implements FlowEventHandler {
 
 	@Override
 	public void handleEvent(Object source, FlowEventArgs flowEventArgs) {
-		if (logger.isDebugEnabled()) {
-			logger.debug(String.format("(%s): Received Solace Flow event [%s].", source, flowEventArgs));
-		}
+		LOGGER.debug("({}): Received Solace Flow event [{}].", source, flowEventArgs);
 
 		if (flowEventArgs.getEvent() == FlowEvent.FLOW_RECONNECTED && xmlMessageMapper != null) {
-			if (logger.isDebugEnabled()) {
-				logger.debug(String.format("Received flow event %s for flow receiver container %s. Will clear ignored properties.",
-						flowEventArgs.getEvent().name(), flowReceiverContainerId));
-			}
+			LOGGER.debug("Received flow event {} for flow receiver container {}. Will clear ignored properties.",
+					flowEventArgs.getEvent().name(), flowReceiverContainerId);
 			xmlMessageMapper.resetIgnoredProperties(flowReceiverContainerId);
 		}
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/acknowledge/JCSMPAcknowledgementCallbackFactoryIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/acknowledge/JCSMPAcknowledgementCallbackFactoryIT.java
@@ -32,8 +32,6 @@ import com.solacesystems.jcsmp.XMLMessageProducer;
 import com.solacesystems.jcsmp.transaction.RollbackException;
 import com.solacesystems.jcsmp.transaction.TransactedSession;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.function.ThrowingRunnable;
 import org.junit.jupiter.api.AfterEach;
@@ -46,6 +44,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.lang.Nullable;
@@ -90,7 +90,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 	private String vpnName;
 	private Runnable closeErrorQueueInfrastructureCallback;
 
-	private static final Log logger = LogFactory.getLog(JCSMPAcknowledgementCallbackFactoryIT.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JCSMPAcknowledgementCallbackFactoryIT.class);
 
 	@BeforeEach
 	public void setup(JCSMPSession jcsmpSession) throws Exception {
@@ -117,7 +117,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 						   Queue durableQueue,
 						   SempV2Api sempV2Api) throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -149,7 +149,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 						   SempV2Api sempV2Api)
 			throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -180,7 +180,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 							   Queue queue,
 							   SempV2Api sempV2Api) throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -191,7 +191,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 		AcknowledgmentCallback acknowledgmentCallback = createAcknowledgmentCallback(acknowledgementCallbackFactory,
 				messageContainers, flowReceiverContainer.getTransactedSession());
 
-		logger.info(String.format("Disabling egress for queue %s", queue.getName()));
+		LOGGER.info("Disabling egress for queue {}", queue.getName());
 		sempV2Api.config().updateMsgVpnQueue((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
 				queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false), null, null);
 		retryAssert(() -> assertFalse(sempV2Api.monitor()
@@ -199,7 +199,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.getData()
 				.isEgressEnabled()));
 
-		logger.info("Acknowledging messages");
+		LOGGER.info("Acknowledging messages");
 		acknowledgmentCallback.acknowledge(AcknowledgmentCallback.Status.REJECT);
 		assertThat(acknowledgmentCallback.isAcknowledged()).isTrue();
 
@@ -212,7 +212,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.getBindRequestCount())
 				.isGreaterThan(1);
 
-		logger.info(String.format("Enabling egress for queue %s", queue.getName()));
+		LOGGER.info("Enabling egress for queue {}", queue.getName());
 		sempV2Api.config().updateMsgVpnQueue((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
 				queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true), null, null);
 		retryAssert(() -> assertTrue(sempV2Api.monitor()
@@ -221,7 +221,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.isEgressEnabled()));
 
 		// Message was redelivered
-		logger.info("Verifying message was redelivered");
+		LOGGER.info("Verifying message was redelivered");
 		validateNumRedeliveredMessages(sempV2Api, queue.getName(), numMessages);
 		validateQueueBindSuccesses(sempV2Api, queue.getName(), 2);
 		validateNumEnqueuedMessages(sempV2Api, queue.getName(), numMessages);
@@ -274,8 +274,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 		AcknowledgmentCallback acknowledgmentCallback = createAcknowledgmentCallback(acknowledgementCallbackFactory,
 				messageContainers, flowReceiverContainer.getTransactedSession());
 
-		logger.info(String.format("Disabling ingress for error queue %s",
-				errorQueueInfrastructure.getErrorQueueName()));
+		LOGGER.info("Disabling ingress for error queue {}", errorQueueInfrastructure.getErrorQueueName());
 		sempV2Api.config().updateMsgVpnQueue((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
 				errorQueueInfrastructure.getErrorQueueName(), new ConfigMsgVpnQueue().ingressEnabled(false), null, null);
 		retryAssert(() -> assertFalse(sempV2Api.monitor()
@@ -283,7 +282,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.getData()
 				.isIngressEnabled()));
 
-		logger.info("Acknowledging messages");
+		LOGGER.info("Acknowledging messages");
 		acknowledgmentCallback.acknowledge(AcknowledgmentCallback.Status.REJECT);
 		assertThat(acknowledgmentCallback.isAcknowledged()).isTrue();
 
@@ -304,7 +303,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 							Queue durableQueue,
 							SempV2Api sempV2Api) throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -335,7 +334,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 								Queue queue,
 								SempV2Api sempV2Api) throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -347,7 +346,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 		AcknowledgmentCallback acknowledgmentCallback = createAcknowledgmentCallback(acknowledgementCallbackFactory,
 				messageContainers, flowReceiverContainer.getTransactedSession());
 
-		logger.info(String.format("Disabling egress for queue %s", queue.getName()));
+		LOGGER.info("Disabling egress for queue {}", queue.getName());
 		sempV2Api.config().updateMsgVpnQueue((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
 				queue.getName(), new ConfigMsgVpnQueue().egressEnabled(false), null, null);
 		retryAssert(() -> assertFalse(sempV2Api.monitor()
@@ -355,7 +354,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.getData()
 				.isEgressEnabled()));
 
-		logger.info("Acknowledging messages");
+		LOGGER.info("Acknowledging messages");
 		acknowledgmentCallback.acknowledge(AcknowledgmentCallback.Status.REQUEUE);
 		assertThat(acknowledgmentCallback.isAcknowledged()).isTrue();
 
@@ -368,7 +367,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.getBindRequestCount())
 				.isGreaterThan(1);
 
-		logger.info(String.format("Enabling egress for queue %s", queue.getName()));
+		LOGGER.info("Enabling egress for queue {}", queue.getName());
 		sempV2Api.config().updateMsgVpnQueue((String) jcsmpSession.getProperty(JCSMPProperties.VPN_NAME),
 				queue.getName(), new ConfigMsgVpnQueue().egressEnabled(true), null, null);
 		retryAssert(() -> assertTrue(sempV2Api.monitor()
@@ -377,7 +376,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 				.isEgressEnabled()));
 
 		// Message was redelivered
-		logger.info("Verifying message was redelivered");
+		LOGGER.info("Verifying message was redelivered");
 		validateNumRedeliveredMessages(sempV2Api, queue.getName(), numMessages);
 		validateQueueBindSuccesses(sempV2Api, queue.getName(), 2);
 		validateNumEnqueuedMessages(sempV2Api, queue.getName(), numMessages);
@@ -395,7 +394,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 									 Queue durableQueue,
 									 SempV2Api sempV2Api) throws Throwable {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -437,7 +436,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 									 Queue durableQueue,
 									 SempV2Api sempV2Api) throws Throwable {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -515,7 +514,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 									  Queue durableQueue,
 									  SempV2Api sempV2Api) throws Throwable {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -560,7 +559,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 			Queue durableQueue,
 			SempV2Api sempV2Api) throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 
@@ -619,7 +618,7 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 			@Values(booleans = {false, true}) boolean isDurable,
 			JCSMPSession jcsmpSession, Queue durableQueue, SempV2Api sempV2Api) throws Exception {
 		if (numMessages == 1 && transacted) {
-			logger.info("No support yet for non-batched, transacted consumers");
+			LOGGER.info("No support yet for non-batched, transacted consumers");
 			return;
 		}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/messaging/SolaceHeadersTest.java
@@ -7,11 +7,11 @@ import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLMessage;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.MessageHeaders;
 
 import java.lang.reflect.Field;
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class SolaceHeadersTest {
-	private static final Log logger = LogFactory.getLog(SolaceHeadersTest.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceHeadersTest.class);
 
 	@ParameterizedTest
 	@ArgumentsSource(SolaceSpringHeaderArgumentsProvider.ClassesOnly.class)
@@ -136,7 +136,7 @@ public class SolaceHeadersTest {
 	@ArgumentsSource(SolaceSpringHeaderArgumentsProvider.class)
 	public void testMetaReadActions(Class<?> headersClass, Map<String, ? extends HeaderMeta<?>> headersMeta) {
 		if (!(headersClass.equals(SolaceHeaders.class))) {
-			logger.info(String.format("Test does not apply to %s", headersClass.getSimpleName()));
+			LOGGER.info("Test does not apply to {}", headersClass.getSimpleName());
 			return;
 		}
 
@@ -158,7 +158,7 @@ public class SolaceHeadersTest {
 	public void testMetaWriteActions(Class<?> headersClass, Map<String, ? extends HeaderMeta<?>> headersMeta)
 			throws Exception {
 		if (!(headersClass.equals(SolaceHeaders.class))) {
-			logger.info(String.format("Test does not apply to %s", headersClass.getSimpleName()));
+			LOGGER.info("Test does not apply to {}", headersClass.getSimpleName());
 			return;
 		}
 
@@ -189,26 +189,25 @@ public class SolaceHeadersTest {
 				throw new Exception(String.format("Failed to generate test value for %s", headerMeta.getKey()), e);
 			}
 
-			logger.info(String.format("Writing %s: %s", headerMeta.getKey(), value));
+			LOGGER.info("Writing {}: {}", headerMeta.getKey(), value);
 			headerMeta.getValue().getWriteAction().accept(xmlMessage, value);
 
 			if (headerMeta.getValue().isReadable()) {
 				assertEquals(value, headerMeta.getValue().getReadAction().apply(xmlMessage));
 			} else {
-				logger.warn(String.format("No read action for header %s. Cannot validate that write operation worked",
-						headerMeta.getKey()));
+				LOGGER.warn("No read action for header {}. Cannot validate that write operation worked", headerMeta.getKey());
 			}
 		}
 
-		logger.info("Message Dump:\n" + xmlMessage.dump(XMLMessage.MSGDUMP_FULL));
-		logger.info("Message String:\n" + xmlMessage);
+		LOGGER.info("Message Dump:\n{}", xmlMessage.dump(XMLMessage.MSGDUMP_FULL));
+		LOGGER.info("Message String:\n{}", xmlMessage);
 	}
 
 	@ParameterizedTest(name = "[{index}] {0}")
 	@ArgumentsSource(SolaceSpringHeaderArgumentsProvider.class)
 	public void testDefaultValueOverride(Class<?> headersClass, Map<String, ? extends HeaderMeta<?>> headersMeta) {
 		if (!(headersClass.equals(SolaceHeaders.class))) {
-			logger.info(String.format("Test does not apply to %s", headersClass.getSimpleName()));
+			LOGGER.info("Test does not apply to {}", headersClass.getSimpleName());
 			return;
 		}
 
@@ -231,19 +230,19 @@ public class SolaceHeadersTest {
 			}
 
 
-			logger.info(String.format("Writing %s: %s", headerMeta.getKey(), value));
+			LOGGER.info("Writing {}: {}", headerMeta.getKey(), value);
 			headerMeta.getValue().getWriteAction().accept(xmlMessage, value);
 
 			if (headerMeta.getValue().isReadable()) {
 				assertEquals(value, headerMeta.getValue().getReadAction().apply(xmlMessage));
 			} else {
-				logger.warn(String.format("No read action for header %s. Cannot validate that write operation worked",
-						headerMeta.getKey()));
+				LOGGER.warn("No read action for header {}. Cannot validate that write operation worked",
+						headerMeta.getKey());
 			}
 		}
 
-		logger.info("Message Dump:\n" + xmlMessage.dump(XMLMessage.MSGDUMP_FULL));
-		logger.info("Message String:\n" + xmlMessage);
+		LOGGER.info("Message Dump:\n{}", xmlMessage.dump(XMLMessage.MSGDUMP_FULL));
+		LOGGER.info("Message String:\n{}", xmlMessage);
 	}
 
 	@ParameterizedTest(name = "[{index}] {0}")
@@ -251,7 +250,7 @@ public class SolaceHeadersTest {
 	public void testFailMetaWriteActionsWithInvalidType(Class<?> headersClass,
 														Map<String, ? extends HeaderMeta<?>> headersMeta) {
 		if (!(headersClass.equals(SolaceHeaders.class))) {
-			logger.info(String.format("Test does not apply to %s", headersClass.getSimpleName()));
+			LOGGER.info("Test does not apply to {}", headersClass.getSimpleName());
 			return;
 		}
 
@@ -335,7 +334,7 @@ public class SolaceHeadersTest {
 
 	private String camelCaseToSnakeCase(String camelCase) {
 		Matcher camelCaseMatcher = Pattern.compile("(?<=[a-z])[A-Z]").matcher(camelCase);
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		while (camelCaseMatcher.find()) {
 			camelCaseMatcher.appendReplacement(buffer, "_" + camelCaseMatcher.group().toLowerCase());
 		}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/test/junit/extension/pubsubplus/provider/PubSubPlusSpringProvider.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/test/junit/extension/pubsubplus/provider/PubSubPlusSpringProvider.java
@@ -24,19 +24,15 @@ public class PubSubPlusSpringProvider implements PubSubPlusExtension.ExternalPro
 		try {
 			applicationContext.getBean(JCSMPProperties.class);
 		} catch (NoSuchBeanDefinitionException e) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Didn't find required bean: " + JCSMPProperties.class, e);
-			}
+			LOGGER.trace("Didn't find required bean: {}", JCSMPProperties.class, e);
 			return false;
 		}
 
 		if (!Stream.of(TestProperties.values()).map(TestProperties::getProperty)
 				.allMatch(contextEnvironment::containsProperty)) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Didn't find required test properties: [{}]", Stream.of(TestProperties.values())
-						.map(TestProperties::getProperty)
-						.collect(Collectors.joining(", ")));
-			}
+			LOGGER.trace("Didn't find required test properties: [{}]", Stream.of(TestProperties.values())
+					.map(TestProperties::getProperty)
+					.collect(Collectors.joining(", ")));
 			return false;
 		}
 		return true;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -27,8 +27,6 @@ import com.solacesystems.jcsmp.XMLContentMessage;
 import com.solacesystems.jcsmp.XMLMessage;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.MapAssert;
@@ -49,6 +47,8 @@ import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
@@ -111,7 +111,7 @@ public class XMLMessageMapperTest {
 	@Spy
 	private final XMLMessageMapper xmlMessageMapper = new XMLMessageMapper();
 
-	private static final Log logger = LogFactory.getLog(XMLMessageMapperTest.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(XMLMessageMapperTest.class);
 	private static final Set<String> JMS_INVALID_HEADER_NAMES = new HashSet<>(Arrays.asList("~ab;c", "NULL",
 			"TRUE", "FALSE", "NOT", "AND", "OR", "BETWEEN", "LIKE", "IN", "IS", "ESCAPE", "JMSX_abc", "JMS_abc"));
 
@@ -1681,12 +1681,12 @@ public class XMLMessageMapperTest {
 		XMLMessage xmlMessage;
 		int i = 0;
 		do {
-			logger.info(String.format("Iteration %s - Message<?> to XMLMessage:\n%s", i, springMessage));
+			LOGGER.info("Iteration {} - Message<?> to XMLMessage:\n{}", i, springMessage);
 			xmlMessage = xmlMessageMapper.map(springMessage, null, false);
 			validateXMLProperties(xmlMessage, expectedSpringMessage.getPayload(), expectedSpringMessage.getHeaders(),
 					springHeaders);
 
-			logger.info(String.format("Iteration %s - XMLMessage to Message<?>:\n%s", i, xmlMessage));
+			LOGGER.info("Iteration {} - XMLMessage to Message<?>:\n{}", i, xmlMessage);
 			AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 			springMessage = xmlMessageMapper.map(xmlMessage, acknowledgmentCallback, consumerProperties);
 			validateSpringHeaders(springMessage.getHeaders(), expectedXmlMessage);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceHealthIndicatorsConfiguration.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceHealthIndicatorsConfiguration.java
@@ -9,8 +9,8 @@ import com.solace.spring.cloud.stream.binder.properties.SolaceSessionHealthPrope
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.SolaceSessionOAuth2TokenProvider;
 import jakarta.annotation.Nullable;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnEnabledHealthIndicator("binders")
 @EnableConfigurationProperties({SolaceSessionHealthProperties.class})
 public class SolaceHealthIndicatorsConfiguration {
-	private static final Log logger = LogFactory.getLog(SolaceHealthIndicatorsConfiguration.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceHealthIndicatorsConfiguration.class);
 
 	@Bean
 	public SolaceBinderHealthAccessor solaceBinderHealthAccessor(
@@ -33,9 +33,7 @@ public class SolaceHealthIndicatorsConfiguration {
 	@Bean
 	public SolaceBinderHealthContributor solaceBinderHealthContributor(
 			SolaceSessionHealthProperties solaceSessionHealthProperties) {
-		if (logger.isDebugEnabled()) {
-			logger.debug("Creating Solace Connection Health Indicators Hierarchy");
-		}
+		LOGGER.debug("Creating Solace Connection Health Indicators Hierarchy");
 		return new SolaceBinderHealthContributor(
 				new SessionHealthIndicator(solaceSessionHealthProperties),
 				new BindingsHealthContributor()
@@ -47,9 +45,7 @@ public class SolaceHealthIndicatorsConfiguration {
 			JCSMPProperties jcsmpProperties,
 			@Nullable  SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider,
 			SolaceBinderHealthContributor healthContributor) {
-		if (logger.isDebugEnabled()) {
-			logger.debug("Creating Solace Session Event Handler for monitoring Health");
-		}
+		LOGGER.debug("Creating Solace Session Event Handler for monitoring Health");
 		return new SolaceSessionEventHandler(jcsmpProperties, solaceSessionOAuth2TokenProvider, healthContributor.getSolaceSessionHealthIndicator());
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
@@ -15,8 +15,8 @@ import com.solacesystems.jcsmp.SolaceSessionOAuth2TokenProvider;
 import com.solacesystems.jcsmp.SpringJCSMPFactory;
 import com.solacesystems.jcsmp.impl.JCSMPBasicSession;
 import jakarta.annotation.PostConstruct;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -42,14 +42,14 @@ public class SolaceMessageChannelBinderConfiguration {
 	private Context context;
 
 	@Nullable
-	private SolaceSessionOAuth2TokenProvider	solaceSessionOAuth2TokenProvider;
+	private final SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider;
 
-	private static final Log logger = LogFactory.getLog(SolaceMessageChannelBinderConfiguration.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceMessageChannelBinderConfiguration.class);
 
 	public SolaceMessageChannelBinderConfiguration(JCSMPProperties jcsmpProperties,
 	                                               SolaceExtendedBindingProperties solaceExtendedBindingProperties,
 	                                               @Nullable SolaceSessionEventHandler eventHandler,
-			 																					 @Nullable SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider) {
+												   @Nullable SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider) {
 		this.jcsmpProperties = jcsmpProperties;
 		this.solaceExtendedBindingProperties = solaceExtendedBindingProperties;
 		this.solaceSessionEventHandler = eventHandler;
@@ -62,9 +62,7 @@ public class SolaceMessageChannelBinderConfiguration {
 		solaceJcsmpProperties.setProperty(JCSMPProperties.CLIENT_INFO_PROVIDER, new SolaceBinderClientInfoProvider());
 		try {
 			if (solaceSessionEventHandler != null) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Registering Solace Session Event handler on session");
-				}
+				LOGGER.debug("Registering Solace Session Event handler on session");
 
 				SpringJCSMPFactory springJCSMPFactory = new SpringJCSMPFactory(solaceJcsmpProperties, solaceSessionOAuth2TokenProvider);
 				context = springJCSMPFactory.createContext(new ContextProperties());
@@ -73,7 +71,7 @@ public class SolaceMessageChannelBinderConfiguration {
 				SpringJCSMPFactory springJCSMPFactory = new SpringJCSMPFactory(solaceJcsmpProperties, solaceSessionOAuth2TokenProvider);
 				jcsmpSession = springJCSMPFactory.createSession();
 			}
-			logger.info(String.format("Connecting JCSMP session %s", jcsmpSession.getSessionName()));
+			LOGGER.info("Connecting JCSMP session {}", jcsmpSession.getSessionName());
 			jcsmpSession.connect();
 			if (solaceSessionEventHandler != null) {
 				// after setting the session health indicator status to UP,
@@ -85,7 +83,7 @@ public class SolaceMessageChannelBinderConfiguration {
 
 			if (jcsmpSession instanceof JCSMPBasicSession session &&
 					!session.isRequiredSettlementCapable(Set.of(ACCEPTED,FAILED,REJECTED))) {
-				logger.warn("The connected Solace PubSub+ Broker is not compatible. It doesn't support message NACK capability. Consumer bindings will fail to start.");
+				LOGGER.warn("The connected Solace PubSub+ Broker is not compatible. It doesn't support message NACK capability. Consumer bindings will fail to start.");
 			}
 		} catch (Exception e) {
 			if (context != null) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/junit/extension/pubsubplus/provider/PubSubPlusSpringProvider.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/junit/extension/pubsubplus/provider/PubSubPlusSpringProvider.java
@@ -24,19 +24,15 @@ public class PubSubPlusSpringProvider implements PubSubPlusExtension.ExternalPro
 		try {
 			applicationContext.getBean(JCSMPProperties.class);
 		} catch (NoSuchBeanDefinitionException e) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Didn't find required bean: " + JCSMPProperties.class, e);
-			}
+			LOGGER.trace("Didn't find required bean: {}", JCSMPProperties.class, e);
 			return false;
 		}
 
 		if (!Stream.of(TestProperties.values()).map(TestProperties::getProperty)
 				.allMatch(contextEnvironment::containsProperty)) {
-			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Didn't find required test properties: [{}]", Stream.of(TestProperties.values())
-						.map(TestProperties::getProperty)
-						.collect(Collectors.joining(", ")));
-			}
+			LOGGER.trace("Didn't find required test properties: [{}]", Stream.of(TestProperties.values())
+					.map(TestProperties::getProperty)
+					.collect(Collectors.joining(", ")));
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Use SLF4J instead of Apache Commons Logging.

Although the Spring team themselves uses `LogAccessor` (a wrapper around Apache Commons Logging) throughout the Spring codebase, we should be fine to use SLF4J since the [Spring Logging starters](https://docs.spring.io/spring-boot/how-to/logging.html) allcome with the `slfj4j-api` dependency out-of-the-box:

* `spring-boot-starter-logging`
* `spring-boot-starter-log4j2`