### PR TITLE
Added a Header Name Mapping feature for consumer and producer bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <repoName>SolaceProducts</repoName>
 
         <!-- This is the version of Spring Cloud we have targeted for this build -->
-        <spring.cloud.version>2024.0.0</spring.cloud.version>
+        <spring.cloud.version>2024.0.2</spring.cloud.version>
 
         <!-- This is the version of Solace Spring Boot we have targeted for this build -->
         <!-- This also dictates the expected version of Spring Boot -->
@@ -30,7 +30,7 @@
 
         <!-- Override spring-boot version from solace-spring-boot to latest patch version -->
         <!-- Remove this if the next version of solace-spring-boot works fine -->
-        <spring.boot.version>3.4.4</spring.boot.version>
+        <spring.boot.version>3.4.9</spring.boot.version>
 
         <solace.spring.cloud.stream-starter.version>5.8.2-SNAPSHOT</solace.spring.cloud.stream-starter.version>
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -1213,14 +1213,14 @@ spring:
         bindings:
           uppercase-in-0:
             consumer:
-              headerNameMapping:
+              header-name-mapping:
                 timestamp: original-timestamp
                 id: original-message-id
                 contentType: original-content-type
                 priority: original-priority
           uppercase-out-0:
             producer:
-              headerNameMapping:
+              header-name-mapping:
                 original-timestamp: timestamp
                 original-message-id: id
                 original-content-type: contentType

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -384,6 +384,13 @@ The list of headers to exclude when converting consumed Solace message to Spring
 +
 Default: Empty `List&lt;String&gt;`
 
+headerNameMapping::
+Mapping from Solace message user property names to Spring message header names. Useful for retaining Solace message user properties that have the same names as reserved Spring message headers, such as `id`, `timestamp`, `contentType`, `priority`, `correlationId`, `sequenceNumber`, `replyChannel`, `errorChannel`, etc.
++
+Default: Empty `Map&lt;String,String&gt;`
++
+See: <<Header Name Mapping>>
+
 ==== Solace Producer Properties
 
 The following properties are available for Solace producers only and must be prefixed with `spring.cloud.stream.solace.bindings.&lt;bindingName&gt;.producer.` where `bindingName` looks something like `functionName-out-0` as defined in https://docs.spring.io/spring-cloud-stream/reference/{scst-version}/spring-cloud-stream/functional-binding-names.html[Functional Binding Names].
@@ -521,6 +528,13 @@ Default: Empty `Map&lt;String,String[]&gt;` +
 See: <<Overview>> for more info on how this binder uses topic-to-queue mapping to implement Spring Cloud Streams consumer groups.
 +
 NOTE: Does not apply when `destinationType=queue`.
+
+headerNameMapping::
+Mapping from Spring message header names to Solace message user property names. Useful when you need to preserve the original values of Spring message headers that conflict with reserved header names such as `id`, `timestamp`, `contentType`, `priority`, `correlationId`, `sequenceNumber`, `replyChannel`, `errorChannel`, etc.
++
+Default: Empty `Map&lt;String,String&gt;`
++
+See: <<Header Name Mapping>>
 
 ==== Solace Connection Health-Check Properties
 
@@ -756,6 +770,127 @@ Specifies that the dynamic destination is a queue
 
 When absent, the binding’s configured destination-type is used.
 |===
+
+== Header Name Mapping
+
+The Solace Spring Cloud Stream Binder allows you to configure custom mappings between Spring Message header names and JCSMP User Property keys. This feature provides flexibility when you need to preserve the original values of message headers that would otherwise be overwritten by the Spring Cloud Stream framework, such as reserved headers like `id`, `timestamp`, `contentType`, `priority`, `correlationId`, `sequenceNumber`, `replyChannel`, `errorChannel`, etc.
+
+=== Configuration
+
+Header name mapping can be configured per binding or as default configuration for all bindings.
+
+==== Per-Binding Configuration
+
+To configure header name mapping for specific consumer and producer bindings:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    stream:
+      solace:
+        bindings:
+          uppercase-in-0:
+            consumer:
+              headerNameMapping:
+                timestamp: original-timestamp
+                id: original-message-id
+                contentType: original-content-type
+                priority: original-priority
+          uppercase-out-0:
+            producer:
+              headerNameMapping:
+                original-timestamp: timestamp
+                original-message-id: id  
+                original-content-type: contentType
+                original-priority: priority
+----
+
+==== Default Configuration
+
+Configure header name mapping for all bindings:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    stream:
+      solace:
+        default:
+          consumer:
+            headerNameMapping:
+              timestamp: original-timestamp
+              id: original-message-id
+              contentType: original-content-type
+          producer:
+            headerNameMapping:
+              original-timestamp: timestamp
+              original-message-id: id
+              original-content-type: contentType
+----
+
+=== Behavior
+
+==== Consumer Side (Solace to Spring)
+When the binder consumes messages from Solace and converts them to Spring Cloud Stream messages:
+
+1. **Header Mapping Resolution**: The binder examines each Solace user property and checks if it has a corresponding mapping in the `headerNameMapping` configuration
+2. **Mapped Properties**: User properties with configured mappings are converted to Spring message headers using the mapped header name (e.g., `timestamp` user property becomes `original-timestamp` header)
+3. **Unmapped Properties**: User properties without mappings are converted to Spring message headers using their original property names, in which case it may be overwritten if it is Spring Integration reserved header (e.g. id, timestamp etc)
+4. **Reserved Header Preservation**: This allows access to original Solace message metadata that would otherwise be overwritten by Spring Cloud Stream's reserved headers during message processing
+
+==== Producer Side (Spring to Solace)
+When the binder publishes Spring Cloud Stream messages to Solace:
+
+1. **Header Mapping Lookup**: The binder examines each Spring message header and checks if it has a corresponding mapping in the `headerNameMapping` configuration
+2. **Mapped Headers**: Headers with configured mappings are converted to Solace user properties using the mapped property name (e.g., `original-timestamp` header becomes `timestamp` user property)
+3. **Unmapped Headers**: Headers without mappings are converted to Solace user properties using their original header names
+4. **Reserved Header Handling**: This prevents Spring Cloud Stream reserved headers from overwriting important application-specific metadata when publishing to Solace
+
+=== Backward Compatibility
+
+This feature is fully backward compatible:
+
+* If no `headerNameMapping` is configured, the binder behaves exactly as before
+* Existing applications will continue to work without any changes
+
+=== Example Use Cases
+
+==== Preserving Reserved Headers
+When you need to retain the original values of Spring Cloud Stream reserved headers:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    stream:
+      solace:
+        bindings:
+          data-processor-in-0:
+            consumer:
+              headerNameMapping:
+                timestamp: original-timestamp        #Preserve publisher application set timestamp
+                id: original-id             #Preserve publisher application set id
+                correlationId: original-correlationId  #Preserve publisher application set correlation ID
+----
+
+==== Cross-System Integration
+When integrating with legacy systems that expect specific property names:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    stream:
+      solace:
+        bindings:
+          legacy-system-out-0:
+            producer:
+              headerNameMapping:
+                id: MSG_ID
+                timestamp: TS
+                spring-source: SRC_SYS
+----
 
 == Native Payload Types
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -771,48 +771,6 @@ Specifies that the dynamic destination is a queue
 When absent, the binding’s configured destination-type is used.
 |===
 
