### PR TITLE
DATAGO-88859: add headerTypeCompatibility & payloadTypeCompatibility producer bindng options

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -404,12 +404,23 @@ The list of headers to exclude from the published message. Excluding Solace mess
 +
 Default: Empty `List&lt;String&gt;`
 
+headerTypeCompatibility::
+The compatibility mode for message headers when they're being written to the SMF message.
++
+When set to `native_only`, only headers which are natively supported by SMF are allowed to be written. Unsupported types will throw an exception.
++
+When set to `serialize_and_encode_non_native_types`, non-native and serializable headers will be serialized to a byte array then encoded into a string with the corresponding  `solace_scst_serializedHeaders` and `solace_scst_serializedHeadersEncoding` headers set accordingly.
++
+Default: `serialize_and_encode_non_native_types`
+
 nonserializableHeaderConvertToString::
 When set to `true`, irreversibly convert non-serializable headers to strings. An exception is thrown otherwise.
 +
 Default: `false`
 +
 IMPORTANT: Non-serializable headers should have a meaningful `toString()` implementation. Otherwise enabling this feature may result in potential data loss.
++
+NOTE: Only applies when `headerTypeCompatibility` is set to `serialize_and_encode_non_native_types`.
 
 transacted::
 When set to `true`, messages will be delivered using local transactions.
@@ -420,6 +431,15 @@ WARNING: A transacted producer cannot be used by multiple threads.
 +
 NOTE: The maximum transaction size is 256 messages. +
 The size of the transaction is 1 when the binding receives a regular Spring message. Otherwise, if it receives a <<Batch Producers, batched message>>, then the transaction size is equal to the batch size.
