### PR TITLE
Lazy Solace session initialization

### DIFF
--- a/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
+++ b/solace-spring-cloud-starters/solace-spring-cloud-stream-starter/README.adoc
@@ -180,6 +180,19 @@ See https://github.com/SolaceProducts/solace-spring-boot/tree/master/solace-spri
 The Solace session can be configured to use OAuth2 authentication. See https://github.com/SolaceDev/solace-spring-boot/tree/master/solace-spring-boot-starters/solace-java-spring-boot-starter#using-oauth2-authentication-scheme-with-solace-java-api[JCSMP Spring Boot: Using OAuth2 Authentication Scheme] for more info.
 ====
 
+==== Solace Binder Properties
+
+The following properties are available for configuring the Solace binder itself and must be prefixed with `spring.cloud.stream.solace.binder.`.
+
+sessionInitializationMode::
+Specifies when the Solace session should be initialized for the binder.
++
+When set to `lazy`, the session will be created only when the first binding (producer or consumer) is created that requires it.
++
+When set to `eager`, the session will be created immediately when the binder is initialized, regardless of whether any bindings exist.
++
+Default: `eager`
+
 ==== Solace Consumer Properties
 
 The following properties are available for Solace consumers only and must be prefixed with `spring.cloud.stream.solace.bindings.&lt;bindingName&gt;.consumer.` where `bindingName` looks something like `functionName-in-0` as defined in https://docs.spring.io/spring-cloud-stream/reference/{scst-version}/spring-cloud-stream/functional-binding-names.html[Functional Binding Names].

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/handlers/SolaceSessionEventHandler.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/health/handlers/SolaceSessionEventHandler.java
@@ -34,4 +34,12 @@ public class SolaceSessionEventHandler extends DefaultSolaceOAuth2SessionEventHa
 	public void setSessionHealthUp() {
 		this.sessionHealthIndicator.up();
 	}
