### PR TITLE
DATAGO-137875: use GITHUB_TOKEN to authenticate github packages

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,6 +41,8 @@ jobs:
           cache: maven
       - name: Build and run Tests
         run: mvn clean verify -s maven/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,27 +28,10 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      packages: write
-      id-token: write
+      packages: read
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Retrieve secrets from Vault
-        id: secrets
-        uses: hashicorp/vault-action@v3
-        continue-on-error: true
-        with:
-          url: "${{ secrets.VAULT_ADDR }}"
-          role: "cicd-workflows-secret-read-role"
-          method: jwt
-          path: jwt-github
-          jwtGithubAudience: https://github.com/${{ github.repository_owner }}
-          exportToken: true
-          secrets:
-            secret/data/tools/githubactions RE_BOT_PACKAGES_READ_ONLY_CLASSIC_USER | PACKAGES_ADMIN_USER ;
-            secret/data/tools/githubactions RE_BOT_PACKAGES_READ_ONLY_CLASSIC_TOKEN | PACKAGES_ADMIN_TOKEN ;
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,5 @@ jobs:
           -P releaseCentral \
           -s maven/settings.xml \
           release:prepare release:perform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
           jwtGithubAudience: https://github.com/${{ github.repository_owner }}
           exportToken: true
           secrets:
-            secret/data/tools/githubactions RE_BOT_PACKAGES_READ_ONLY_CLASSIC_USER | PACKAGES_ADMIN_USER ;
-            secret/data/tools/githubactions RE_BOT_PACKAGES_READ_ONLY_CLASSIC_TOKEN | PACKAGES_ADMIN_TOKEN ;
             secret/data/tools/githubactions MAVEN_GPG_KEY_PASSPHRASE | MAVEN_GPG_KEY_PASSPHRASE ;
             secret/data/tools/githubactions MAVEN_GPG_KEY | MAVEN_GPG_KEY ;
             secret/data/tools/githubactions MAVEN_USERNAME | MAVEN_USERNAME ;

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -14,28 +14,11 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
-      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-
-      - name: Retrieve secrets from Vault
-        id: secrets
-        uses: hashicorp/vault-action@v3
-        continue-on-error: true
-        with:
-          url: "${{ secrets.VAULT_ADDR }}"
-          role: "cicd-workflows-secret-read-role"
-          method: jwt
-          path: jwt-github
-          jwtGithubAudience: https://github.com/${{ github.repository_owner }}
-          exportToken: true
-          secrets:
-            secret/data/tools/githubactions RE_BOT_PACKAGES_READ_ONLY_CLASSIC_USER | PACKAGES_ADMIN_USER ;
-            secret/data/tools/githubactions RE_BOT_PACKAGES_READ_ONLY_CLASSIC_TOKEN | PACKAGES_ADMIN_TOKEN ;
 
       - uses: actions/setup-java@v5
         with:

--- a/maven/settings.xml
+++ b/maven/settings.xml
@@ -18,16 +18,8 @@
 					</snapshots>
 				</repository>
 				<repository>
-					<id>github-solacedev</id>
-					<url>https://maven.pkg.github.com/SolaceDev/*</url>
-					<releases>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-					</snapshots>
+					<id>github-solace-integration-test-support</id>
+					<url>https://maven.pkg.github.com/solacedev/solace-integration-test-support</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -35,7 +27,7 @@
 
 	<servers>
 		<server>
-			<id>github-solacedev</id>
+			<id>github-solace-integration-test-support</id>
 			<username>${env.GITHUB_ACTOR}</username>
 			<password>${env.GITHUB_TOKEN}</password>
 		</server>

--- a/maven/settings.xml
+++ b/maven/settings.xml
@@ -36,8 +36,8 @@
 	<servers>
 		<server>
 			<id>github-solacedev</id>
-			<username>${env.PACKAGES_ADMIN_USER}</username>
-			<password>${env.PACKAGES_ADMIN_TOKEN}</password>
+			<username>${env.GITHUB_ACTOR}</username>
+			<password>${env.GITHUB_TOKEN}</password>
 		</server>
 		<server>
 			<id>github</id>


### PR DESCRIPTION
Use `GITHUB_TOKEN` over vault to pull down github packages