+
+payloadTypeCompatibility::
+The compatibility mode for message payloads when they're being written to the SMF message.
++
+When set to `native_only`, only payloads which are natively supported by SMF are allowed to be written. Unsupported types will throw an exception.
++
+When set to `serialize_non_native_types`, non-native and serializable payloads will be serialized into a byte array with the corresponding  `solace_scst_serializedPayload` header set accordingly. Native payloads will be written as usual.
++
+Default: `serialize_non_native_types`
 
 provisionDurableQueue::
 Whether to provision durable queues for non-anonymous consumer groups or queue destinations. This should only be set to `false` if you have externally pre-provisioned the required queue on the message broker.

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -228,13 +228,13 @@ abstract class InboundXMLMessageListener implements Runnable {
 
 	Message<?> createOneMessage(BytesXMLMessage bytesXMLMessage, AcknowledgmentCallback acknowledgmentCallback) {
 		setAttributesIfNecessary(bytesXMLMessage, acknowledgmentCallback);
-		return xmlMessageMapper.map(bytesXMLMessage, acknowledgmentCallback, consumerProperties.getExtension());
+		return xmlMessageMapper.mapToSpring(bytesXMLMessage, acknowledgmentCallback, consumerProperties.getExtension());
 	}
 
 	Message<?> createBatchMessage(List<BytesXMLMessage> bytesXMLMessages,
 								  AcknowledgmentCallback acknowledgmentCallback) {
 		setBatchAttributesIfNecessary(bytesXMLMessages, null, acknowledgmentCallback);
-		return xmlMessageMapper.mapBatchMessage(bytesXMLMessages, acknowledgmentCallback, consumerProperties.getExtension());
+		return xmlMessageMapper.mapBatchedToSpring(bytesXMLMessages, acknowledgmentCallback, consumerProperties.getExtension());
 	}
 
 	void sendOneToConsumer(final Message<?> message, final BytesXMLMessage bytesXMLMessage)

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
@@ -157,7 +157,7 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 	private Message<?> processMessage(MessageContainer messageContainer) {
 		AcknowledgmentCallback acknowledgmentCallback = ackCallbackFactory.createCallback(messageContainer);
 		try {
-			return xmlMessageMapper.map(messageContainer.getMessage(), acknowledgmentCallback, true, consumerProperties.getExtension());
+			return xmlMessageMapper.mapToSpring(messageContainer.getMessage(), acknowledgmentCallback, true, consumerProperties.getExtension());
 		} catch (Exception e) {
 			//TODO If one day the errorChannel or attributesHolder can be retrieved, use those instead
 			logger.warn("XMLMessage {} cannot be consumed. It will be requeued",
@@ -181,7 +181,7 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 				ackCallbackFactory.createBatchCallback(batchedMessages.get());
 
 		try {
-			return xmlMessageMapper.mapBatchMessage(batchedMessages.get()
+			return xmlMessageMapper.mapBatchedToSpring(batchedMessages.get()
 					.stream()
 					.map(MessageContainer::getMessage)
 					.collect(Collectors.toList()), acknowledgmentCallback, true, consumerProperties.getExtension());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageWriterProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageWriterProperties.java
@@ -1,0 +1,53 @@
+package com.solace.spring.cloud.stream.binder.properties;
+
+import com.solace.spring.cloud.stream.binder.util.SmfMessageHeaderWriteCompatibility;
+import com.solace.spring.cloud.stream.binder.util.SmfMessagePayloadWriteCompatibility;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class SmfMessageWriterProperties {
+	private Set<String> headerExclusions;
+	private SmfMessageHeaderWriteCompatibility headerTypeCompatibility;
+	private SmfMessagePayloadWriteCompatibility payloadTypeCompatibility;
+	private boolean nonSerializableHeaderConvertToString;
+
+	public SmfMessageWriterProperties(SolaceProducerProperties solaceProducerProperties) {
+		this.headerExclusions = new HashSet<>(solaceProducerProperties.getHeaderExclusions());
+		this.headerTypeCompatibility = solaceProducerProperties.getHeaderTypeCompatibility();
+		this.payloadTypeCompatibility = solaceProducerProperties.getPayloadTypeCompatibility();
+		this.nonSerializableHeaderConvertToString = solaceProducerProperties.isNonserializableHeaderConvertToString();
+	}
+
+	public Set<String> getHeaderExclusions() {
+		return headerExclusions;
+	}
+
+	public void setHeaderExclusions(Set<String> headerExclusions) {
+		this.headerExclusions = headerExclusions;
+	}
+
+	public SmfMessageHeaderWriteCompatibility getHeaderTypeCompatibility() {
+		return headerTypeCompatibility;
+	}
+
+	public void setHeaderTypeCompatibility(SmfMessageHeaderWriteCompatibility headerTypeCompatibility) {
+		this.headerTypeCompatibility = headerTypeCompatibility;
+	}
+
+	public SmfMessagePayloadWriteCompatibility getPayloadTypeCompatibility() {
+		return payloadTypeCompatibility;
+	}
+
+	public void setPayloadTypeCompatibility(SmfMessagePayloadWriteCompatibility payloadTypeCompatibility) {
+		this.payloadTypeCompatibility = payloadTypeCompatibility;
+	}
+
+	public boolean isNonSerializableHeaderConvertToString() {
+		return nonSerializableHeaderConvertToString;
+	}
+
+	public void setNonSerializableHeaderConvertToString(boolean nonSerializableHeaderConvertToString) {
+		this.nonSerializableHeaderConvertToString = nonSerializableHeaderConvertToString;
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceBindingProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceBindingProperties.java
@@ -1,10 +1,17 @@
 package com.solace.spring.cloud.stream.binder.properties;
 
+import jakarta.validation.Valid;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 
 public class SolaceBindingProperties implements BinderSpecificPropertiesProvider {
 
+	@NestedConfigurationProperty
+	@Valid
 	private SolaceConsumerProperties consumer = new SolaceConsumerProperties();
+
+	@NestedConfigurationProperty
+	@Valid
 	private SolaceProducerProperties producer = new SolaceProducerProperties();
 
 	@Override

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -1,6 +1,8 @@
 package com.solace.spring.cloud.stream.binder.properties;
 
 import com.solace.spring.cloud.stream.binder.util.DestinationType;
+import com.solace.spring.cloud.stream.binder.util.SmfMessageHeaderWriteCompatibility;
+import com.solace.spring.cloud.stream.binder.util.SmfMessagePayloadWriteCompatibility;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.ArrayList;
@@ -44,8 +46,20 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	 * The list of headers to exclude from the published message. Excluding Solace message headers is not supported.
 	 */
 	private List<String> headerExclusions = new ArrayList<>();
+
+	/**
+	 * The compatibility mode for message headers when they're being written to the SMF message.
+	 */
+	private SmfMessageHeaderWriteCompatibility headerTypeCompatibility = SmfMessageHeaderWriteCompatibility.SERIALIZE_AND_ENCODE_NON_NATIVE_TYPES;
+
+	/**
+	 * The compatibility mode for message payloads when they're being written to the SMF message.
+	 */
+	private SmfMessagePayloadWriteCompatibility payloadTypeCompatibility = SmfMessagePayloadWriteCompatibility.SERIALIZE_NON_NATIVE_TYPES;
+
 	/**
 	 * When set to true, irreversibly convert non-serializable headers to strings. An exception is thrown otherwise.
+	 * Only applies when {@link #headerTypeCompatibility} is set to {@link SmfMessageHeaderWriteCompatibility#SERIALIZE_AND_ENCODE_NON_NATIVE_TYPES}.
 	 */
 	private boolean nonserializableHeaderConvertToString = false;
 
@@ -87,6 +101,22 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 
 	public void setHeaderExclusions(List<String> headerExclusions) {
 		this.headerExclusions = headerExclusions;
+	}
+
+	public SmfMessageHeaderWriteCompatibility getHeaderTypeCompatibility() {
+		return headerTypeCompatibility;
+	}
+
+	public void setHeaderTypeCompatibility(SmfMessageHeaderWriteCompatibility headerTypeCompatibility) {
+		this.headerTypeCompatibility = headerTypeCompatibility;
+	}
+
+	public SmfMessagePayloadWriteCompatibility getPayloadTypeCompatibility() {
+		return payloadTypeCompatibility;
+	}
+
+	public void setPayloadTypeCompatibility(SmfMessagePayloadWriteCompatibility payloadTypeCompatibility) {
+		this.payloadTypeCompatibility = payloadTypeCompatibility;
 	}
 
 	public boolean isNonserializableHeaderConvertToString() {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SmfMessageHeaderWriteCompatibility.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SmfMessageHeaderWriteCompatibility.java
@@ -1,0 +1,17 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+public enum SmfMessageHeaderWriteCompatibility {
+	/**
+	 * Only headers which are natively supported by SMF are allowed to be written.
+	 * Unsupported types will throw an exception.
+	 */
+	NATIVE_ONLY,
+
+	/**
+	 * Non-native and serializable headers will be serialized to a byte array then encoded into a string with the
+	 * corresponding {@link com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders#SERIALIZED_HEADERS} and
+	 * {@link com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders#SERIALIZED_HEADERS_ENCODING} headers
+	 * set accordingly.
+	 */
+	SERIALIZE_AND_ENCODE_NON_NATIVE_TYPES
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SmfMessagePayloadWriteCompatibility.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SmfMessagePayloadWriteCompatibility.java
@@ -1,0 +1,17 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+public enum SmfMessagePayloadWriteCompatibility {
+	/**
+	 * Only payloads which are natively supported by SMF are allowed to be written.
+	 * Unsupported types will throw an exception.
+	 */
+	NATIVE_ONLY,
+
+	/**
+	 * Non-native and serializable payloads will be serialized into a byte array with the corresponding
+	 * {@link com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders#SERIALIZED_PAYLOAD} header set
+	 * accordingly.
+	 * Native payloads will be written as usual.
+	 */
+	SERIALIZE_NON_NATIVE_TYPES
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageWriterPropertiesTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageWriterPropertiesTest.java
@@ -1,0 +1,32 @@
+package com.solace.spring.cloud.stream.binder.properties;
+
+import com.solace.spring.cloud.stream.binder.util.SmfMessageHeaderWriteCompatibility;
+import com.solace.spring.cloud.stream.binder.util.SmfMessagePayloadWriteCompatibility;
+import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SmfMessageWriterPropertiesTest {
+	@CartesianTest
+	void testCreateFromSolaceProducerProperties(@Values(booleans = {false, true}) boolean defaultValues) {
+		SolaceProducerProperties producerProperties = new SolaceProducerProperties();
+
+		if (!defaultValues) {
+			producerProperties.getHeaderExclusions().add("foobar");
+			producerProperties.setHeaderTypeCompatibility(SmfMessageHeaderWriteCompatibility.NATIVE_ONLY);
+			producerProperties.setPayloadTypeCompatibility(SmfMessagePayloadWriteCompatibility.NATIVE_ONLY);
+			producerProperties.setNonserializableHeaderConvertToString(true);
+		}
+
+		SmfMessageWriterProperties smfMessageWriterProperties = new SmfMessageWriterProperties(producerProperties);
+		assertThat(smfMessageWriterProperties.getHeaderExclusions())
+				.containsExactlyInAnyOrderElementsOf(producerProperties.getHeaderExclusions());
+		assertThat(smfMessageWriterProperties.getHeaderTypeCompatibility())
+				.isSameAs(producerProperties.getHeaderTypeCompatibility());
+		assertThat(smfMessageWriterProperties.getPayloadTypeCompatibility())
+				.isSameAs(producerProperties.getPayloadTypeCompatibility());
+		assertThat(smfMessageWriterProperties.isNonSerializableHeaderConvertToString())
+				.isEqualTo(producerProperties.isNonserializableHeaderConvertToString());
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -293,7 +293,7 @@ public class XMLMessageMapperTest {
 				Mockito.anyMap(),
 				Mockito.eq(StaticMessageHeaderAccessor.getId(testSpringMessage)),
 				Mockito.eq(serializationProperties));
-		assertThatThrownBy(() -> xmlMessageMapper.mapToSmf(testSpringMessage, serializationProperties))
+		assertThatThrownBy(() -> xmlMessageMapper.mapBatchedToSmf(testSpringMessage, serializationProperties))
 				.isEqualTo(exception);
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SerializableFoo.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SerializableFoo.java
@@ -1,0 +1,6 @@
+package com.solace.spring.cloud.stream.binder.test.util;
+
+import java.io.Serializable;
+
+public record SerializableFoo(String foo) implements Serializable {
+}


### PR DESCRIPTION
* add `headerTypeCompatibility` & `payloadTypeCompatibility` producer binding options
* Convert `headerExclusions` in the producer side from a `List<String>` to `Set<String>` before handing it off to the message converter.
  * This config option should have originally been a `Set<String>`  to begin with since values were unique and to optimize lookup time...
  * Added a TODO to later do the same for the consumer side.