### PR TITLE
DATAGO-68275: fix SolaceErrorMessageHandler acknowledgmentCallback detection and error handling

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandler.java
@@ -31,14 +31,12 @@ public class SolaceErrorMessageHandler implements MessageHandler {
 					springId, ErrorMessage.class.getSimpleName(), message.getClass().getSimpleName()));
 		}
 
-		Throwable payload = errorMessage.getPayload();
-
 		Set<AcknowledgmentCallback> acknowledgmentCallbacks = new HashSet<>();
 
 		Optional.ofNullable(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message))
 				.ifPresent(acknowledgmentCallbacks::add);
 
-		if (payload instanceof MessagingException messagingException) {
+		if (errorMessage.getPayload() instanceof MessagingException messagingException) {
 			Optional.ofNullable(messagingException.getFailedMessage())
 					.map(m -> {
 						info.append("messaging-exception-message: ").append(StaticMessageHeaderAccessor.getId(m)).append(", ");

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandler.java
@@ -34,6 +34,10 @@ public class SolaceErrorMessageHandler implements MessageHandler {
 		Throwable payload = errorMessage.getPayload();
 
 		Set<AcknowledgmentCallback> acknowledgmentCallbacks = new HashSet<>();
+
+		Optional.ofNullable(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message))
+				.ifPresent(acknowledgmentCallbacks::add);
+
 		if (payload instanceof MessagingException messagingException) {
 			Optional.ofNullable(messagingException.getFailedMessage())
 					.map(m -> {
@@ -50,9 +54,6 @@ public class SolaceErrorMessageHandler implements MessageHandler {
 					return m;
 				})
 				.map(StaticMessageHeaderAccessor::getAcknowledgmentCallback)
-				.ifPresent(acknowledgmentCallbacks::add);
-
-		Optional.ofNullable(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message))
 				.ifPresent(acknowledgmentCallbacks::add);
 
 		if (StaticMessageHeaderAccessor.getSourceData(message) instanceof XMLMessage xmlMessage) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandlerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/SolaceErrorMessageHandlerTest.java
@@ -1,17 +1,17 @@
 package com.solace.spring.cloud.stream.binder.util;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.TextMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
-import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.acks.AcknowledgmentCallback.Status;
 import org.springframework.integration.support.ErrorMessageUtils;
@@ -19,6 +19,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class SolaceErrorMessageHandlerTest {
@@ -30,6 +33,13 @@ public class SolaceErrorMessageHandlerTest {
 	public void setup() {
 		errorMessageHandler = new SolaceErrorMessageHandler();
 		attributeAccessor = ErrorMessageUtils.getAttributeAccessor(null, null);
+	}
+
+	@Test
+	public void testNotAnErrorMessage() {
+		assertThatThrownBy(() -> errorMessageHandler.handleMessage(MessageBuilder.withPayload("test").build()))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Expected an ErrorMessage");
 	}
 
 	@Test
@@ -49,8 +59,6 @@ public class SolaceErrorMessageHandlerTest {
 
 		errorMessageHandler.handleMessage(errorMessage);
 		Mockito.verify(acknowledgementCallback).acknowledge(Status.REQUEUE);
-		Mockito.verify(StaticMessageHeaderAccessor.getAcknowledgmentCallback(inputMessage), Mockito.never())
-				.acknowledge(Mockito.any());
 	}
 
 	@Test
@@ -68,13 +76,14 @@ public class SolaceErrorMessageHandlerTest {
 	}
 
 	@Test
-	public void testNoFailedMessage(@Mock AcknowledgmentCallback acknowledgementCallback) {
+	public void testNoFailedMessage() {
 		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
 				new MessagingException("test"),
 				attributeAccessor);
 
-		errorMessageHandler.handleMessage(errorMessage);
-		Mockito.verify(acknowledgementCallback, Mockito.never()).acknowledge(AcknowledgmentCallback.Status.REJECT);
+		assertThatThrownBy(() -> errorMessageHandler.handleMessage(errorMessage))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("does not contain an acknowledgment callback");
 	}
 
 	@Test
@@ -91,21 +100,44 @@ public class SolaceErrorMessageHandlerTest {
 		Mockito.verify(acknowledgementCallback).acknowledge(Status.REQUEUE);
 	}
 
-	@Test
+	@CartesianTest(name = "[{index}] ackCallbackHeaderProvider={0}")
 	public void testMessagingExceptionContainingDifferentFailedMessage(
-			@Mock AcknowledgmentCallback acknowledgementCallback) {
-		Message<?> inputMessage = MessageBuilder.withPayload("test")
-				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback)
+			@Values(strings = {"messaging-exception", "input-message", "error-message", "all:same", "all:different"})
+			String ackCallbackHeaderProvider,
+			@Mock AcknowledgmentCallback acknowledgementCallback1,
+			@Mock AcknowledgmentCallback acknowledgementCallback2,
+			@Mock AcknowledgmentCallback acknowledgementCallback3) {
+		Message<?> messageWithAckCallback = MessageBuilder.withPayload("with-callback-1")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback1)
 				.build();
-		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY,
-				MessageBuilder.withPayload("some-other-message").build());
+		Message<String> messageNoAckCallback = MessageBuilder.withPayload("some-other-message").build();
 
-		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(
-				new MessagingException(inputMessage),
-				attributeAccessor);
+		MessagingException exception = switch (ackCallbackHeaderProvider) {
+			case "messaging-exception", "all:same", "all:different" -> new MessagingException(messageWithAckCallback);
+			default -> new MessagingException(messageNoAckCallback);
+		};
+
+		attributeAccessor.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, switch (ackCallbackHeaderProvider) {
+			case "input-message", "all:same" -> messageWithAckCallback;
+			case "all:different" -> MessageBuilder.withPayload("with-callback-1")
+					.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgementCallback2)
+					.build();
+			default -> messageNoAckCallback;
+		});
+
+		if (ackCallbackHeaderProvider.equals("error-message") || ackCallbackHeaderProvider.startsWith("all:")) {
+			attributeAccessor.setAttribute(SolaceMessageHeaderErrorMessageStrategy.ATTR_SOLACE_ACKNOWLEDGMENT_CALLBACK,
+					ackCallbackHeaderProvider.equals("all:different") ? acknowledgementCallback3 : acknowledgementCallback1);
+		}
+
+		ErrorMessage errorMessage = errorMessageStrategy.buildErrorMessage(exception, attributeAccessor);
 
 		errorMessageHandler.handleMessage(errorMessage);
-		Mockito.verify(acknowledgementCallback).acknowledge(Status.REQUEUE);
+		Mockito.verify(acknowledgementCallback1).acknowledge(Status.REQUEUE);
+		Mockito.verify(acknowledgementCallback2, Mockito.times(ackCallbackHeaderProvider.equals("all:different") ? 1 : 0))
+				.acknowledge(Status.REQUEUE);
+		Mockito.verify(acknowledgementCallback3, Mockito.times(ackCallbackHeaderProvider.equals("all:different") ? 1 : 0))
+				.acknowledge(Status.REQUEUE);
 	}
 
 	@Test


### PR DESCRIPTION
This prevents an edge case of messages being stuck in an unacknowledged state when a `MessagingException` is thrown which contains a `failedMessage` that doesn't have its `acknowledgmentCallback` header set.

e.g.:
```java
@Bean
public Consumer<Message<?>> sink(){
    return msg -> throw new MessagingException(MessageBuilder.fromMessage(msg)
			.removeHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK)
			.build());
}
```

# Issue 1: Detection of AcknowledgmentCallback

Currently, this binder's error message handler detects the message's `acknowledgmentCallback` in the following order of precedence, where upon first discovery, the other potential sources for this callback are not searched:

1. From the `errorMessage`'s header.
    * Injected here by this binder's consumer binding if an exception was thrown during conversion of the SMF message to the Spring `Message<?>`.
2. If the thrown exception is a `MessagingException` that has a `failedMessage` set, then get it from that `failedMessage`.
    * what is causing the above issue.
3. the original message.
    * The original Spring `Message<?>` created by this binder's consumer binding.

## Fix: Detect and handle ack callback from all sources

Detect and handle `acknowledgmentCallback` from all potential sources.

**NOTE:** Ideally, we should just ignore source 2 (`failedMessage` message set on the `MessagingException`), but I wasn't sure if this would cause backwards incompatibility. @mgevantmakher @carolmorneau , if you think that this isn't a use case and I'm worrying for nothing, then I can just remove that source entirely...

# Issue 2: When the error message handler needs to fail

Currently, the error message handler just returns when it isn't able to process an error. This is faulty, since Spring will treat the errored message as "successfully handled", and returns control back to the binder as-if the message was processed successfully.

This results in the message getting acknowledged, and is the other contributor to the above issue.

## Fix: Error handler should throw an exception when it isn't able to ack the message

Just throwing an exception instead of returning...

