### PR TITLE
DATAGO-84854: Use ProducerFlowProperties constructor that supports full session pass-through

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/pom.xml
@@ -73,7 +73,7 @@
 
         <dependency>
             <groupId>com.solacesystems</groupId>
-            <artifactId>sol-jms</artifactId>
+            <artifactId>sol-jms-jakarta</artifactId>
             <version>${solace.jms.version}</version>
             <scope>test</scope>
         </dependency>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandler.java
@@ -16,6 +16,7 @@ import com.solace.spring.cloud.stream.binder.util.XMLMessageMapper;
 import com.solacesystems.jcsmp.Destination;
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.Topic;
@@ -48,6 +49,7 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
 	private final DestinationType configDestinationType;
 	private final Destination configDestination;
 	private final JCSMPSession jcsmpSession;
+	private final JCSMPProperties jcsmpProperties;
 	private final MessageChannel errorChannel;
 	private final JCSMPSessionProducerManager producerManager;
 	private final ExtendedProducerProperties<SolaceProducerProperties> properties;
@@ -63,6 +65,7 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
 
 	public JCSMPOutboundMessageHandler(ProducerDestination destination,
 									   JCSMPSession jcsmpSession,
+									   JCSMPProperties jcsmpProperties,
 									   MessageChannel errorChannel,
 									   JCSMPSessionProducerManager producerManager,
 									   ExtendedProducerProperties<SolaceProducerProperties> properties,
@@ -72,6 +75,7 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
 				JCSMPFactory.onlyInstance().createTopic(destination.getName()) :
 				JCSMPFactory.onlyInstance().createQueue(destination.getName());
 		this.jcsmpSession = jcsmpSession;
+		this.jcsmpProperties = jcsmpProperties;
 		this.errorChannel = errorChannel;
 		this.producerManager = producerManager;
 		this.properties = properties;
@@ -239,10 +243,10 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
 			if (properties.getExtension().isTransacted()) {
 				LOGGER.info("Creating transacted session  <message handler ID: {}>", id);
 				transactedSession = jcsmpSession.createTransactedSession();
-				producer = transactedSession.createProducer(SolaceProvisioningUtil.getProducerFlowProperties(jcsmpSession),
+				producer = transactedSession.createProducer(SolaceProvisioningUtil.getProducerFlowProperties(jcsmpProperties),
 						producerEventHandler);
 			} else {
-				producer = jcsmpSession.createProducer(SolaceProvisioningUtil.getProducerFlowProperties(jcsmpSession),
+				producer = jcsmpSession.createProducer(SolaceProvisioningUtil.getProducerFlowProperties(jcsmpProperties),
 						producerEventHandler);
 			}
 		} catch (Exception e) {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/provisioning/SolaceProvisioningUtil.java
@@ -8,7 +8,6 @@ import com.solacesystems.jcsmp.ConsumerFlowProperties;
 import com.solacesystems.jcsmp.EndpointProperties;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
-import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.ProducerFlowProperties;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
@@ -51,22 +50,8 @@ public class SolaceProvisioningUtil {
 		return endpointProperties;
 	}
 
-	public static ProducerFlowProperties getProducerFlowProperties(JCSMPSession jcsmpSession) {
-		ProducerFlowProperties producerFlowProperties = new ProducerFlowProperties();
-
-		// SOL-118898:
-		// PUB_ACK_WINDOW_SIZE & ACK_EVENT_MODE aren't automatically used as default values for
-		// ProducerFlowProperties.
-		Integer pubAckWindowSize = (Integer) jcsmpSession.getProperty(JCSMPProperties.PUB_ACK_WINDOW_SIZE);
-		if (pubAckWindowSize != null) {
-			producerFlowProperties.setWindowSize(pubAckWindowSize);
-		}
-		String ackEventMode = (String) jcsmpSession.getProperty(JCSMPProperties.ACK_EVENT_MODE);
-		if (ackEventMode != null) {
-			producerFlowProperties.setAckEventMode(ackEventMode);
-		}
-
-		return producerFlowProperties;
+	public static ProducerFlowProperties getProducerFlowProperties(JCSMPProperties jcsmpProperties) {
+		return new ProducerFlowProperties(jcsmpProperties);
 	}
 
 	public static ConsumerFlowProperties getConsumerFlowProperties(

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
@@ -69,6 +69,7 @@ public class JCSMPOutboundMessageHandlerTest {
 	private ArgumentCaptor<ProducerFlowProperties> producerFlowPropertiesCaptor;
 	private ExtendedProducerProperties<SolaceProducerProperties> producerProperties;
 	private JCSMPSessionProducerManager sessionProducerManager;
+	@Mock private JCSMPProperties jcsmpProperties;
 	@Mock private JCSMPSession session;
 	@Mock private TransactedSession transactedSession;
 	@Mock private XMLMessageProducer messageProducer;
@@ -105,6 +106,7 @@ public class JCSMPOutboundMessageHandlerTest {
 		messageHandler = new JCSMPOutboundMessageHandler(
 				dest,
 				session,
+				jcsmpProperties,
 				errChannel,
 				sessionProducerManager,
 				producerProperties,
@@ -500,6 +502,7 @@ public class JCSMPOutboundMessageHandlerTest {
 		messageHandler = new JCSMPOutboundMessageHandler(
 				dest,
 				session,
+				jcsmpProperties,
 				null,
 				new JCSMPSessionProducerManager(session),
 				new ExtendedProducerProperties<>(producerProperties),

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -43,11 +43,6 @@ import org.springframework.messaging.Message;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.SerializationUtils;
 
-import javax.jms.Connection;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.ObjectMessage;
-import javax.jms.Session;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Enumeration;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/SolaceMessageChannelBinder.java
@@ -19,6 +19,7 @@ import com.solace.spring.cloud.stream.binder.util.SolaceMessageHeaderErrorMessag
 import com.solacesystems.jcsmp.Context;
 import com.solacesystems.jcsmp.Endpoint;
 import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.XMLMessage;
@@ -52,6 +53,7 @@ public class SolaceMessageChannelBinder
 				DisposableBean {
 
 	private final JCSMPSession jcsmpSession;
+	private final JCSMPProperties jcsmpProperties;
 	private final Context jcsmpContext;
 	private final JCSMPSessionProducerManager sessionProducerManager;
 	private final AtomicBoolean consumersRemoteStopFlag = new AtomicBoolean(false);
@@ -61,12 +63,13 @@ public class SolaceMessageChannelBinder
 	private static final SolaceMessageHeaderErrorMessageStrategy errorMessageStrategy = new SolaceMessageHeaderErrorMessageStrategy();
 	@Nullable private SolaceBinderHealthAccessor solaceBinderHealthAccessor;
 
-	public SolaceMessageChannelBinder(JCSMPSession jcsmpSession, SolaceEndpointProvisioner solaceEndpointProvisioner) {
-		this(jcsmpSession, null, solaceEndpointProvisioner);
+	public SolaceMessageChannelBinder(JCSMPSession jcsmpSession, JCSMPProperties jcsmpProperties, SolaceEndpointProvisioner solaceEndpointProvisioner) {
+		this(jcsmpSession, jcsmpProperties, null, solaceEndpointProvisioner);
 	}
-	public SolaceMessageChannelBinder(JCSMPSession jcsmpSession, Context jcsmpContext, SolaceEndpointProvisioner solaceEndpointProvisioner) {
+	public SolaceMessageChannelBinder(JCSMPSession jcsmpSession, JCSMPProperties jcsmpProperties, Context jcsmpContext, SolaceEndpointProvisioner solaceEndpointProvisioner) {
 		super(new String[0], solaceEndpointProvisioner);
 		this.jcsmpSession = jcsmpSession;
+		this.jcsmpProperties = jcsmpProperties;
 		this.jcsmpContext = jcsmpContext;
 		this.sessionProducerManager = new JCSMPSessionProducerManager(jcsmpSession);
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
@@ -97,7 +97,7 @@ public class SolaceMessageChannelBinderConfiguration {
 	SolaceMessageChannelBinder solaceMessageChannelBinder(SolaceEndpointProvisioner solaceEndpointProvisioner,
 														  @Nullable SolaceBinderHealthAccessor solaceBinderHealthAccessor,
 														  @Nullable SolaceMeterAccessor solaceMeterAccessor) {
-		SolaceMessageChannelBinder binder = new SolaceMessageChannelBinder(jcsmpSession, context, solaceEndpointProvisioner);
+		SolaceMessageChannelBinder binder = new SolaceMessageChannelBinder(jcsmpSession, jcsmpProperties, context, solaceEndpointProvisioner);
 		binder.setExtendedBindingProperties(solaceExtendedBindingProperties);
 		binder.setSolaceMeterAccessor(solaceMeterAccessor);
 		if (solaceBinderHealthAccessor != null) {


### PR DESCRIPTION
Use new `ProducerFlowProperties` constructor that properly supports full `JCSMPProperties` propagation.