-== Header Name Mapping
-
-The Solace Spring Cloud Stream Binder allows you to configure custom mappings between Spring Message header names and JCSMP User Property keys. This feature provides flexibility when you need to preserve the original values of message headers that would otherwise be overwritten by the Spring Cloud Stream framework, such as reserved headers like `id`, `timestamp`, `contentType`, `priority`, `correlationId`, `sequenceNumber`, `replyChannel`, `errorChannel`, etc.
-
-=== Configuration
-
-Header name mapping can be configured per binding or as default configuration for all bindings.
-
-==== Per-Binding Configuration
-
-To configure header name mapping for specific consumer and producer bindings:
-
-[source,yaml]
-----
-spring:
-  cloud:
-    stream:
-      solace:
-        bindings:
-          uppercase-in-0:
-            consumer:
-              headerNameMapping:
-                timestamp: original-timestamp
-                id: original-message-id
-                contentType: original-content-type
-                priority: original-priority
-          uppercase-out-0:
-            producer:
-              headerNameMapping:
-                original-timestamp: timestamp
-                original-message-id: id  
-                original-content-type: contentType
-                original-priority: priority
-----
-
-=== Backward Compatibility
-
-This feature is fully backward compatible:
-
-* If no `headerNameMapping` is configured, the binder behaves exactly as before
-* Existing applications will continue to work without any changes
-
 == Native Payload Types
 
 Below are the payload types natively supported by this binder (before/after https://docs.spring.io/spring-cloud-stream/reference/{scst-version}/spring-cloud-stream/content-type.html[Content Type Negotiation]):
@@ -1237,6 +1195,37 @@ public Function<Message<SDTMap>, Message<SDTMap>> transform() {
 If the consumer binding was configured with `maxAttempts > 1`, then on the following reprocessing attempts, the payload will still contain the key `"new-key"` from the previous attempt.
 
 If this behavior is undesirable, then you should configure your consumers `maxAttempts` to `1` and rely on <<Message Redelivery>> to handle reprocessing.
+
+== Header Name Mapping
+
+The Solace Spring Cloud Stream Binder allows you to configure custom mappings between Spring Message header names and JCSMP User Property keys. This feature provides flexibility when you need to preserve the original values of message headers that would otherwise be overwritten by the Spring Cloud Stream reserved headers, such as `id`, `timestamp`, `contentType`, `priority`, `correlationId`, `sequenceNumber`, `replyChannel`, `errorChannel`, etc.
+
+Header name mapping can be configured per binding or as default configuration for all bindings.
+
+.Example: consumer and producer header name mapping:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    stream:
+      solace:
+        bindings:
+          uppercase-in-0:
+            consumer:
+              headerNameMapping:
+                timestamp: original-timestamp
+                id: original-message-id
+                contentType: original-content-type
+                priority: original-priority
+          uppercase-out-0:
+            producer:
+              headerNameMapping:
+                original-timestamp: timestamp
+                original-message-id: id
+                original-content-type: contentType
+                original-priority: priority
+----
 
 == Consumer Bindings Pause/Resume
 

--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -806,91 +806,12 @@ spring:
                 original-priority: priority
 ----
 
-==== Default Configuration
-
-Configure header name mapping for all bindings:
-
-[source,yaml]
-----
-spring:
-  cloud:
-    stream:
-      solace:
-        default:
-          consumer:
-            headerNameMapping:
-              timestamp: original-timestamp
-              id: original-message-id
-              contentType: original-content-type
-          producer:
-            headerNameMapping:
-              original-timestamp: timestamp
-              original-message-id: id
-              original-content-type: contentType
-----
-
-=== Behavior
-
-==== Consumer Side (Solace to Spring)
-When the binder consumes messages from Solace and converts them to Spring Cloud Stream messages:
-
-1. **Header Mapping Resolution**: The binder examines each Solace user property and checks if it has a corresponding mapping in the `headerNameMapping` configuration
-2. **Mapped Properties**: User properties with configured mappings are converted to Spring message headers using the mapped header name (e.g., `timestamp` user property becomes `original-timestamp` header)
-3. **Unmapped Properties**: User properties without mappings are converted to Spring message headers using their original property names, in which case it may be overwritten if it is Spring Integration reserved header (e.g. id, timestamp etc)
-4. **Reserved Header Preservation**: This allows access to original Solace message metadata that would otherwise be overwritten by Spring Cloud Stream's reserved headers during message processing
-
-==== Producer Side (Spring to Solace)
-When the binder publishes Spring Cloud Stream messages to Solace:
-
-1. **Header Mapping Lookup**: The binder examines each Spring message header and checks if it has a corresponding mapping in the `headerNameMapping` configuration
-2. **Mapped Headers**: Headers with configured mappings are converted to Solace user properties using the mapped property name (e.g., `original-timestamp` header becomes `timestamp` user property)
-3. **Unmapped Headers**: Headers without mappings are converted to Solace user properties using their original header names
-4. **Reserved Header Handling**: This prevents Spring Cloud Stream reserved headers from overwriting important application-specific metadata when publishing to Solace
-
 === Backward Compatibility
 
 This feature is fully backward compatible:
 
 * If no `headerNameMapping` is configured, the binder behaves exactly as before
 * Existing applications will continue to work without any changes
-
-=== Example Use Cases
-
-==== Preserving Reserved Headers
-When you need to retain the original values of Spring Cloud Stream reserved headers:
-
-[source,yaml]
-----
-spring:
-  cloud:
-    stream:
-      solace:
-        bindings:
-          data-processor-in-0:
-            consumer:
-              headerNameMapping:
-                timestamp: original-timestamp        #Preserve publisher application set timestamp
-                id: original-id             #Preserve publisher application set id
-                correlationId: original-correlationId  #Preserve publisher application set correlation ID
-----
-
-==== Cross-System Integration
-When integrating with legacy systems that expect specific property names:
-
-[source,yaml]
-----
-spring:
-  cloud:
-    stream:
-      solace:
-        bindings:
-          legacy-system-out-0:
-            producer:
-              headerNameMapping:
-                id: MSG_ID
-                timestamp: TS
-                spring-source: SRC_SYS
-----
 
 == Native Payload Types
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListener.java
@@ -3,6 +3,7 @@ package com.solace.spring.cloud.stream.binder.inbound;
 import com.solace.spring.cloud.stream.binder.inbound.acknowledge.JCSMPAcknowledgementCallbackFactory;
 import com.solace.spring.cloud.stream.binder.inbound.acknowledge.SolaceAckUtil;
 import com.solace.spring.cloud.stream.binder.meter.SolaceMeterAccessor;
+import com.solace.spring.cloud.stream.binder.properties.SmfMessageReaderProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
 import com.solace.spring.cloud.stream.binder.util.MessageContainer;
@@ -43,6 +44,7 @@ public abstract class InboundXMLMessageListener implements Runnable {
 	final FlowReceiverContainer flowReceiverContainer;
 	final ConsumerDestination consumerDestination;
 	private final ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties;
+	private final SmfMessageReaderProperties smfMessageReaderProperties;
 	final ThreadLocal<AttributeAccessor> attributesHolder;
 	private final BatchCollector batchCollector;
 	private final XMLMessageMapper xmlMessageMapper;
@@ -79,6 +81,7 @@ public abstract class InboundXMLMessageListener implements Runnable {
 		this.needHolder = needHolder;
 		this.needAttributes = needAttributes;
 		this.xmlMessageMapper = flowReceiverContainer.getXMLMessageMapper();
+		this.smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties.getExtension());
 	}
 
 	abstract void handleMessage(Supplier<Message<?>> messageSupplier, Consumer<Message<?>> sendToConsumerHandler,
@@ -228,13 +231,13 @@ public abstract class InboundXMLMessageListener implements Runnable {
 
 	Message<?> createOneMessage(BytesXMLMessage bytesXMLMessage, AcknowledgmentCallback acknowledgmentCallback) {
 		setAttributesIfNecessary(bytesXMLMessage, acknowledgmentCallback);
-		return xmlMessageMapper.mapToSpring(bytesXMLMessage, acknowledgmentCallback, consumerProperties.getExtension());
+		return xmlMessageMapper.mapToSpring(bytesXMLMessage, acknowledgmentCallback, smfMessageReaderProperties);
 	}
 
 	Message<?> createBatchMessage(List<BytesXMLMessage> bytesXMLMessages,
 								  AcknowledgmentCallback acknowledgmentCallback) {
 		setBatchAttributesIfNecessary(bytesXMLMessages, null, acknowledgmentCallback);
-		return xmlMessageMapper.mapBatchedToSpring(bytesXMLMessages, acknowledgmentCallback, consumerProperties.getExtension());
+		return xmlMessageMapper.mapBatchedToSpring(bytesXMLMessages, acknowledgmentCallback, smfMessageReaderProperties);
 	}
 
 	void sendOneToConsumer(final Message<?> message, final BytesXMLMessage bytesXMLMessage)
@@ -297,5 +300,9 @@ public abstract class InboundXMLMessageListener implements Runnable {
 
 	public AtomicBoolean getStopFlag() {
 		return stopFlag;
+	}
+
+	public SmfMessageReaderProperties getSmfMessageReaderProperties() {
+		return smfMessageReaderProperties;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
@@ -19,6 +19,7 @@ import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.XMLMessage.Outcome;
 import com.solacesystems.jcsmp.impl.JCSMPBasicSession;
 import com.solacesystems.jcsmp.transaction.RollbackException;
+import java.util.Map;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,6 +106,18 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
                     consumerProperties.getConcurrency(), id));
             logger.warn(exception.getMessage());
             throw exception;
+        }
+
+        Map<String, String> headerNameMapping = consumerProperties.getExtension().getHeaderNameMapping();
+        if (headerNameMapping != null && !headerNameMapping.isEmpty()) {
+            Set<String> targetHeaderNames = new HashSet<>(headerNameMapping.values());
+            if (targetHeaderNames.size() < headerNameMapping.size()) {
+                MessagingException exception = new MessagingException(String.format(
+                    "Two or more keys map to the same header name in headerNameMapping %s <inbound adapter %s>",
+                    consumerProperties.getExtension().getHeaderNameMapping(), id));
+                logger.warn(exception.getMessage());
+                throw exception;
+            }
         }
 
         if (jcsmpSession instanceof JCSMPBasicSession jcsmpBasicSession

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapter.java
@@ -112,7 +112,7 @@ public class JCSMPInboundChannelAdapter extends MessageProducerSupport implement
         if (headerNameMapping != null && !headerNameMapping.isEmpty()) {
             Set<String> targetHeaderNames = new HashSet<>(headerNameMapping.values());
             if (targetHeaderNames.size() < headerNameMapping.size()) {
-                MessagingException exception = new MessagingException(String.format(
+                IllegalArgumentException exception = new IllegalArgumentException(String.format(
                     "Two or more keys map to the same header name in headerNameMapping %s <inbound adapter %s>",
                     consumerProperties.getExtension().getHeaderNameMapping(), id));
                 logger.warn(exception.getMessage());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
@@ -22,6 +22,9 @@ import com.solacesystems.jcsmp.EndpointProperties;
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.JCSMPTransportException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -214,6 +217,18 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 			if (isRunning()) {
 				logger.warn("Nothing to do, message source {} is already running", id);
 				return;
+			}
+
+			Map<String, String> headerNameMapping = consumerProperties.getExtension().getHeaderNameMapping();
+			if (headerNameMapping != null && !headerNameMapping.isEmpty()) {
+				Set<String> targetHeaderNames = new HashSet<>(headerNameMapping.values());
+				if (targetHeaderNames.size() < headerNameMapping.size()) {
+					MessagingException exception = new MessagingException(String.format(
+							"Two or more keys map to the same header name in headerNameMapping %s <inbound adapter %s>",
+							consumerProperties.getExtension().getHeaderNameMapping(), id));
+					logger.warn(exception.getMessage());
+					throw exception;
+				}
 			}
 
 			try {

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSource.java
@@ -223,7 +223,7 @@ public class JCSMPMessageSource extends AbstractMessageSource<Object> implements
 			if (headerNameMapping != null && !headerNameMapping.isEmpty()) {
 				Set<String> targetHeaderNames = new HashSet<>(headerNameMapping.values());
 				if (targetHeaderNames.size() < headerNameMapping.size()) {
-					MessagingException exception = new MessagingException(String.format(
+					IllegalArgumentException exception = new IllegalArgumentException(String.format(
 							"Two or more keys map to the same header name in headerNameMapping %s <inbound adapter %s>",
 							consumerProperties.getExtension().getHeaderNameMapping(), id));
 					logger.warn(exception.getMessage());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandler.java
@@ -239,7 +239,7 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
 			if (headerNameMapping != null && !headerNameMapping.isEmpty()) {
 				Set<String> uniqueTargetHeaderNames = new HashSet<>(headerNameMapping.values());
 				if (uniqueTargetHeaderNames.size() < headerNameMapping.size()) {
-					MessagingException exception = new MessagingException(String.format(
+					IllegalArgumentException exception = new IllegalArgumentException(String.format(
 							"Two or more headers map to the same header name in headerNameMapping %s <outbound adapter %s>",
 							properties.getExtension().getHeaderNameMapping(), id));
 					LOGGER.warn(exception.getMessage());

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageReaderProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageReaderProperties.java
@@ -1,0 +1,26 @@
+package com.solace.spring.cloud.stream.binder.properties;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class SmfMessageReaderProperties {
+
+  private Set<String> headerExclusions;
+  private Map<String, String> headerNameMapping;
+
+  public SmfMessageReaderProperties(SolaceConsumerProperties solaceConsumerProperties) {
+    this.headerExclusions = new HashSet<>(Objects.requireNonNullElse(solaceConsumerProperties.getHeaderExclusions(), Set.of()));
+    this.headerNameMapping = new LinkedHashMap<>(Objects.requireNonNullElse(solaceConsumerProperties.getHeaderNameMapping(), Map.of()));
+  }
+
+  public Set<String> getHeaderExclusions() {
+    return headerExclusions;
+  }
+
+  public Map<String, String> getHeaderNameMapping() {
+    return headerNameMapping;
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageWriterProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SmfMessageWriterProperties.java
@@ -4,6 +4,9 @@ import com.solace.spring.cloud.stream.binder.util.SmfMessageHeaderWriteCompatibi
 import com.solace.spring.cloud.stream.binder.util.SmfMessagePayloadWriteCompatibility;
 
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class SmfMessageWriterProperties {
@@ -11,12 +14,14 @@ public class SmfMessageWriterProperties {
 	private SmfMessageHeaderWriteCompatibility headerTypeCompatibility;
 	private SmfMessagePayloadWriteCompatibility payloadTypeCompatibility;
 	private boolean nonSerializableHeaderConvertToString;
+	private final Map<String, String> headerNameMapping;
 
 	public SmfMessageWriterProperties(SolaceProducerProperties solaceProducerProperties) {
 		this.headerExclusions = new HashSet<>(solaceProducerProperties.getHeaderExclusions());
 		this.headerTypeCompatibility = solaceProducerProperties.getHeaderTypeCompatibility();
 		this.payloadTypeCompatibility = solaceProducerProperties.getPayloadTypeCompatibility();
 		this.nonSerializableHeaderConvertToString = solaceProducerProperties.isNonserializableHeaderConvertToString();
+		this.headerNameMapping = new LinkedHashMap<>(Objects.requireNonNullElse(solaceProducerProperties.getHeaderNameMapping(), Map.of()));
 	}
 
 	public Set<String> getHeaderExclusions() {
@@ -49,5 +54,9 @@ public class SmfMessageWriterProperties {
 
 	public void setNonSerializableHeaderConvertToString(boolean nonSerializableHeaderConvertToString) {
 		this.nonSerializableHeaderConvertToString = nonSerializableHeaderConvertToString;
+	}
+
+	public Map<String, String> getHeaderNameMapping() {
+		return headerNameMapping;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceConsumerProperties.java
@@ -4,6 +4,8 @@ import com.solace.spring.cloud.stream.binder.util.BatchWaitStrategy;
 import com.solace.spring.cloud.stream.binder.util.EndpointType;
 import com.solacesystems.jcsmp.EndpointProperties;
 import jakarta.validation.constraints.Min;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.Assert;
 
@@ -126,6 +128,12 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 	 * The number of milliseconds before republished messages are discarded or moved to a Dead Message Queue.
 	 */
 	private Long errorMsgTtl = null;
+
+	/**
+	 * Mapping from Solace message user property names to Spring message header names.
+	 * Useful for retaining Solace message user properties that have the same names as reserved Spring message headers, such as timestamp, id, contentType, etc.
+	 */
+	private Map<String, String> headerNameMapping = new HashMap<>();
 	// ------------------------
 
 	public EndpointType getEndpointType() {
@@ -309,5 +317,13 @@ public class SolaceConsumerProperties extends SolaceCommonProperties {
 
 	public void setHeaderExclusions(List<String> headerExclusions) {
 		this.headerExclusions = headerExclusions;
+	}
+
+	public Map<String, String> getHeaderNameMapping() {
+		return headerNameMapping;
+	}
+
+	public void setHeaderNameMapping(Map<String, String> headerNameMapping) {
+		this.headerNameMapping = headerNameMapping;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -63,6 +63,11 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 	 */
 	private boolean nonserializableHeaderConvertToString = false;
 
+	/**
+	 * Mapping from Spring message header names to Solace message user property names.
+	 */
+	private Map<String, String> headerNameMapping = new HashMap<>();
+
 	public DestinationType getDestinationType() {
 		return destinationType;
 	}
@@ -125,5 +130,13 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
 
 	public void setNonserializableHeaderConvertToString(boolean nonserializableHeaderConvertToString) {
 		this.nonserializableHeaderConvertToString = nonserializableHeaderConvertToString;
+	}
+
+	public Map<String, String> getHeaderNameMapping() {
+		return headerNameMapping;
+	}
+
+	public void setHeaderNameMapping(Map<String, String> headerNameMapping) {
+		this.headerNameMapping = headerNameMapping;
 	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -114,7 +114,7 @@ public class XMLMessageMapper {
 			String targetKey = keyMapping.getValue();
 
       if (result.containsKey(sourceKey)) {
-        result.put(targetKey, result.get(sourceKey));
+        result.put(targetKey, result.remove(sourceKey));
       }
 		}
 		return Collections.unmodifiableMap(result);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapper.java
@@ -7,8 +7,9 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceHeaderMeta;
-import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.properties.SmfMessageReaderProperties;
 import com.solace.spring.cloud.stream.binder.properties.SmfMessageWriterProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solacesystems.common.util.ByteArray;
 import com.solacesystems.jcsmp.BytesMessage;
 import com.solacesystems.jcsmp.BytesXMLMessage;
@@ -39,7 +40,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,13 +89,44 @@ public class XMLMessageMapper {
 				writerProperties);
 	}
 
+	Map<String, Object> applyHeaderNameMapping(final Map<String, Object> sourceHeaders,
+			Map<String, String> headerKeyMapping) {
+		if (sourceHeaders == null || sourceHeaders.isEmpty() || headerKeyMapping == null
+				|| headerKeyMapping.isEmpty()) {
+			return sourceHeaders;
+		}
+
+		//Optimization for performance: check if there are any applicable mappings
+		boolean hasApplicableMappings = false;
+		for (String sourceKey : headerKeyMapping.keySet()) {
+			if (sourceHeaders.containsKey(sourceKey)) {
+				hasApplicableMappings = true;
+				break;
+			}
+		}
+		if (!hasApplicableMappings) {
+			return sourceHeaders;
+		}
+
+		Map<String, Object> result = new HashMap<>(sourceHeaders);
+		for (Map.Entry<String, String> keyMapping : headerKeyMapping.entrySet()) {
+			String sourceKey = keyMapping.getKey();
+			String targetKey = keyMapping.getValue();
+
+      if (result.containsKey(sourceKey)) {
+        result.put(targetKey, result.get(sourceKey));
+      }
+		}
+		return Collections.unmodifiableMap(result);
+	}
+
 	// exposed for testing
 	XMLMessage mapToSmf(Object payload,
 						Map<String, Object> headers,
 						UUID messageId,
 						SmfMessageWriterProperties writerProperties) {
 		XMLMessage xmlMessage;
-		SDTMap metadata = mapHeadersToSmf(headers, writerProperties);
+		SDTMap metadata = mapHeadersToSmf(applyHeaderNameMapping(headers, writerProperties.getHeaderNameMapping()), writerProperties);
 		rethrowableCall(metadata::putInteger, SolaceBinderHeaders.MESSAGE_VERSION, MESSAGE_VERSION);
 
 		if (payload instanceof byte[]) {
@@ -222,18 +253,18 @@ public class XMLMessageMapper {
 	}
 
 	public Message<List<?>> mapBatchedToSpring(List<? extends XMLMessage> xmlMessages,
-											   AcknowledgmentCallback acknowledgmentCallback, SolaceConsumerProperties solaceConsumerProperties)
+											   AcknowledgmentCallback acknowledgmentCallback, SmfMessageReaderProperties smfMessageReaderProperties)
 			throws SolaceMessageConversionException {
-		return mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, solaceConsumerProperties);
+		return mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, smfMessageReaderProperties);
 	}
 
 	public Message<List<?>> mapBatchedToSpring(List<? extends XMLMessage> xmlMessages,
 											   AcknowledgmentCallback acknowledgmentCallback,
-											   boolean setRawMessageHeader, SolaceConsumerProperties solaceConsumerProperties) throws SolaceMessageConversionException {
+											   boolean setRawMessageHeader, SmfMessageReaderProperties smfMessageReaderProperties) throws SolaceMessageConversionException {
 		List<Map<String, Object>> batchedHeaders = new ArrayList<>();
 		List<Object> batchedPayloads = new ArrayList<>();
 		for (XMLMessage xmlMessage : xmlMessages) {
-			Message<?> message = mapToSpringInternal(xmlMessage, solaceConsumerProperties).build();
+			Message<?> message = mapToSpringInternal(xmlMessage, smfMessageReaderProperties).build();
 			batchedHeaders.add(message.getHeaders());
 			batchedPayloads.add(message.getPayload());
 		}
@@ -244,24 +275,20 @@ public class XMLMessageMapper {
 				.build();
 	}
 
-	public Message<?> mapToSpring(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback, SolaceConsumerProperties solaceConsumerProperties)
+	public Message<?> mapToSpring(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback, SmfMessageReaderProperties smfMessageReaderProperties)
 			throws SolaceMessageConversionException {
-		return mapToSpring(xmlMessage, acknowledgmentCallback, false, solaceConsumerProperties);
+		return mapToSpring(xmlMessage, acknowledgmentCallback, false, smfMessageReaderProperties);
 	}
 
 	public Message<?> mapToSpring(XMLMessage xmlMessage, AcknowledgmentCallback acknowledgmentCallback,
-								  boolean setRawMessageHeader, SolaceConsumerProperties solaceConsumerProperties) throws SolaceMessageConversionException {
-		return injectRootSpringHeaders(mapToSpringInternal(xmlMessage, solaceConsumerProperties), acknowledgmentCallback, setRawMessageHeader ?
+								  boolean setRawMessageHeader, SmfMessageReaderProperties smfMessageReaderProperties) throws SolaceMessageConversionException {
+		return injectRootSpringHeaders(mapToSpringInternal(xmlMessage, smfMessageReaderProperties), acknowledgmentCallback, setRawMessageHeader ?
 				xmlMessage : null).build();
 	}
 
-	private AbstractIntegrationMessageBuilder<?> mapToSpringInternal(XMLMessage xmlMessage, SolaceConsumerProperties solaceConsumerProperties)
+	private AbstractIntegrationMessageBuilder<?> mapToSpringInternal(XMLMessage xmlMessage, SmfMessageReaderProperties smfMessageReaderProperties)
 			throws SolaceMessageConversionException {
 		SDTMap metadata = xmlMessage.getProperties();
-		//TODO This needs to be made into a Set for performance reasons.
-		// Do this by taking the same approach as SmfMessageWriterProperties.
-		// i.e. create a corresponding SmfMessageReaderProperties class (which we need to do anyway).
-		List<String> excludedHeaders = solaceConsumerProperties.getHeaderExclusions();
 
 		Object payload;
 		if (xmlMessage instanceof BytesMessage) {
@@ -316,7 +343,7 @@ public class XMLMessageMapper {
 
 		AbstractIntegrationMessageBuilder<?> builder = MESSAGE_BUILDER_FACTORY
 				.withPayload(payload)
-				.copyHeaders(mapHeadersToSpring(metadata, excludedHeaders))
+				.copyHeaders(mapHeadersToSpring(metadata, smfMessageReaderProperties))
 				.setHeaderIfAbsent(MessageHeaders.CONTENT_TYPE, xmlMessage.getHTTPContentType());
 
 		if (isNullPayload) {
@@ -328,7 +355,7 @@ public class XMLMessageMapper {
 			if (!header.getValue().isReadable()) {
 				continue;
 			}
-			if (excludedHeaders != null && excludedHeaders.contains(header.getKey())) {
+			if (smfMessageReaderProperties.getHeaderExclusions() != null && smfMessageReaderProperties.getHeaderExclusions().contains(header.getKey())) {
 				continue;
 			}
 			if (ignoredHeaderProperties.contains(header.getKey())) {
@@ -365,6 +392,7 @@ public class XMLMessageMapper {
 					SolaceBinderHeaderMeta.META.containsKey(header.getKey())) {
 				continue;
 			}
+
 			if (writerProperties.getHeaderExclusions() != null &&
 					writerProperties.getHeaderExclusions().contains(header.getKey())) {
 				continue;
@@ -398,13 +426,13 @@ public class XMLMessageMapper {
 		return metadata;
 	}
 
-	MessageHeaders mapHeadersToSpring(SDTMap metadata, Collection<String> excludedHeaders) {
+	MessageHeaders mapHeadersToSpring(SDTMap metadata, SmfMessageReaderProperties smfMessageReaderProperties) {
 		if (metadata == null) {
 			return new MessageHeaders(Collections.emptyMap());
 		}
 
-		final Collection<String> exclusionList =
-				excludedHeaders != null ? excludedHeaders : Collections.emptyList();
+		final Set<String> exclusionList = smfMessageReaderProperties.getHeaderExclusions() != null
+				? smfMessageReaderProperties.getHeaderExclusions() : Collections.emptySet();
 
 		Map<String,Object> headers = new HashMap<>();
 
@@ -461,7 +489,7 @@ public class XMLMessageMapper {
 			headers.put(SolaceBinderHeaders.MESSAGE_VERSION, messageVersion);
 		}
 
-		return new MessageHeaders(headers);
+		return new MessageHeaders(applyHeaderNameMapping(headers, smfMessageReaderProperties.getHeaderNameMapping()));
 	}
 
 	private void addSDTMapObject(SDTMap sdtMap, Set<String> serializedHeaders, String key, Object object,

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListenerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/InboundXMLMessageListenerTest.java
@@ -1,5 +1,6 @@
 package com.solace.spring.cloud.stream.binder.inbound;
 
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
 import com.solace.spring.cloud.stream.binder.util.UnboundFlowReceiverContainerException;
 import com.solacesystems.jcsmp.JCSMPException;
@@ -11,6 +12,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +34,7 @@ public class InboundXMLMessageListenerTest {
                 .thenThrow(new StaleSessionException("Session has become stale", new JCSMPException("Specific JCSMP exception")));
 
         BasicInboundXMLMessageListener inboundXMLMessageListener = new BasicInboundXMLMessageListener(
-                flowReceiverContainer, consumerDestination, null, null, null, null, null, null,
+                flowReceiverContainer, consumerDestination, new ExtendedConsumerProperties<>(new SolaceConsumerProperties()), null, null, null, null, null,
                 null, null, false);
 
         inboundXMLMessageListener.run();

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapterTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapterTest.java
@@ -1,0 +1,57 @@
+package com.solace.spring.cloud.stream.binder.inbound;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.solace.spring.cloud.stream.binder.meter.SolaceMeterAccessor;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.provisioning.SolaceConsumerDestination;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.messaging.MessagingException;
+
+@Timeout(value = 10)
+@ExtendWith(MockitoExtension.class)
+class JCSMPInboundChannelAdapterTest {
+
+  private JCSMPInboundChannelAdapter inboundChannelAdapter;
+  private ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties;
+  @Mock private JCSMPSession session;
+  @Mock private EndpointProperties endpointProperties;
+  @Mock private SolaceMeterAccessor solaceMeterAccessor;
+
+  @BeforeEach
+  void init() {
+    SolaceConsumerDestination dest = Mockito.mock(SolaceConsumerDestination.class);
+    Mockito.when(dest.getName()).thenReturn("fake/topic");
+
+    consumerProperties = new ExtendedConsumerProperties<>(new SolaceConsumerProperties());
+    consumerProperties.populateBindingName(RandomStringUtils.randomAlphanumeric(100));
+
+    inboundChannelAdapter = new JCSMPInboundChannelAdapter(
+        dest,
+        session,
+        consumerProperties,
+        endpointProperties,
+        solaceMeterAccessor
+    );
+  }
+
+  @Test
+  void test_startFailedForBadHeaderNameMapping() {
+    consumerProperties.getExtension().setHeaderNameMapping(Map.of("k1", "v1", "k2", "v1"));
+    assertThatThrownBy(() -> inboundChannelAdapter.start())
+        .isInstanceOf(MessagingException.class)
+        .hasMessageStartingWith(
+            "Two or more keys map to the same header name in headerNameMapping");
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapterTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPInboundChannelAdapterTest.java
@@ -50,7 +50,7 @@ class JCSMPInboundChannelAdapterTest {
   void test_startFailedForBadHeaderNameMapping() {
     consumerProperties.getExtension().setHeaderNameMapping(Map.of("k1", "v1", "k2", "v1"));
     assertThatThrownBy(() -> inboundChannelAdapter.start())
-        .isInstanceOf(MessagingException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             "Two or more keys map to the same header name in headerNameMapping");
   }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSourceTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSourceTest.java
@@ -17,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
-import org.springframework.messaging.MessagingException;
 
 @Timeout(value = 10)
 @ExtendWith(MockitoExtension.class)
@@ -52,7 +51,7 @@ class JCSMPMessageSourceTest {
   void test_startFailedForBadHeaderNameMapping() {
     consumerProperties.getExtension().setHeaderNameMapping(Map.of("k1", "v1", "k2", "v1"));
     assertThatThrownBy(() -> messageSource.start())
-        .isInstanceOf(MessagingException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             "Two or more keys map to the same header name in headerNameMapping");
   }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSourceTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/JCSMPMessageSourceTest.java
@@ -1,0 +1,59 @@
+package com.solace.spring.cloud.stream.binder.inbound;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.solace.spring.cloud.stream.binder.meter.SolaceMeterAccessor;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.provisioning.SolaceConsumerDestination;
+import com.solacesystems.jcsmp.EndpointProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.messaging.MessagingException;
+
+@Timeout(value = 10)
+@ExtendWith(MockitoExtension.class)
+class JCSMPMessageSourceTest {
+
+  private JCSMPMessageSource messageSource;
+  private ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties;
+  @Mock private JCSMPSession session;
+  @Mock private BatchCollector batchCollector;
+  @Mock private EndpointProperties endpointProperties;
+  @Mock private SolaceMeterAccessor solaceMeterAccessor;
+
+  @BeforeEach
+  void init() {
+    SolaceConsumerDestination dest = Mockito.mock(SolaceConsumerDestination.class);
+    Mockito.when(dest.getName()).thenReturn("fake/topic");
+
+    consumerProperties = new ExtendedConsumerProperties<>(new SolaceConsumerProperties());
+    consumerProperties.populateBindingName(RandomStringUtils.randomAlphanumeric(100));
+
+    messageSource = new JCSMPMessageSource(
+        dest,
+        session,
+        batchCollector,
+        consumerProperties,
+        endpointProperties,
+        solaceMeterAccessor
+    );
+  }
+
+  @Test
+  void test_startFailedForBadHeaderNameMapping() {
+    consumerProperties.getExtension().setHeaderNameMapping(Map.of("k1", "v1", "k2", "v1"));
+    assertThatThrownBy(() -> messageSource.start())
+        .isInstanceOf(MessagingException.class)
+        .hasMessageStartingWith(
+            "Two or more keys map to the same header name in headerNameMapping");
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
@@ -694,4 +694,15 @@ public class JCSMPOutboundMessageHandlerTest {
 				.build();
 		return createCorrelationKey(correlationData, msg);
 	}
+
+	@CartesianTest(name = "[{index}] transacted={0}")
+	public void test_startFailedForBadHeaderNameMapping(@Values(booleans = {false, true}) boolean transacted) {
+		producerProperties.getExtension().setTransacted(transacted);
+		producerProperties.getExtension().setHeaderNameMapping(Map.of("k1", "v1", "k2", "v1"));
+
+		assertThatThrownBy(() -> messageHandler.start())
+				.hasRootCauseInstanceOf(MessagingException.class)
+				.extracting(throwable -> throwable.getCause().getMessage()).asString()
+				.startsWith("Two or more headers map to the same header name in headerNameMapping");
+	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
@@ -701,7 +701,7 @@ public class JCSMPOutboundMessageHandlerTest {
 		producerProperties.getExtension().setHeaderNameMapping(Map.of("k1", "v1", "k2", "v1"));
 
 		assertThatThrownBy(() -> messageHandler.start())
-				.hasRootCauseInstanceOf(MessagingException.class)
+				.hasRootCauseInstanceOf(IllegalArgumentException.class)
 				.extracting(throwable -> throwable.getCause().getMessage()).asString()
 				.startsWith("Two or more headers map to the same header name in headerNameMapping");
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/JmsCompatibilityIT.java
@@ -6,6 +6,7 @@ import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
 import com.solace.spring.cloud.stream.binder.messaging.HeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
+import com.solace.spring.cloud.stream.binder.properties.SmfMessageReaderProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SmfMessageWriterProperties;
@@ -346,6 +347,7 @@ public class JmsCompatibilityIT {
 		}
 
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 		XMLMessageConsumer messageConsumer = null;
 		try {
 			Set<Class<? extends XMLMessage>> processedMessageTypes = new HashSet<>();
@@ -356,7 +358,7 @@ public class JmsCompatibilityIT {
 				public void onReceive(BytesXMLMessage bytesXMLMessage) {
 					LOGGER.info("Got message {}", bytesXMLMessage);
 					try {
-						Message<?> msg = xmlMessageMapper.mapToSpring(bytesXMLMessage, null, consumerProperties);
+						Message<?> msg = xmlMessageMapper.mapToSpring(bytesXMLMessage, null, smfMessageReaderProperties);
 						if (msg.getPayload() instanceof byte[]) {
 							softly.assertThat(msg.getPayload()).isEqualTo("test".getBytes());
 							processedMessageTypes.add(BytesMessage.class);
@@ -436,6 +438,7 @@ public class JmsCompatibilityIT {
 		message.setBooleanProperty(SolaceBinderHeaders.SERIALIZED_PAYLOAD, true);
 
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 		XMLMessageConsumer messageConsumer = null;
 		try {
 			AtomicReference<Exception> exceptionAtomicReference = new AtomicReference<>();
@@ -445,7 +448,7 @@ public class JmsCompatibilityIT {
 				public void onReceive(BytesXMLMessage bytesXMLMessage) {
 					LOGGER.info("Got message {}", bytesXMLMessage);
 					try {
-						softly.assertThat(xmlMessageMapper.mapToSpring(bytesXMLMessage, null, consumerProperties).getPayload())
+						softly.assertThat(xmlMessageMapper.mapToSpring(bytesXMLMessage, null, smfMessageReaderProperties).getPayload())
 								.isEqualTo(payload);
 					} catch (Exception e) {
 						exceptionAtomicReference.set(e);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -2326,34 +2326,6 @@ public class XMLMessageMapperTest {
 		assertEquals("some-value", properties.getString("original-unmapped-header"));
 	}
 
-	//@Test
-	void testApplyHeaderNameMapping_DuplicateSpringHeadersToSolaceUserPropertyNameMapping()
-			throws SDTException {
-		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
-		headerToUserPropertyKeyMapping.put("original-timestamp-header", "timestamp");
-		headerToUserPropertyKeyMapping.put("original-app-header", "timestamp");
-
-		Message<?> springMessage = MessageBuilder.withPayload("test")
-				.setHeader("original-timestamp-header", "2025-01-01T00:00:00Z")
-				.setHeader("original-app-header", "test-app")
-				.setHeader("original-unmapped-header", "some-value").build();
-
-		SolaceProducerProperties producerProperties = new SolaceProducerProperties();
-		producerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
-		SmfMessageWriterProperties writerProperties = new SmfMessageWriterProperties(
-				producerProperties);
-
-		XMLMessage xmlMessage = xmlMessageMapper.mapToSmf(springMessage, writerProperties);
-
-		//Log contains warning about duplicate mapping
-		SDTMap properties = xmlMessage.getProperties();
-		assertEquals("2025-01-01T00:00:00Z", properties.getString("timestamp"));
-
-		assertEquals("2025-01-01T00:00:00Z", properties.getString("original-timestamp-header"));
-		assertEquals("test-app", properties.getString("original-app-header"));
-		assertEquals("some-value", properties.getString("original-unmapped-header"));
-	}
-
 	@Test
 	void testApplyHeaderNameMapping_SolaceUserPropertiesToSpringHeadersMapping() throws SDTException {
 		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
@@ -2509,7 +2481,7 @@ public class XMLMessageMapperTest {
 		headerToUserPropertyKeyMapping.put("original-timestamp-header", "timestamp");
 		headerToUserPropertyKeyMapping.put("original-app-header", "app");
 
-		List<String> excludedHeaders = List.of("original-timestamp-header", "original-app-header");
+		List<String> excludedHeaders = List.of("original-timestamp-header");
 
 		Message<?> springMessage = MessageBuilder.withPayload("test")
 				.setHeader("original-timestamp-header", "2025-01-01T00:00:00Z")
@@ -2530,7 +2502,7 @@ public class XMLMessageMapperTest {
 
 		//Excluded headers should not be present in the properties
 		assertNull(properties.getString("original-timestamp-header"));
-		assertNull(properties.getString("original-app-header"));
+		assertEquals("test-app", properties.getString("original-app-header"));
 		assertEquals("some-value", properties.getString("original-unmapped-header"));
 	}
 

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/XMLMessageMapperTest.java
@@ -10,6 +10,7 @@ import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceHeaderMeta;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceHeaders;
+import com.solace.spring.cloud.stream.binder.properties.SmfMessageReaderProperties;
 import com.solace.spring.cloud.stream.binder.properties.SmfMessageWriterProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
@@ -29,6 +30,7 @@ import com.solacesystems.jcsmp.StreamMessage;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLContentMessage;
 import com.solacesystems.jcsmp.XMLMessage;
+import java.util.LinkedHashMap;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.assertj.core.api.Assertions;
@@ -106,6 +108,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class XMLMessageMapperTest {
@@ -880,8 +886,9 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
-		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
-		Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, consumerProperties);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
+		Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, smfMessageReaderProperties);
 
 		validateSpringPayload(springMessage.getPayload(), expectedPayload);
 		validateSpringHeaders(springMessage.getHeaders(), xmlMessage);
@@ -911,8 +918,9 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
-		Message<List<?>> springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
-		Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, consumerProperties);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+		Message<List<?>> springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
+		Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, smfMessageReaderProperties);
 
 		validateSpringBatchPayload(springMessage.getPayload(), expectedPayloads);
 		validateSpringBatchHeaders(springMessage.getHeaders(), xmlMessages);
@@ -936,7 +944,8 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
-		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, true, consumerProperties);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, true, smfMessageReaderProperties);
 
 		validateSpringPayload(springMessage.getPayload(), expectedPayload);
 		validateSpringHeaders(springMessage.getHeaders(), xmlMessage);
@@ -966,7 +975,8 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
-		Message<List<?>> springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, true, consumerProperties);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+		Message<List<?>> springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, true, smfMessageReaderProperties);
 
 		validateSpringBatchPayload(springMessage.getPayload(), expectedPayloads);
 		validateSpringBatchHeaders(springMessage.getHeaders(), xmlMessages);
@@ -997,19 +1007,20 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<MT> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, smfMessageReaderProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1118,20 +1129,21 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, smfMessageReaderProperties);
 
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 							.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1264,21 +1276,22 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, smfMessageReaderProperties);
 
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1328,21 +1341,22 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapBatchedToSpring(xmlMessages, acknowledgmentCallback, false, smfMessageReaderProperties);
 
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
-			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
+			Mockito.verify(xmlMessageMapper).mapToSpring(xmlMessage, acknowledgmentCallback, false, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1383,16 +1397,17 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 		MapAssert<String, Object> headersAssert;
 		if (batchMode) {
 			headersAssert = Assertions.assertThat(Objects.requireNonNull(xmlMessageMapper
-									.mapBatchedToSpring(Collections.singletonList(xmlMessage), acknowledgmentCallback, consumerProperties)
+									.mapBatchedToSpring(Collections.singletonList(xmlMessage), acknowledgmentCallback, smfMessageReaderProperties)
 									.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class))
 					.get(0))
 					.asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class));
 		} else {
-			headersAssert = Assertions.assertThat(xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties)
+			headersAssert = Assertions.assertThat(xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties)
 					.getHeaders());
 		}
 		headersAssert.extractingByKey(SolaceHeaders.DELIVERY_COUNT).isEqualTo(deliveryCount);
@@ -1415,18 +1430,19 @@ public class XMLMessageMapperTest {
 
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<TextMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1446,18 +1462,19 @@ public class XMLMessageMapperTest {
 		BytesMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(BytesMessage.class);
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
 		Message<?> springMessage;
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<BytesMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1474,8 +1491,9 @@ public class XMLMessageMapperTest {
 		xmlMessage.writeBytes(payload); // Write Payload as XML Attachment
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
-		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
 		MessageHeaders springMessageHeaders = springMessage.getHeaders();
 
 		assertNull(springMessageHeaders.get(SolaceBinderHeaders.NULL_PAYLOAD, Boolean.class));
@@ -1499,13 +1517,14 @@ public class XMLMessageMapperTest {
 		xmlMessage.setProperties(metadata);
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
 		Message<?> springMessage;
 		if (batchMode) {
 			springMessage = xmlMessageMapper.mapBatchedToSpring(Collections.singletonList(xmlMessage),
-					acknowledgmentCallback, consumerProperties);
+					acknowledgmentCallback, smfMessageReaderProperties);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
 		}
 
 		if (batchMode) {
@@ -1609,7 +1628,8 @@ public class XMLMessageMapperTest {
 		List<String> serializedHeaders = Arrays.asList(key, key);
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of());
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(new SolaceConsumerProperties()));
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
@@ -1623,25 +1643,11 @@ public class XMLMessageMapperTest {
 		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
 		sdtMap.putObject(key, null);
 
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of());
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(new SolaceConsumerProperties()));
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertNull(messageHeaders.get(key));
-	}
-
-	@Test
-	void testMapSDTMapToMessageHeaders_WithNullExcludedHeader() throws Exception {
-		SDTMap sdtMap = JCSMPFactory.onlyInstance().createMap();
-		for (int i = 0; i < 10; i++) {
-			sdtMap.putObject("headerKey" + i, UUID.randomUUID().toString());
-		}
-
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, null);
-
-		for (int i = 0; i < 10; i++) {
-			String key = "headerKey" + i;
-			assertEquals(sdtMap.get(key), messageHeaders.get(key));
-		}
 	}
 
 	@ParameterizedTest(name = "[{index}] batchMode={0}")
@@ -1655,6 +1661,7 @@ public class XMLMessageMapperTest {
 		AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
 		consumerProperties.setHeaderExclusions(excludedHeaders);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 
 		SDTMap metadata = JCSMPFactory.onlyInstance().createMap();
 		Mockito.when(xmlMessage.getProperties()).thenReturn(metadata);
@@ -1666,13 +1673,13 @@ public class XMLMessageMapperTest {
 		MessageHeaders springMessageHeaders;
 		if (batchMode) {
 			List<BytesMessage> xmlMessages = Collections.singletonList(xmlMessage);
-			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapBatchedToSpring(xmlMessages, acknowledgmentCallback, smfMessageReaderProperties);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> messageHeaders = (Map<String, Object>) Objects.requireNonNull(springMessage.getHeaders()
 					.get(SolaceBinderHeaders.BATCHED_HEADERS, List.class)).get(0);
 			springMessageHeaders = new MessageHeaders(messageHeaders);
 		} else {
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
 			springMessageHeaders = springMessage.getHeaders();
 		}
 
@@ -1694,7 +1701,10 @@ public class XMLMessageMapperTest {
 		}
 
 		List<String> excludedHeaders = List.of("headerKey1", "headerKey2", "headerKey5");
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, excludedHeaders);
+		SolaceConsumerProperties solaceConsumerProperties = new SolaceConsumerProperties();
+		solaceConsumerProperties.setHeaderExclusions(excludedHeaders);
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(solaceConsumerProperties));
 
 		for (int i = 0; i < 10; i++) {
 			String key = "headerKey" + i;
@@ -1714,7 +1724,10 @@ public class XMLMessageMapperTest {
 		sdtMap.putObject("retainedHeader", "test");
 
 		List<String> excludedHeaders = List.of(SolaceBinderHeaders.MESSAGE_VERSION, SolaceBinderHeaders.SERIALIZED_HEADERS);
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, excludedHeaders);
+		SolaceConsumerProperties solaceConsumerProperties = new SolaceConsumerProperties();
+		solaceConsumerProperties.setHeaderExclusions(excludedHeaders);
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(solaceConsumerProperties));
 
 		sdtMap.keySet().forEach(key -> {
 			if (excludedHeaders.contains(key)) {
@@ -1739,7 +1752,8 @@ public class XMLMessageMapperTest {
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "base64");
 
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of());
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(new SolaceConsumerProperties()));
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
@@ -1754,7 +1768,8 @@ public class XMLMessageMapperTest {
 		Set<String> serializedHeaders = Collections.singleton(key);
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of());
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(new SolaceConsumerProperties()));
 
 		assertThat(messageHeaders.keySet(), not(hasItem(key)));
 		assertThat(messageHeaders.keySet(), not(hasItem(SolaceBinderHeaders.SERIALIZED_HEADERS)));
@@ -1769,7 +1784,8 @@ public class XMLMessageMapperTest {
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS, objectWriter.writeValueAsString(serializedHeaders));
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "base64");
 
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of());
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(new SolaceConsumerProperties()));
 
 		assertThat(messageHeaders.keySet(), hasItem(key));
 		assertNull(messageHeaders.get(key));
@@ -1787,7 +1803,7 @@ public class XMLMessageMapperTest {
 		sdtMap.putString(SolaceBinderHeaders.SERIALIZED_HEADERS_ENCODING, "abc");
 
 		SolaceMessageConversionException exception = assertThrows(SolaceMessageConversionException.class,
-				() -> xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of()));
+				() -> xmlMessageMapper.mapHeadersToSpring(sdtMap, new SmfMessageReaderProperties(new SolaceConsumerProperties())));
 		assertThat(exception.getMessage(), containsString("encoding is not supported"));
 	}
 
@@ -1799,7 +1815,8 @@ public class XMLMessageMapperTest {
 			sdtMap.putBytes(header, value);
 		}
 
-		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap, List.of());
+		MessageHeaders messageHeaders = xmlMessageMapper.mapHeadersToSpring(sdtMap,
+				new SmfMessageReaderProperties(new SolaceConsumerProperties()));
 
 		for (String header : JMS_INVALID_HEADER_NAMES) {
 			assertThat(messageHeaders.keySet(), hasItem(header));
@@ -1826,6 +1843,7 @@ public class XMLMessageMapperTest {
 		expectedXmlMessage.setHTTPContentType(MimeTypeUtils.TEXT_PLAIN_VALUE);
 
 		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
 		Message<?> springMessage = expectedSpringMessage;
 		XMLMessage xmlMessage;
 		int i = 0;
@@ -1838,7 +1856,7 @@ public class XMLMessageMapperTest {
 
 			LOGGER.info("Iteration {} - XMLMessage to Message<?>:\n{}", i, xmlMessage);
 			AcknowledgmentCallback acknowledgmentCallback = Mockito.mock(AcknowledgmentCallback.class);
-			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, consumerProperties);
+			springMessage = xmlMessageMapper.mapToSpring(xmlMessage, acknowledgmentCallback, smfMessageReaderProperties);
 			validateSpringHeaders(springMessage.getHeaders(), expectedXmlMessage);
 
 			// Update the expected default spring headers
@@ -2279,5 +2297,275 @@ public class XMLMessageMapperTest {
 				Arguments.of(JCSMPFactory.onlyInstance().createMessage(MapMessage.class)),
 				Arguments.of(JCSMPFactory.onlyInstance().createMessage(StreamMessage.class))
 		);
+	}
+
+	@Test
+	void testApplyHeaderNameMapping_SpringHeadersToSolaceUserPropertyNameMapping() throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("original-timestamp-header", "timestamp");
+		headerToUserPropertyKeyMapping.put("original-app-header", "app");
+
+		Message<?> springMessage = MessageBuilder.withPayload("test")
+				.setHeader("original-timestamp-header", "2025-01-01T00:00:00Z")
+				.setHeader("original-app-header", "test-app")
+				.setHeader("original-unmapped-header", "some-value").build();
+
+		SolaceProducerProperties producerProperties = new SolaceProducerProperties();
+		producerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		SmfMessageWriterProperties writerProperties = new SmfMessageWriterProperties(
+				producerProperties);
+
+		XMLMessage xmlMessage = xmlMessageMapper.mapToSmf(springMessage, writerProperties);
+
+		SDTMap properties = xmlMessage.getProperties();
+		assertEquals("2025-01-01T00:00:00Z", properties.getString("timestamp"));
+		assertEquals("test-app", properties.getString("app"));
+
+		assertEquals("2025-01-01T00:00:00Z", properties.getString("original-timestamp-header"));
+		assertEquals("test-app", properties.getString("original-app-header"));
+		assertEquals("some-value", properties.getString("original-unmapped-header"));
+	}
+
+	//@Test
+	void testApplyHeaderNameMapping_DuplicateSpringHeadersToSolaceUserPropertyNameMapping()
+			throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("original-timestamp-header", "timestamp");
+		headerToUserPropertyKeyMapping.put("original-app-header", "timestamp");
+
+		Message<?> springMessage = MessageBuilder.withPayload("test")
+				.setHeader("original-timestamp-header", "2025-01-01T00:00:00Z")
+				.setHeader("original-app-header", "test-app")
+				.setHeader("original-unmapped-header", "some-value").build();
+
+		SolaceProducerProperties producerProperties = new SolaceProducerProperties();
+		producerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		SmfMessageWriterProperties writerProperties = new SmfMessageWriterProperties(
+				producerProperties);
+
+		XMLMessage xmlMessage = xmlMessageMapper.mapToSmf(springMessage, writerProperties);
+
+		//Log contains warning about duplicate mapping
+		SDTMap properties = xmlMessage.getProperties();
+		assertEquals("2025-01-01T00:00:00Z", properties.getString("timestamp"));
+
+		assertEquals("2025-01-01T00:00:00Z", properties.getString("original-timestamp-header"));
+		assertEquals("test-app", properties.getString("original-app-header"));
+		assertEquals("some-value", properties.getString("original-unmapped-header"));
+	}
+
+	@Test
+	void testApplyHeaderNameMapping_SolaceUserPropertiesToSpringHeadersMapping() throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("id", "mapped-id-header");
+		headerToUserPropertyKeyMapping.put("timestamp", "mapped-timestamp-header");
+		headerToUserPropertyKeyMapping.put("app", "mapped-app-header");
+
+		TextMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
+		xmlMessage.setText("test");
+		SDTMap properties = JCSMPFactory.onlyInstance().createMap();
+		properties.putString("id", "12345");
+		properties.putString("timestamp", "2025-01-01T00:00:00Z");
+		properties.putString("app", "test-app");
+		properties.putString("unmapped-user-prop", "some-value");
+		xmlMessage.setProperties(properties);
+
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, null, smfMessageReaderProperties);
+
+		assertEquals("12345", springMessage.getHeaders().get("mapped-id-header"));
+		assertEquals("2025-01-01T00:00:00Z", springMessage.getHeaders().get("mapped-timestamp-header"));
+		assertEquals("test-app", springMessage.getHeaders().get("mapped-app-header"));
+
+		//id and timestamp is Spring Integration reserved headers, original values will not be preserved
+		assertNotEquals("12345", springMessage.getHeaders().get("id"));
+		assertNotEquals("2025-01-01T00:00:00Z", springMessage.getHeaders().get("timestamp"));
+		assertNotNull(springMessage.getHeaders().get("id"));
+		assertNotNull(springMessage.getHeaders().get("timestamp"));
+		assertEquals("test-app", springMessage.getHeaders().get("app"));
+		assertEquals("some-value", springMessage.getHeaders().get("unmapped-user-prop"));
+	}
+
+	//@Test
+	void testApplyHeaderNameMapping_DuplicateSolaceUserPropertiesToSpringHeadersMapping()
+			throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("timestamp", "mapped-timestamp-header");
+		headerToUserPropertyKeyMapping.put("app", "mapped-timestamp-header");
+
+		TextMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
+		xmlMessage.setText("test");
+		SDTMap properties = JCSMPFactory.onlyInstance().createMap();
+		properties.putString("timestamp", "2025-01-01T00:00:00Z");
+		properties.putString("app", "test-app");
+		properties.putString("unmapped-user-prop", "some-value");
+		xmlMessage.setProperties(properties);
+
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, null, smfMessageReaderProperties);
+
+		assertEquals("2025-01-01T00:00:00Z", springMessage.getHeaders().get("mapped-timestamp-header"));
+
+		//id and timestamp is Spring Integration reserved headers, original values will not be preserved
+		assertNotEquals("2025-01-01T00:00:00Z", springMessage.getHeaders().get("timestamp"));
+		assertNotNull(springMessage.getHeaders().get("timestamp"));
+		assertEquals("test-app", springMessage.getHeaders().get("app"));
+		assertEquals("some-value", springMessage.getHeaders().get("unmapped-user-prop"));
+	}
+
+	@ParameterizedTest(name = "{index} testApplyHeaderNameMapping_ProducerBackwardCompatibility - {1}")
+	@MethodSource("publisherBackwardCompatibilityArguments")
+	void testApplyHeaderNameMapping_ProducerBackwardCompatibility(
+			SolaceProducerProperties producerProperties, String scenario) throws SDTException {
+		Message<?> springMessage = MessageBuilder.withPayload("test").setHeader("my-header", "my-value")
+				.build();
+
+		SmfMessageWriterProperties writerProperties = new SmfMessageWriterProperties(
+				producerProperties);
+		XMLMessage xmlMessage = xmlMessageMapper.mapToSmf(springMessage, writerProperties);
+
+		verify(xmlMessageMapper).applyHeaderNameMapping(anyMap(),
+				eq(writerProperties.getHeaderNameMapping()));
+
+		SDTMap properties = xmlMessage.getProperties();
+		assertEquals("my-value", properties.getString("my-header"));
+	}
+
+	private static Stream<Arguments> publisherBackwardCompatibilityArguments() {
+		SolaceProducerProperties producerPropertiesWithEmptyHeaderMapping = new SolaceProducerProperties();
+		producerPropertiesWithEmptyHeaderMapping.setHeaderNameMapping(
+				new LinkedHashMap<>());
+
+		return Stream.of(arguments(new SolaceProducerProperties(), "Default Producer Properties"),
+				arguments(producerPropertiesWithEmptyHeaderMapping,
+						"Producer Properties with Empty Mapping"));
+	}
+
+	@ParameterizedTest(name = "{index} testApplyHeaderNameMapping_ConsumerBackwardCompatibility - {1}")
+	@MethodSource("consumerBackwardCompatibilityArguments")
+	void testApplyHeaderNameMapping_ConsumerBackwardCompatibility(
+			SolaceConsumerProperties consumerProperties, String scenario) throws SDTException {
+		TextMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
+		xmlMessage.setText("test");
+		SDTMap properties = JCSMPFactory.onlyInstance().createMap();
+		properties.putString("my-header", "my-value");
+		xmlMessage.setProperties(properties);
+
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, null,
+				smfMessageReaderProperties);
+
+		verify(xmlMessageMapper).applyHeaderNameMapping(anyMap(), anyMap());
+
+		assertEquals("my-value", springMessage.getHeaders().get("my-header"));
+	}
+
+	private static Stream<Arguments> consumerBackwardCompatibilityArguments() {
+		SolaceConsumerProperties consumerPropertiesWithEmptyHeaderMapping = new SolaceConsumerProperties();
+		consumerPropertiesWithEmptyHeaderMapping.setHeaderNameMapping(
+				new LinkedHashMap<>());
+
+		return Stream.of(arguments(new SolaceConsumerProperties(), "Default Consumer Properties"),
+				arguments(consumerPropertiesWithEmptyHeaderMapping,
+						"Consumer Properties with Empty Mapping"));
+	}
+
+	@Test
+	void testApplyHeaderNameMapping_MultipleMappingsAndTypes() throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("string-header", "str");
+		headerToUserPropertyKeyMapping.put("number-header", "num");
+		headerToUserPropertyKeyMapping.put("boolean-header", "bool");
+
+		// Create test message with different types
+		Message<?> springMessage = MessageBuilder.withPayload("test")
+				.setHeader("string-header", "string-value").setHeader("number-header", 42)
+				.setHeader("boolean-header", true).setHeader("unmapped-header", "unmapped-value").build();
+
+		SolaceProducerProperties producerProperties = new SolaceProducerProperties();
+		producerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		SmfMessageWriterProperties writerProperties = new SmfMessageWriterProperties(
+				producerProperties);
+		XMLMessage xmlMessage = xmlMessageMapper.mapToSmf(springMessage, writerProperties);
+
+		// Verify all mappings work correctly
+		SDTMap properties = xmlMessage.getProperties();
+		assertEquals("string-value", properties.getString("str"));
+		assertEquals(42, properties.getInteger("num").intValue());
+		assertEquals(true, properties.getBoolean("bool"));
+		assertEquals("unmapped-value", properties.getString("unmapped-header"));
+	}
+
+	@Test
+	void testApplyHeaderNameMapping_producerHeaderExclusionWithMapping() throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("original-timestamp-header", "timestamp");
+		headerToUserPropertyKeyMapping.put("original-app-header", "app");
+
+		List<String> excludedHeaders = List.of("original-timestamp-header", "original-app-header");
+
+		Message<?> springMessage = MessageBuilder.withPayload("test")
+				.setHeader("original-timestamp-header", "2025-01-01T00:00:00Z")
+				.setHeader("original-app-header", "test-app")
+				.setHeader("original-unmapped-header", "some-value").build();
+
+		SolaceProducerProperties producerProperties = new SolaceProducerProperties();
+		producerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		producerProperties.setHeaderExclusions(excludedHeaders);
+		SmfMessageWriterProperties writerProperties = new SmfMessageWriterProperties(
+				producerProperties);
+
+		XMLMessage xmlMessage = xmlMessageMapper.mapToSmf(springMessage, writerProperties);
+
+		SDTMap properties = xmlMessage.getProperties();
+		assertEquals("2025-01-01T00:00:00Z", properties.getString("timestamp"));
+		assertEquals("test-app", properties.getString("app"));
+
+		//Excluded headers should not be present in the properties
+		assertNull(properties.getString("original-timestamp-header"));
+		assertNull(properties.getString("original-app-header"));
+		assertEquals("some-value", properties.getString("original-unmapped-header"));
+	}
+
+	@Test
+	void testApplyHeaderNameMapping_consumerHeaderExclusionWithMapping() throws SDTException {
+		Map<String, String> headerToUserPropertyKeyMapping = new LinkedHashMap<>();
+		headerToUserPropertyKeyMapping.put("timestamp", "mapped-timestamp-header");
+		headerToUserPropertyKeyMapping.put("excluded-header", "mapped-excluded-header");
+
+		List<String> excludedHeaders = List.of("excluded-header");
+
+		TextMessage xmlMessage = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
+		xmlMessage.setText("test");
+		SDTMap properties = JCSMPFactory.onlyInstance().createMap();
+		properties.putString("timestamp", "2025-01-01T00:00:00Z");
+		properties.putString("unmapped-user-prop", "some-value");
+		properties.putString("excluded-header", "some-value");
+		xmlMessage.setProperties(properties);
+
+		SolaceConsumerProperties consumerProperties = new SolaceConsumerProperties();
+		consumerProperties.setHeaderNameMapping(headerToUserPropertyKeyMapping);
+		consumerProperties.setHeaderExclusions(excludedHeaders);
+		SmfMessageReaderProperties smfMessageReaderProperties = new SmfMessageReaderProperties(consumerProperties);
+
+		Message<?> springMessage = xmlMessageMapper.mapToSpring(xmlMessage, null, smfMessageReaderProperties);
+
+		assertEquals("2025-01-01T00:00:00Z", springMessage.getHeaders().get("mapped-timestamp-header"));
+
+		//timestamp is Spring Integration reserved headers, original values will not be preserved
+		assertNotEquals("2025-01-01T00:00:00Z", springMessage.getHeaders().get("timestamp"));
+		assertNotNull(springMessage.getHeaders().get("timestamp"));
+		assertEquals("some-value", springMessage.getHeaders().get("unmapped-user-prop"));
+
+		//Excluded header should not be present in the Spring message headers, and won't be mapped
+		assertNull(springMessage.getHeaders().get("mapped-excluded-header"));
+		assertNull(springMessage.getHeaders().get("excluded-header"));
 	}
 }


### PR DESCRIPTION
Add header name mapping functionality for propagating reserved headers between Solace and Spring messaging systems