+
+	public void setSessionHealthDown() {
+		this.sessionHealthIndicator.down(null, false);
+	}
+
+	public void setSessionHealthReconnecting() {
+		this.sessionHealthIndicator.reconnecting(null);
+	}
 }

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceBinderConfigurationProperties.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceBinderConfigurationProperties.java
@@ -1,0 +1,20 @@
+package com.solace.spring.cloud.stream.binder.properties;
+
+
+import com.solace.spring.cloud.stream.binder.util.SessionInitializationMode;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.cloud.stream.solace.binder")
+public class SolaceBinderConfigurationProperties {
+
+
+  private SessionInitializationMode sessionInitializationMode = SessionInitializationMode.EAGER;
+
+  public SessionInitializationMode getSessionInitializationMode() {
+    return sessionInitializationMode;
+  }
+
+  public void setSessionInitializationMode(SessionInitializationMode sessionInitializationMode) {
+    this.sessionInitializationMode = sessionInitializationMode;
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/DefaultSolaceSessionManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/DefaultSolaceSessionManager.java
@@ -1,0 +1,129 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import static com.solacesystems.jcsmp.XMLMessage.Outcome.ACCEPTED;
+import static com.solacesystems.jcsmp.XMLMessage.Outcome.FAILED;
+import static com.solacesystems.jcsmp.XMLMessage.Outcome.REJECTED;
+
+import com.solace.spring.cloud.stream.binder.health.handlers.SolaceSessionEventHandler;
+import com.solacesystems.jcsmp.Context;
+import com.solacesystems.jcsmp.ContextProperties;
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.SolaceSessionOAuth2TokenProvider;
+import com.solacesystems.jcsmp.SpringJCSMPFactory;
+import com.solacesystems.jcsmp.impl.JCSMPBasicSession;
+import com.solacesystems.jcsmp.impl.client.ClientInfoProvider;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+
+public class DefaultSolaceSessionManager implements SolaceSessionManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolaceSessionManager.class);
+
+  private final JCSMPProperties jcsmpProperties;
+  private final ClientInfoProvider clientInfoProvider;
+  private final SolaceSessionEventHandler solaceSessionEventHandler;
+  private final SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider;
+
+  private volatile JCSMPSession jcsmpSession;
+  private volatile Context context;
+  private final Object sessionLock = new Object();
+
+  public DefaultSolaceSessionManager(JCSMPProperties jcsmpProperties,
+      @Nullable ClientInfoProvider clientInfoProvider,
+      @Nullable SolaceSessionEventHandler eventHandler,
+      @Nullable SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider) {
+    this.jcsmpProperties = jcsmpProperties;
+    this.clientInfoProvider = clientInfoProvider;
+    this.solaceSessionEventHandler = eventHandler;
+    this.solaceSessionOAuth2TokenProvider = solaceSessionOAuth2TokenProvider;
+  }
+
+  @Override
+  public JCSMPSession getSession() throws JCSMPException {
+    if (jcsmpSession == null) {
+      createSessionIfNeeded();
+    }
+    return jcsmpSession;
+  }
+
+  private void createSessionIfNeeded() throws JCSMPException {
+    if (jcsmpSession != null) {
+      return;
+    }
+
+    synchronized (sessionLock) {
+      if (jcsmpSession != null) {
+        return;
+      }
+
+      JCSMPProperties solaceJcsmpProperties = (JCSMPProperties) this.jcsmpProperties.clone();
+      if (this.clientInfoProvider != null) {
+        solaceJcsmpProperties.setProperty(JCSMPProperties.CLIENT_INFO_PROVIDER, clientInfoProvider);
+      }
+
+      try {
+        SpringJCSMPFactory springJCSMPFactory = new SpringJCSMPFactory(solaceJcsmpProperties,
+            solaceSessionOAuth2TokenProvider);
+
+        if (solaceSessionEventHandler != null) {
+          LOGGER.debug("Registering Solace Session Event handler on session");
+          context = springJCSMPFactory.createContext(new ContextProperties());
+          jcsmpSession = springJCSMPFactory.createSession(context, solaceSessionEventHandler);
+        } else {
+          jcsmpSession = springJCSMPFactory.createSession();
+        }
+
+        if (solaceSessionEventHandler != null) {
+          solaceSessionEventHandler.setSessionHealthDown();
+        }
+
+        LOGGER.info("Connecting JCSMP session {}", jcsmpSession.getSessionName());
+        jcsmpSession.connect();
+
+        if (solaceSessionEventHandler != null) {
+          solaceSessionEventHandler.setSessionHealthUp();
+        }
+
+        // Check broker compatibility
+        if (jcsmpSession instanceof JCSMPBasicSession session
+            && !session.isRequiredSettlementCapable(Set.of(ACCEPTED, FAILED, REJECTED))) {
+          LOGGER.warn("The connected Solace PubSub+ Broker is not compatible. It doesn't support message NACK capability. Consumer bindings will fail to start.");
+        }
+
+        LOGGER.info("Successfully created and connected Solace JCSMP session");
+      } catch (JCSMPException e) {
+        LOGGER.error("Failed to initialize Solace JCSMP session", e);
+        throw e;
+      }
+    }
+  }
+
+  public void close() {
+    synchronized (sessionLock) {
+      if (jcsmpSession != null) {
+        try {
+          LOGGER.info("Closing JCSMP session {}", jcsmpSession.getSessionName());
+          jcsmpSession.closeSession();
+        } catch (Exception e) {
+          LOGGER.warn("Error closing JCSMP session", e);
+        } finally {
+          jcsmpSession = null;
+        }
+      }
+
+      if (context != null) {
+        try {
+          context.destroy();
+        } catch (Exception e) {
+          LOGGER.warn("Error destroying JCSMP context", e);
+        } finally {
+          context = null;
+        }
+      }
+    }
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/JCSMPSessionProducerManager.java
@@ -1,7 +1,6 @@
 package com.solace.spring.cloud.stream.binder.util;
 
 import com.solacesystems.jcsmp.JCSMPException;
-import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 import org.slf4j.Logger;
@@ -15,19 +14,19 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class JCSMPSessionProducerManager extends SharedResourceManager<XMLMessageProducer> {
-	private final JCSMPSession session;
+	private final SolaceSessionManager solaceSessionManager;
 	private final CloudStreamEventHandler publisherEventHandler = new CloudStreamEventHandler();
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(JCSMPSessionProducerManager.class);
 
-	public JCSMPSessionProducerManager(JCSMPSession session) {
+	public JCSMPSessionProducerManager(SolaceSessionManager solaceSessionManager) {
 		super("producer");
-		this.session = session;
+		this.solaceSessionManager = solaceSessionManager;
 	}
 
 	@Override
 	XMLMessageProducer create() throws JCSMPException {
-		return session.getMessageProducer(publisherEventHandler);
+		return solaceSessionManager.getSession().getMessageProducer(publisherEventHandler);
 	}
 
 	@Override

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SessionInitializationMode.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SessionInitializationMode.java
@@ -1,0 +1,7 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+public enum SessionInitializationMode {
+
+  EAGER,
+  LAZY;
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceSessionManager.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/main/java/com/solace/spring/cloud/stream/binder/util/SolaceSessionManager.java
@@ -1,0 +1,9 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPSession;
+
+public interface SolaceSessionManager {
+
+  JCSMPSession getSession() throws JCSMPException;
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/acknowledge/JCSMPAcknowledgementCallbackFactoryIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/acknowledge/JCSMPAcknowledgementCallbackFactoryIT.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder.inbound.acknowledge;
 
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.util.DefaultSolaceSessionManager;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.ErrorQueueInfrastructure;
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
@@ -828,29 +829,36 @@ public class JCSMPAcknowledgementCallbackFactoryIT {
 			throw new IllegalStateException("Should only have one error queue infrastructure");
 		}
 
-		String producerManagerKey = UUID.randomUUID().toString();
-		JCSMPSessionProducerManager jcsmpSessionProducerManager = new JCSMPSessionProducerManager(jcsmpSession);
-		ErrorQueueInfrastructure errorQueueInfrastructure = new ErrorQueueInfrastructure(jcsmpSessionProducerManager,
-				producerManagerKey, RandomStringUtils.randomAlphanumeric(20), new SolaceConsumerProperties());
-		Queue errorQueue = JCSMPFactory.onlyInstance().createQueue(errorQueueInfrastructure.getErrorQueueName());
-		ackCallbackFactory.setErrorQueueInfrastructure(errorQueueInfrastructure);
-		closeErrorQueueInfrastructureCallback = () -> {
-			jcsmpSessionProducerManager.release(producerManagerKey);
-
-			try {
-				jcsmpSession.deprovision(errorQueue, JCSMPSession.WAIT_FOR_CONFIRM);
-			} catch (JCSMPException e) {
-				throw new RuntimeException(e);
-			}
-		};
-
 		try {
+			DefaultSolaceSessionManager defaultSolaceSessionManager = Mockito.mock(
+					DefaultSolaceSessionManager.class);
+			when(defaultSolaceSessionManager.getSession()).thenReturn(jcsmpSession);
+
+			String producerManagerKey = UUID.randomUUID().toString();
+			JCSMPSessionProducerManager jcsmpSessionProducerManager = new JCSMPSessionProducerManager(
+					defaultSolaceSessionManager);
+			ErrorQueueInfrastructure errorQueueInfrastructure = new ErrorQueueInfrastructure(
+					jcsmpSessionProducerManager,
+					producerManagerKey, RandomStringUtils.randomAlphanumeric(20),
+					new SolaceConsumerProperties());
+			Queue errorQueue = JCSMPFactory.onlyInstance()
+					.createQueue(errorQueueInfrastructure.getErrorQueueName());
+			ackCallbackFactory.setErrorQueueInfrastructure(errorQueueInfrastructure);
+			closeErrorQueueInfrastructureCallback = () -> {
+				jcsmpSessionProducerManager.release(producerManagerKey);
+
+				try {
+					jcsmpSession.deprovision(errorQueue, JCSMPSession.WAIT_FOR_CONFIRM);
+				} catch (JCSMPException e) {
+					throw new RuntimeException(e);
+				}
+			};
+
 			jcsmpSession.provision(errorQueue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+			return errorQueueInfrastructure;
 		} catch (JCSMPException e) {
 			throw new RuntimeException(e);
 		}
-
-		return errorQueueInfrastructure;
 	}
 
 	private void validateNumEnqueuedMessages(SempV2Api sempV2Api, String queueName, int expectedCount)

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/acknowledge/SolaceAckUtilIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/inbound/acknowledge/SolaceAckUtilIT.java
@@ -1,6 +1,7 @@
 package com.solace.spring.cloud.stream.binder.inbound.acknowledge;
 
 import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.util.DefaultSolaceSessionManager;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.util.ErrorQueueInfrastructure;
 import com.solace.spring.cloud.stream.binder.util.FlowReceiverContainer;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.acks.AcknowledgmentCallback.Status;
@@ -201,33 +203,35 @@ class SolaceAckUtilIT {
       throw new IllegalStateException("Should only have one error queue infrastructure");
     }
 
-    String producerManagerKey = UUID.randomUUID().toString();
-    JCSMPSessionProducerManager jcsmpSessionProducerManager = new JCSMPSessionProducerManager(
-        jcsmpSession);
-    ErrorQueueInfrastructure errorQueueInfrastructure = new ErrorQueueInfrastructure(
-        jcsmpSessionProducerManager,
-        producerManagerKey, RandomStringUtils.randomAlphanumeric(20),
-        new SolaceConsumerProperties());
-    Queue errorQueue = JCSMPFactory.onlyInstance()
-        .createQueue(errorQueueInfrastructure.getErrorQueueName());
-    ackCallbackFactory.setErrorQueueInfrastructure(errorQueueInfrastructure);
-    closeErrorQueueInfrastructureCallback = () -> {
-      jcsmpSessionProducerManager.release(producerManagerKey);
-
-      try {
-        jcsmpSession.deprovision(errorQueue, JCSMPSession.WAIT_FOR_CONFIRM);
-      } catch (JCSMPException e) {
-        throw new RuntimeException(e);
-      }
-    };
-
     try {
+      String producerManagerKey = UUID.randomUUID().toString();
+      DefaultSolaceSessionManager defaultSolaceSessionManager = Mockito.mock(
+          DefaultSolaceSessionManager.class);
+      Mockito.when(defaultSolaceSessionManager.getSession()).thenReturn(jcsmpSession);
+      JCSMPSessionProducerManager jcsmpSessionProducerManager = new JCSMPSessionProducerManager(
+          defaultSolaceSessionManager);
+      ErrorQueueInfrastructure errorQueueInfrastructure = new ErrorQueueInfrastructure(
+          jcsmpSessionProducerManager,
+          producerManagerKey, RandomStringUtils.randomAlphanumeric(20),
+          new SolaceConsumerProperties());
+      Queue errorQueue = JCSMPFactory.onlyInstance()
+          .createQueue(errorQueueInfrastructure.getErrorQueueName());
+      ackCallbackFactory.setErrorQueueInfrastructure(errorQueueInfrastructure);
+      closeErrorQueueInfrastructureCallback = () -> {
+        jcsmpSessionProducerManager.release(producerManagerKey);
+
+        try {
+          jcsmpSession.deprovision(errorQueue, JCSMPSession.WAIT_FOR_CONFIRM);
+        } catch (JCSMPException e) {
+          throw new RuntimeException(e);
+        }
+      };
+
       jcsmpSession.provision(errorQueue, new EndpointProperties(), JCSMPSession.WAIT_FOR_CONFIRM);
+      return errorQueueInfrastructure;
     } catch (JCSMPException e) {
       throw new RuntimeException(e);
     }
-
-    return errorQueueInfrastructure;
   }
 
   private List<MessageContainer> sendAndReceiveMessages(Queue queue,

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
@@ -1,5 +1,6 @@
 package com.solace.spring.cloud.stream.binder.outbound;
 
+import com.solace.spring.cloud.stream.binder.util.DefaultSolaceSessionManager;
 import com.solace.spring.cloud.stream.binder.messaging.SolaceBinderHeaders;
 import com.solace.spring.cloud.stream.binder.meter.SolaceMeterAccessor;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
@@ -107,7 +108,11 @@ public class JCSMPOutboundMessageHandlerTest {
 		producerProperties = new ExtendedProducerProperties<>(new SolaceProducerProperties());
 		producerProperties.populateBindingName(RandomStringUtils.randomAlphanumeric(100));
 
-		sessionProducerManager = Mockito.spy(new JCSMPSessionProducerManager(session));
+		DefaultSolaceSessionManager defaultSolaceSessionManager = Mockito.mock(
+				DefaultSolaceSessionManager.class);
+		Mockito.lenient().when(defaultSolaceSessionManager.getSession()).thenReturn(session);
+		sessionProducerManager = Mockito.spy(new JCSMPSessionProducerManager(
+				defaultSolaceSessionManager));
 
 		messageHandler = new JCSMPOutboundMessageHandler(
 				dest,
@@ -504,11 +509,15 @@ public class JCSMPOutboundMessageHandlerTest {
 		ProducerDestination dest = Mockito.mock(ProducerDestination.class);
 		Mockito.when(dest.getName()).thenReturn("thisIsOverriddenByDynamicDestinationName");
 
+		DefaultSolaceSessionManager defaultSolaceSessionManager = Mockito.mock(
+				DefaultSolaceSessionManager.class);
+		Mockito.when(defaultSolaceSessionManager.getSession()).thenReturn(session);
+
 		messageHandler = new JCSMPOutboundMessageHandler(
 				dest,
 				session,
 				null,
-				new JCSMPSessionProducerManager(session),
+				new JCSMPSessionProducerManager(defaultSolaceSessionManager),
 				new ExtendedProducerProperties<>(producerProperties),
 				solaceMeterAccessor
 		);

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/DefaultSolaceSessionManagerIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/DefaultSolaceSessionManagerIT.java
@@ -1,0 +1,94 @@
+package com.solace.spring.cloud.stream.binder.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.health.handlers.SolaceSessionEventHandler;
+import com.solace.test.integration.junit.jupiter.extension.PubSubPlusExtension;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = SolaceJavaAutoConfiguration.class,
+    initializers = ConfigDataApplicationContextInitializer.class)
+@ExtendWith(PubSubPlusExtension.class)
+class DefaultSolaceSessionManagerIT {
+
+  private JCSMPProperties jcsmpProperties;
+  private @Mock SolaceSessionEventHandler solaceSessionEventHandler;
+
+  @BeforeEach
+  void setUp(JCSMPProperties jcsmpProperties) {
+    this.jcsmpProperties = jcsmpProperties;
+  }
+
+  @Test
+  void testGetSession() throws Exception {
+    DefaultSolaceSessionManager sessionManager = new DefaultSolaceSessionManager(
+        jcsmpProperties, null, solaceSessionEventHandler, null);
+    assertFalse(sessionManager.getSession().isClosed());
+
+    verify(solaceSessionEventHandler).setSessionHealthDown();
+    verify(solaceSessionEventHandler).setSessionHealthUp();
+  }
+
+  @Test
+  void testCloseSession() throws Exception {
+
+    DefaultSolaceSessionManager sessionManager = new DefaultSolaceSessionManager(
+        jcsmpProperties, null, solaceSessionEventHandler, null);
+    JCSMPSession jcsmpSession = sessionManager.getSession();
+    assertFalse(jcsmpSession.isClosed());
+
+    sessionManager.close();
+
+    assertTrue(jcsmpSession.isClosed());
+    verify(solaceSessionEventHandler).setSessionHealthDown();
+    verify(solaceSessionEventHandler).setSessionHealthUp();
+  }
+
+  @Test
+  void testGetSessionConcurrent() throws Exception {
+    DefaultSolaceSessionManager sessionManager = new DefaultSolaceSessionManager(
+        jcsmpProperties, null, solaceSessionEventHandler, null);
+
+    CountDownLatch latch = new CountDownLatch(10);
+    List<JCSMPSession> sessions = new ArrayList<>();
+    Runnable task = () -> {
+      try {
+        JCSMPSession session = sessionManager.getSession();
+        sessions.add(session);
+        latch.countDown();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    IntStream.range(0, 10).forEach(i -> {
+      new Thread(task).start();
+    });
+
+    latch.await();
+
+    IntStream.range(0, 10).forEach(i -> {
+      assertSame(sessions.get(0), sessions.get(i)); //Should be the same instance
+      assertFalse(sessions.get(i).isClosed());
+    });
+
+    sessionManager.close();
+    verify(solaceSessionEventHandler).setSessionHealthDown();
+    verify(solaceSessionEventHandler).setSessionHealthUp();
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder-core/src/test/java/com/solace/spring/cloud/stream/binder/util/ErrorQueueRepublishCorrelationKeyIT.java
@@ -54,7 +54,12 @@ public class ErrorQueueRepublishCorrelationKeyIT {
 	@BeforeEach
 	public void setUp(JCSMPSession jcsmpSession) throws Exception {
 		String producerManagerKey = UUID.randomUUID().toString();
-		JCSMPSessionProducerManager producerManager = new JCSMPSessionProducerManager(jcsmpSession);
+		DefaultSolaceSessionManager defaultSolaceSessionManager = Mockito.mock(
+				DefaultSolaceSessionManager.class);
+		Mockito.when(defaultSolaceSessionManager.getSession()).thenReturn(jcsmpSession);
+
+		JCSMPSessionProducerManager producerManager = new JCSMPSessionProducerManager(
+				defaultSolaceSessionManager);
 		producer = producerManager.get(producerManagerKey);
 
 		errorQueueInfrastructure = Mockito.spy(new ErrorQueueInfrastructure(producerManager, producerManagerKey,

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceSessionConfig.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceSessionConfig.java
@@ -1,0 +1,24 @@
+package com.solace.spring.cloud.stream.binder.config;
+
+import com.solace.spring.cloud.stream.binder.health.handlers.SolaceSessionEventHandler;
+import com.solace.spring.cloud.stream.binder.util.DefaultSolaceSessionManager;
+import com.solace.spring.cloud.stream.binder.util.SolaceSessionManager;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.SolaceSessionOAuth2TokenProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
+
+@Configuration
+public class SolaceSessionConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public SolaceSessionManager solaceSessionManager(JCSMPProperties jcsmpProperties,
+      @Nullable SolaceSessionEventHandler eventHandler,
+      @Nullable SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider) {
+    return new DefaultSolaceSessionManager(jcsmpProperties, new SolaceBinderClientInfoProvider(),
+        eventHandler, solaceSessionOAuth2TokenProvider);
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/resources/META-INF/shared.beans
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/resources/META-INF/shared.beans
@@ -3,3 +3,4 @@ com.solace.spring.cloud.stream.binder.meter.SolaceMeterAccessor
 org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
+com.solace.spring.cloud.stream.binder.util.SolaceSessionManager

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderBasicIT.java
@@ -142,12 +142,12 @@ public class SolaceBinderBasicIT extends SpringCloudStreamContext {
 
 	@BeforeEach
 	void setUp(JCSMPSession jcsmpSession, SempV2Api sempV2Api) {
-		setJcsmpSession(jcsmpSession);
+    setJcsmpSession(jcsmpSession);
 		setSempV2Api(sempV2Api);
 	}
 
 	@AfterEach
-	void tearDown() {
+	void tearDown() throws Exception {
 		super.cleanup();
 		close();
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderLazySessionInitializationIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderLazySessionInitializationIT.java
@@ -1,0 +1,158 @@
+package com.solace.spring.cloud.stream.binder;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
+import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
+import com.solace.spring.cloud.stream.binder.test.junit.extension.SpringCloudStreamExtension;
+import com.solace.spring.cloud.stream.binder.test.spring.ConsumerInfrastructureUtil;
+import com.solace.spring.cloud.stream.binder.test.spring.SpringCloudStreamContext;
+import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
+import com.solace.spring.cloud.stream.binder.util.DestinationType;
+import com.solace.spring.cloud.stream.binder.util.EndpointType;
+import com.solace.test.integration.junit.jupiter.extension.ExecutorServiceExtension;
+import com.solace.test.integration.junit.jupiter.extension.PubSubPlusExtension;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPTransportException;
+import java.net.ConnectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.cloud.stream.binder.BinderException;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.PollableSource;
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.provisioning.ProvisioningException;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = SolaceJavaAutoConfiguration.class,
+    initializers = ConfigDataApplicationContextInitializer.class)
+@ExtendWith(ExecutorServiceExtension.class)
+@ExtendWith(PubSubPlusExtension.class)
+@ExtendWith(SpringCloudStreamExtension.class)
+class SolaceBinderLazySessionInitializationIT {
+
+  private JCSMPProperties jcsmpProperties;
+
+  @BeforeEach
+  void setUp(JCSMPProperties jcsmpProperties) {
+    this.jcsmpProperties = jcsmpProperties;
+  }
+
+  @CartesianTest(name = "[{index}] channelType={0}")
+  @Execution(ExecutionMode.CONCURRENT)
+  <T> void testLazySessionInitializationThrowsExceptionDuringStartConsumerBinding(
+      @Values(classes = {DirectChannel.class, PollableSource.class}) Class<T> channelType,
+      SpringCloudStreamContext context) throws Exception {
+    jcsmpProperties.setProperty("host", "localhost:12345"); //Set invalid host:port to ensure lazy session creation throws exception
+    context.setJcsmpProperties(jcsmpProperties); //Set invalid properties in context
+    SolaceTestBinder binder = context.getBinder();
+    ConsumerInfrastructureUtil<T> consumerInfrastructureUtil = context.createConsumerInfrastructureUtil(channelType);
+    T moduleInputChannel = consumerInfrastructureUtil.createChannel("input", new BindingProperties());
+    ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = context.createConsumerProperties();
+    consumerProperties.getExtension().setProvisionDurableQueue(false);
+    consumerProperties.setAutoStartup(false);
+
+    try {
+      consumerInfrastructureUtil.createBinding(binder, "destination0", "group0", moduleInputChannel, consumerProperties);
+    } catch (Exception e) {
+      assertThat(e)
+          .isInstanceOf(channelType == PollableSource.class ? RuntimeException.class : BinderException.class)
+          .hasCauseInstanceOf(JCSMPTransportException.class)
+          .hasRootCauseInstanceOf(ConnectException.class)
+          .hasRootCauseMessage("Connection refused");
+    }
+  }
+
+  @CartesianTest(name = "[{index}] channelType={0} endpointType={1} autoStartup={2}")
+  @Execution(ExecutionMode.CONCURRENT)
+  <T> void testLazySessionInitializationThrowsExceptionDuringConsumerEndpointProvisioning(
+      @Values(classes = {DirectChannel.class, PollableSource.class}) Class<T> channelType,
+      @CartesianTest.Enum(EndpointType.class) EndpointType endpointType,
+      @Values(booleans = {false, true}) boolean autoStartup,
+      SpringCloudStreamContext context) throws Exception {
+    jcsmpProperties.setProperty("host", "localhost:12345"); //Set invalid host:port to ensure lazy session creation throws exception
+    context.setJcsmpProperties(jcsmpProperties); //Set invalid properties in context
+    SolaceTestBinder binder = context.getBinder();
+    ConsumerInfrastructureUtil<T> consumerInfrastructureUtil = context.createConsumerInfrastructureUtil(channelType);
+    T moduleInputChannel = consumerInfrastructureUtil.createChannel("input", new BindingProperties());
+    ExtendedConsumerProperties<SolaceConsumerProperties> consumerProperties = context.createConsumerProperties();
+    consumerProperties.setAutoStartup(autoStartup);
+    consumerProperties.getExtension().setProvisionDurableQueue(true);
+    consumerProperties.getExtension().setEndpointType(endpointType);
+
+    try {
+      consumerInfrastructureUtil.createBinding(binder, "destination0", "group0", moduleInputChannel, consumerProperties);
+    } catch (Exception e) {
+      assertThat(e)
+          .isInstanceOf(ProvisioningException.class)
+          .hasCauseInstanceOf(JCSMPTransportException.class)
+          .hasRootCauseInstanceOf(ConnectException.class)
+          .hasRootCauseMessage("Connection refused");
+    }
+  }
+
+  @CartesianTest(name = "[{index}] destinationType={0}")
+  @Execution(ExecutionMode.CONCURRENT)
+  <T> void testLazySessionInitializationThrowsExceptionDuringStartPublisherBinding(
+      @CartesianTest.Enum(DestinationType.class) DestinationType destinationType,
+      SpringCloudStreamContext context, TestInfo testInfo) throws Exception {
+    jcsmpProperties.setProperty("host", "localhost:12345"); //Set invalid host:port to ensure lazy session creation throws exception
+    context.setJcsmpProperties(jcsmpProperties); //Set invalid properties in context
+    SolaceTestBinder binder = context.getBinder();
+    ExtendedProducerProperties<SolaceProducerProperties> producerProperties = context.createProducerProperties(testInfo);
+    producerProperties.getExtension().setDestinationType(destinationType);
+    producerProperties.getExtension().setProvisionDurableQueue(false);
+    producerProperties.setAutoStartup(false);
+    BindingProperties producerBindingProperties = new BindingProperties();
+    producerBindingProperties.setProducer(producerProperties);
+
+    DirectChannel moduleOutputChannel = context.createBindableChannel("output", producerBindingProperties);
+
+    try {
+      binder.bindProducer("destination0", moduleOutputChannel, producerProperties);
+    } catch (Exception e) {
+      assertThat(e)
+          .isInstanceOf(BinderException.class)
+          .hasCauseInstanceOf(JCSMPTransportException.class)
+          .hasRootCauseInstanceOf(ConnectException.class)
+          .hasRootCauseMessage("Connection refused");
+    }
+  }
+
+  @CartesianTest(name = "[{index}] destinationType={0}")
+  @Execution(ExecutionMode.CONCURRENT)
+  <T> void testLazySessionInitializationThrowsExceptionDuringPublisherEndpointProvisioning(
+      @Values(strings = {"QUEUE"}) String destinationType, SpringCloudStreamContext context,
+      TestInfo testInfo) throws Exception {
+    jcsmpProperties.setProperty("host", "localhost:12345"); //Set invalid host:port to ensure lazy session creation throws exception
+    context.setJcsmpProperties(jcsmpProperties); //Set invalid properties in context
+    SolaceTestBinder binder = context.getBinder();
+    ExtendedProducerProperties<SolaceProducerProperties> producerProperties = context.createProducerProperties(testInfo);
+    producerProperties.getExtension().setDestinationType(DestinationType.valueOf(destinationType));
+    producerProperties.getExtension().setProvisionDurableQueue(true);
+    producerProperties.setAutoStartup(false);
+    BindingProperties producerBindingProperties = new BindingProperties();
+    producerBindingProperties.setProducer(producerProperties);
+
+    DirectChannel moduleOutputChannel = context.createBindableChannel("output", producerBindingProperties);
+
+    try {
+      binder.bindProducer("destination0", moduleOutputChannel, producerProperties);
+    } catch (Exception e) {
+      assertThat(e)
+          .isInstanceOf(ProvisioningException.class)
+          .hasCauseInstanceOf(JCSMPTransportException.class)
+          .hasRootCauseInstanceOf(ConnectException.class)
+          .hasRootCauseMessage("Connection refused");
+    }
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/springBootTests/session/LazySessionInitializationIT.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/springBootTests/session/LazySessionInitializationIT.java
@@ -1,0 +1,131 @@
+package com.solace.spring.cloud.stream.binder.springBootTests.session;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.solacesystems.jcsmp.JCSMPTransportException;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.binder.ProducerProperties;
+import org.springframework.cloud.stream.binding.BindingService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+class LazySessionInitializationIT {
+
+  @Test
+  void testLazyInitialization() {
+    Map<String, CountDownLatch> latches = new HashMap<>();
+    Set<String> bindingNames = Set.of("sink-in-0", "otherSink-in-0", "source-out-0",
+        "otherSource-out-0", "processor-in-0", "processor-out-0", "otherProcessor-in-0",
+        "otherProcessor-out-0");
+    bindingNames.forEach(bindingName -> latches.put(bindingName, new CountDownLatch(3)));
+
+    try (var applicationContext = new SpringApplicationBuilder(SpringCloudStreamApp.class)
+        .profiles("lazySessionInit")
+        .sources(TestConfig.class)
+        .run()) {
+
+      final BindingService bindingService = applicationContext.getBean(BindingService.class);
+
+      //Consumer Binding Creation Interception
+      doAnswer(invocation -> {
+        String bindingName = invocation.getArgument(1, String.class);
+        RuntimeException runtimeException = invocation.getArgument(6, RuntimeException.class);
+        if (runtimeException != null) {
+          assertThat(runtimeException)
+              .hasCauseInstanceOf(JCSMPTransportException.class)
+              .hasRootCauseInstanceOf(ConnectException.class)
+              .hasRootCauseMessage("Connection refused");
+        }
+        latches.get(bindingName).countDown();
+        return invocation.callRealMethod();
+      }).when(bindingService).rescheduleConsumerBinding(any(), anyString(), any(),
+          any(ConsumerProperties.class), anyString(), any(), any(RuntimeException.class));
+
+      //Producer Binding Creation Interception
+      doAnswer(invocation -> {
+        String bindingName = invocation.getArgument(1, String.class);
+        RuntimeException runtimeException = invocation.getArgument(5, RuntimeException.class);
+        if (runtimeException != null) {
+          assertThat(runtimeException)
+              .hasCauseInstanceOf(JCSMPTransportException.class)
+              .hasRootCauseInstanceOf(ConnectException.class)
+              .hasRootCauseMessage("Connection refused");
+        }
+        latches.get(bindingName).countDown();
+        return invocation.callRealMethod();
+      }).when(bindingService).rescheduleProducerBinding(any(), anyString(), any(),
+          any(ProducerProperties.class), any(), any(RuntimeException.class));
+
+      latches.forEach((bindingName, latch) -> {
+        try {
+          boolean completed = latch.await(60, TimeUnit.SECONDS);
+          System.err.println("Latch for binding " + bindingName + " did not complete in time. "
+              + latch.getCount());
+          assertTrue(completed);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+
+        assertHealthIsDown((WebApplicationContext) applicationContext);
+      });
+    }
+  }
+
+  private static void assertHealthIsDown(WebApplicationContext context) {
+    checkHealth(context, "DOWN");
+  }
+
+  private static void checkHealth(WebApplicationContext context, String status) {
+    var mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    await("Wait until status is " + status)
+        .pollDelay(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofSeconds(5))
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(() -> {
+          mockMvc.perform(get("/actuator/health"))
+              .andExpectAll(
+                  jsonPath("$.status").value(status),
+                  jsonPath("$.components.binders.status").value(status),
+                  jsonPath("$.components.binders.components.solace1.status").value(status),
+                  jsonPath("$.components.binders.components.solace2.status").value(status)
+              );
+        });
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+
+    @Bean
+    public BeanPostProcessor bindingServiceSpyPostProcessor() {
+      return new BeanPostProcessor() {
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) {
+          if (bean instanceof BindingService) {
+            return Mockito.spy(bean);
+          }
+          return bean;
+        }
+      };
+    }
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/springBootTests/session/SpringCloudStreamApp.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/springBootTests/session/SpringCloudStreamApp.java
@@ -1,0 +1,59 @@
+package com.solace.spring.cloud.stream.binder.springBootTests.session;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@SpringBootApplication
+public class SpringCloudStreamApp {
+
+  public static void main(String[] args) {
+    SpringApplication.run(SpringCloudStreamApp.class, args);
+  }
+
+  @Bean
+  public Consumer<Message<?>> sink() {
+    return (msg -> System.out.println(msg.getPayload()));
+  }
+
+  @Bean
+  public Consumer<Message<?>> otherSink() {
+    return (msg -> System.out.println(msg.getPayload()));
+  }
+
+  @Bean
+  public Function<String, String> processor() {
+    return (msg) -> msg;
+  }
+
+  @Bean
+  public Function<String, String> otherProcessor() {
+    return (msg) -> msg;
+  }
+
+  @Bean
+  public Supplier<String> source() {
+    return () -> "test";
+  }
+
+  @Bean
+  public Supplier<String> otherSource() {
+    return () -> "test";
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.authorizeHttpRequests(requests -> requests
+        .requestMatchers(new AntPathRequestMatcher("/actuator/*")).permitAll()
+        .anyRequest().authenticated());
+
+    return http.build();
+  }
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/junit/extension/SpringCloudStreamExtension.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/junit/extension/SpringCloudStreamExtension.java
@@ -52,7 +52,8 @@ public class SpringCloudStreamExtension implements AfterEachCallback, BeforeEach
 					key -> {
 						LOGGER.info("Creating {}", SpringCloudStreamContext.class.getSimpleName());
 						SpringCloudStreamContext context = new SpringCloudStreamContext(
-								PubSubPlusExtension.getJCSMPSession(extensionContext),
+                PubSubPlusExtension.getJCSMPProperties(extensionContext),
+                PubSubPlusExtension.getJCSMPSession(extensionContext),
 								PubSubPlusExtension.getSempV2Api(extensionContext));
 						context.before();
 						return context;

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/spring/SpringCloudStreamContext.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/spring/SpringCloudStreamContext.java
@@ -4,6 +4,7 @@ import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solace.spring.cloud.stream.binder.test.util.SolaceTestBinder;
 import com.solace.test.integration.semp.v2.SempV2Api;
+import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -35,12 +36,14 @@ public class SpringCloudStreamContext extends PartitionCapableBinderTests<Solace
 		implements ExtensionContext.Store.CloseableResource {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SpringCloudStreamContext.class);
 	private JCSMPSession jcsmpSession;
+  private JCSMPProperties jcsmpProperties;
 	private SempV2Api sempV2Api;
 
-	public SpringCloudStreamContext(JCSMPSession jcsmpSession, SempV2Api sempV2Api) {
-		this.jcsmpSession = Objects.requireNonNull(jcsmpSession);
-		this.sempV2Api = sempV2Api;
-	}
+  public SpringCloudStreamContext(JCSMPProperties jcsmpProperties, JCSMPSession jcsmpSession, SempV2Api sempV2Api) {
+    this.jcsmpProperties = Objects.requireNonNull(jcsmpProperties);
+    this.jcsmpSession = Objects.requireNonNull(jcsmpSession);
+    this.sempV2Api = sempV2Api;
+  }
 
 	/**
 	 * Should only be used by subclasses.
@@ -67,7 +70,7 @@ public class SpringCloudStreamContext extends PartitionCapableBinderTests<Solace
 				throw new IllegalStateException("JCSMPSession cannot be null or closed");
 			}
 			logger.info("Creating new test binder");
-			testBinder = new SolaceTestBinder(jcsmpSession, sempV2Api);
+			testBinder = new SolaceTestBinder(jcsmpProperties, jcsmpSession, sempV2Api);
 		}
 		return testBinder;
 	}
@@ -124,7 +127,7 @@ public class SpringCloudStreamContext extends PartitionCapableBinderTests<Solace
 	}
 
 	@Override
-	public void close() {
+	public void close() throws Exception {
 		if (testBinder != null) {
 			LOGGER.info("Destroying binder");
 			testBinder.getBinder().destroy();
@@ -157,6 +160,10 @@ public class SpringCloudStreamContext extends PartitionCapableBinderTests<Solace
 	protected void setJcsmpSession(JCSMPSession jcsmpSession) {
 		this.jcsmpSession = jcsmpSession;
 	}
+
+  public void setJcsmpProperties(JCSMPProperties jcsmpProperties) {
+    this.jcsmpProperties = jcsmpProperties;
+  }
 
 	/**
 	 * Should only be used by subclasses.

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/test/util/SolaceTestBinder.java
@@ -1,12 +1,14 @@
 package com.solace.spring.cloud.stream.binder.test.util;
 
 import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
+import com.solace.spring.cloud.stream.binder.util.DefaultSolaceSessionManager;
 import com.solace.spring.cloud.stream.binder.properties.SolaceConsumerProperties;
 import com.solace.spring.cloud.stream.binder.properties.SolaceProducerProperties;
 import com.solace.spring.cloud.stream.binder.provisioning.EndpointProvider;
 import com.solace.spring.cloud.stream.binder.provisioning.SolaceEndpointProvisioner;
 import com.solace.spring.cloud.stream.binder.provisioning.SolaceProvisioningUtil;
 import com.solace.spring.cloud.stream.binder.util.EndpointType;
+import com.solace.spring.cloud.stream.binder.util.SolaceSessionManager;
 import com.solace.test.integration.semp.v2.SempV2Api;
 import com.solace.test.integration.semp.v2.config.ApiException;
 import com.solacesystems.jcsmp.AccessDeniedException;
@@ -14,6 +16,7 @@ import com.solacesystems.jcsmp.Endpoint;
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.binder.AbstractPollableConsumerTestBinder;
@@ -34,11 +37,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 
 public class SolaceTestBinder
 		extends AbstractPollableConsumerTestBinder<SolaceMessageChannelBinder, ExtendedConsumerProperties<SolaceConsumerProperties>, ExtendedProducerProperties<SolaceProducerProperties>> {
 
 	private final JCSMPSession jcsmpSession;
+  private final JCSMPProperties jcsmpProperties;
 	private final SempV2Api sempV2Api;
 	private final AnnotationConfigApplicationContext applicationContext;
 	private final Map<String, EndpointType> endpoints = new HashMap<>();
@@ -46,11 +51,25 @@ public class SolaceTestBinder
 	private final Map<String, String> bindingNameToErrorQueueName = new HashMap<>();
 	private static final Logger LOGGER = LoggerFactory.getLogger(SolaceTestBinder.class);
 
-	public SolaceTestBinder(JCSMPSession jcsmpSession, SempV2Api sempV2Api) {
+	public SolaceTestBinder(JCSMPProperties jcsmpProperties, JCSMPSession jcsmpSession, SempV2Api sempV2Api) {
 		this.applicationContext = new AnnotationConfigApplicationContext(Config.class);
-		this.jcsmpSession = jcsmpSession;
+    this.jcsmpProperties = jcsmpProperties;
+    this.jcsmpSession = jcsmpSession;
 		this.sempV2Api = sempV2Api;
-		SolaceMessageChannelBinder binder = new SolaceMessageChannelBinder(jcsmpSession, new SolaceEndpointProvisioner(jcsmpSession));
+
+    SolaceSessionManager defaultSolaceSessionManager = null;
+    if(jcsmpProperties == null) {
+      defaultSolaceSessionManager = Mockito.mock(DefaultSolaceSessionManager.class);
+      try {
+        doReturn(jcsmpSession).when(defaultSolaceSessionManager).getSession();
+      } catch (JCSMPException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      defaultSolaceSessionManager = new DefaultSolaceSessionManager(
+          jcsmpProperties, null, null, null);
+    }
+		SolaceMessageChannelBinder binder = new SolaceMessageChannelBinder(defaultSolaceSessionManager, new SolaceEndpointProvisioner(defaultSolaceSessionManager));
 		binder.setApplicationContext(this.applicationContext);
 		this.setPollableConsumerBinder(binder);
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/resources/application-lazySessionInit.yml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/resources/application-lazySessionInit.yml
@@ -1,0 +1,73 @@
+spring:
+  cloud:
+    function:
+      definition: "sink;otherSink;source;otherSource;processor;otherProcessor;"
+    stream:
+      bindingRetryInterval: 1 # seconds
+      binders:
+        solace1:
+          type: solace
+          environment:
+            spring.cloud.stream.solace.binder.session-initialization-mode: lazy
+            spring.cloud.stream.solace.default.consumer.provision-durable-queue: false
+            spring.cloud.stream.solace.default.producer.provision-durable-queue: false
+            solace.java:
+              host: localhost
+              connectRetries: 1
+              connectRetriesPerHost: 1
+              reconnectRetryWaitInMillis: 500
+        solace2:
+          type: solace
+          environment:
+            spring.cloud.stream.solace.binder.session-initialization-mode: lazy
+            spring.cloud.stream.solace.default.consumer.provision-durable-queue: false
+            spring.cloud.stream.solace.default.producer.provision-durable-queue: false
+            solace.java:
+              host: localhost
+              connectRetries: 1
+              connectRetriesPerHost: 1
+              reconnectRetryWaitInMillis: 500
+      bindings:
+        sink-in-0:
+          destination: sink-in-0
+          group: myConsumerGroup
+          binder: solace1
+        otherSink-in-0:
+          destination: otherSink-in-0
+          group: myConsumerGroup
+          binder: solace2
+        source-out-0:
+          destination: source-out-0
+          binder: solace1
+        otherSource-out-0:
+          destination: otherSource-out-0
+          binder: solace2
+        processor-in-0:
+          destination: processor-in-0
+          group: myConsumerGroup
+          binder: solace1
+        processor-out-0:
+          destination: processor-out-0
+          binder: solace1
+        otherProcessor-in-0:
+          destination: otherProcessor-in-0
+          group: myConsumerGroup
+          binder: solace2
+        otherProcessor-out-0:
+          destination: otherProcessor-out-0
+          binder: solace2
+
+      default-binder: solace1
+
+management:
+  endpoint:
+    health:
+      show-components: always
+      show-details: always
+  endpoints:
+    web: # Actuator web endpoint configuration. For more info: https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
+      exposure:
+        include: 'health,metrics'
+  health:
+    binders:
+      enabled: true


### PR DESCRIPTION
- Added lazy Solace session initialization through binder config property `session-initialization-mode`
- Added unit and integration test for session-initialization-mode=lazy. 
- Default session-initialization-mode will still be eager for backwards compatibility. 
